### PR TITLE
Fix deploy install, non-TTY logs, and audit diagnostics

### DIFF
--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -198,12 +198,55 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
       body: JSON.stringify({ lineItems }),
     });
   } catch (err: any) {
-    throw new Error(`Bill Audit API unreachable: ${err.message}. Ensure the service is running on ${BILL_AUDIT_API}`);
+    const baseUrl = BILL_AUDIT_API;
+    const docsHint = "See docs/setup/services.md for local service setup.";
+    const message = typeof err?.message === "string" ? err.message : "Unknown network error";
+    const code = err?.cause?.code || err?.code;
+
+    if (code === "ECONNREFUSED") {
+      throw new Error(
+        `Bill Audit API connection refused (ECONNREFUSED). This is usually a config or startup issue. ` +
+        `Ensure BILL_AUDIT_API_URL points to a running service (currently ${baseUrl}). ${docsHint}`
+      );
+    }
+
+    if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT" || code === "UND_ERR_SOCKET") {
+      throw new Error(
+        `Bill Audit API request timed out. This is often transient (network hiccup or cold start). ` +
+        `Try again; if it persists, verify the service at ${baseUrl} is reachable. ${docsHint}`
+      );
+    }
+
+    if (code === "ENOTFOUND") {
+      throw new Error(
+        `Bill Audit API hostname not found (ENOTFOUND). Check BILL_AUDIT_API_URL (currently ${baseUrl}). ${docsHint}`
+      );
+    }
+
+    throw new Error(
+      `Bill Audit API unreachable. ${message}. Verify the service is reachable at ${baseUrl}. ${docsHint}`
+    );
   }
 
   if (!response.ok) {
     const error = await response.text();
-    throw new Error(`Bill Audit API error (${response.status}): ${error.slice(0, 200)}`);
+    const bodyPreview = error.slice(0, 200);
+
+    if (response.status >= 500) {
+      throw new Error(
+        `Bill Audit API is up but failing (${response.status}). This indicates a downstream/service bug or outage. ` +
+        `Try again later or check the Bill Audit service logs. Details: ${bodyPreview}`
+      );
+    }
+
+    if (response.status >= 400 && response.status < 500) {
+      throw new Error(
+        `Bill Audit API rejected the request (${response.status}). This is likely a caller/input issue. ` +
+        `Verify the payload schema and required env vars. Details: ${bodyPreview}`
+      );
+    }
+
+    throw new Error(`Bill Audit API error (${response.status}): ${bodyPreview}`);
   }
 
   const data = await response.json();

--- a/docs/setup/services.md
+++ b/docs/setup/services.md
@@ -1,0 +1,46 @@
+# Local service setup
+
+CareGuard runs a main server plus several local services. By default, everything binds to `localhost` on fixed ports.
+
+## Prereqs
+
+- Node.js `>= 22`
+- Install deps: `npm ci`
+
+## Environment
+
+Create a `.env` file (or set env vars in your shell). The most common local setup is:
+
+```bash
+# Main agent
+AGENT_SECRET_KEY=...
+
+# Service URLs (optional; defaults shown)
+PHARMACY_API_URL=http://localhost:3001
+BILL_AUDIT_API_URL=http://localhost:3002
+DRUG_INTERACTION_API_URL=http://localhost:3003
+PHARMACY_PAYMENT_URL=http://localhost:3005
+
+# Service recipients (required by services)
+PHARMACY_1_PUBLIC_KEY=...
+PHARMACY_2_PUBLIC_KEY=...
+BILL_PROVIDER_PUBLIC_KEY=...
+
+# Pharmacy payment service
+MPP_SECRET_KEY=...
+```
+
+## Run all services
+
+```bash
+npm run services
+```
+
+## Run an individual service
+
+```bash
+npm run pharmacy-api
+npm run bill-audit-api
+npm run drug-api
+npm run pharmacy-payment
+```

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: careguard-api
     runtime: node
     plan: free
-    buildCommand: npm install --legacy-peer-deps
+    buildCommand: npm ci
     startCommand: node --experimental-strip-types --experimental-transform-types --no-warnings server.ts
     envVars:
       - key: NODE_VERSION

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -7,6 +7,11 @@
  * Fair market rate database based on Medicare reimbursement rates (CMS 2026 fee schedule).
  */
 
+if (!process.stdout.isTTY) {
+  process.env.NO_COLOR ??= "1";
+  process.env.FORCE_COLOR = "0";
+}
+
 import "dotenv/config";
 import express from "express";
 import cors from "cors";

--- a/services/drug-interaction-api/server.ts
+++ b/services/drug-interaction-api/server.ts
@@ -7,6 +7,11 @@
  * Clinical interaction reference database based on FDA drug interaction data.
  */
 
+if (!process.stdout.isTTY) {
+  process.env.NO_COLOR ??= "1";
+  process.env.FORCE_COLOR = "0";
+}
+
 import "dotenv/config";
 import express from "express";
 import cors from "cors";

--- a/services/pharmacy-api/server.ts
+++ b/services/pharmacy-api/server.ts
@@ -7,6 +7,11 @@
  * Pricing reference database based on real-world pharmacy pricing patterns (GoodRx, CostcoRx).
  */
 
+if (!process.stdout.isTTY) {
+  process.env.NO_COLOR ??= "1";
+  process.env.FORCE_COLOR = "0";
+}
+
 import "dotenv/config";
 import express from "express";
 import cors from "cors";

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -7,6 +7,11 @@
  * Flow: Client POST → 402 challenge → Client signs Soroban auth entry → Server broadcasts → Order confirmed
  */
 
+if (!process.stdout.isTTY) {
+  process.env.NO_COLOR ??= "1";
+  process.env.FORCE_COLOR = "0";
+}
+
 import "dotenv/config";
 import express from "express";
 import cors from "cors";


### PR DESCRIPTION
Closes #229
Closes #239
Closes #245
Closes #246

- Render: use `npm ci` (no `--legacy-peer-deps`).
- Services: disable color output in non-TTY log capture via `NO_COLOR`/`FORCE_COLOR`.
- Agent: improve `auditBill` failure diagnostics and link to setup docs.