### PR TITLE
feat(dashboard): fix issues 148, 152, 153, and 154

### DIFF
--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -1,0 +1,36 @@
+name: Dashboard E2E
+
+on:
+  pull_request:
+    paths:
+      - "dashboard/**"
+      - ".github/workflows/dashboard-e2e.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: Run dashboard E2E
+        env:
+          NEXT_PUBLIC_API_URL: "http://localhost:3004"
+        run: npm run test:e2e

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,7 +1,39 @@
 import type { NextConfig } from "next";
 
+const cspDirectives = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "connect-src 'self' https://horizon-testnet.stellar.org http://localhost:3004",
+  "img-src 'self' data: blob: https://*.amazonaws.com https://*.minio.io",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' https://fonts.gstatic.com",
+  "script-src 'self'",
+].join("; ");
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            // Roll out report-only CSP first to avoid breaking existing inline/theme scripts.
+            // After all inline scripts are moved to nonce/hash, move this policy to Content-Security-Policy.
+            key: "Content-Security-Policy-Report-Only",
+            value: cspDirectives,
+          },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -15,12 +15,14 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.54.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.2",
+        "pdf-parse": "^1.1.1",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -69,7 +71,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1238,6 +1239,22 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1586,7 +1603,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1653,7 +1669,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -2179,7 +2194,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2533,7 +2547,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3154,7 +3167,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3340,7 +3352,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3712,6 +3723,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4620,7 +4645,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5205,6 +5229,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -5468,6 +5499,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -5492,6 +5540,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5601,7 +5681,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5611,7 +5690,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6350,7 +6428,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6513,7 +6590,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6799,7 +6875,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "jspdf": "^4.2.1",
@@ -16,7 +18,9 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@tailwindcss/postcss": "^4",
+    "pdf-parse": "^1.1.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
+  ],
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    ? undefined
+    : {
+        command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/dashboard/src/app/__tests__/pdf-pagination.test.ts
+++ b/dashboard/src/app/__tests__/pdf-pagination.test.ts
@@ -20,6 +20,7 @@ const mockSetFontSize = vi.fn();
 const mockSetTextColor = vi.fn();
 const mockSetDrawColor = vi.fn();
 const mockLine = vi.fn();
+const mockSetProperties = vi.fn();
 const mockGetNumberOfPages = vi.fn(() => capturedPageCount);
 const mockSetPage = vi.fn();
 const mockAddPage = vi.fn(() => { capturedPageCount++; });
@@ -35,6 +36,7 @@ vi.mock('jspdf', () => ({
     setDrawColor: mockSetDrawColor,
     text: mockText,
     line: mockLine,
+    setProperties: mockSetProperties,
     save: mockSave,
     getNumberOfPages: mockGetNumberOfPages,
     setPage: mockSetPage,
@@ -142,5 +144,14 @@ describe('downloadBillAuditPDF — pagination (#225)', () => {
   it('saves the document', () => {
     downloadBillAuditPDF(makeAuditResult(5));
     expect(mockSave).toHaveBeenCalledWith('careguard-bill-audit-report.pdf');
+  });
+
+  it("uses provided recipient in PDF header and metadata", () => {
+    downloadBillAuditPDF(makeAuditResult(2), {
+      recipient: { name: "Ada Lovelace", age: 82, facility: "Memorial Clinic" },
+    });
+    const joinedTextArgs = mockText.mock.calls.map((call) => String(call[0])).join(" ");
+    expect(joinedTextArgs).toContain("Ada Lovelace");
+    expect(mockSetProperties).toHaveBeenCalled();
   });
 });

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   type SpendingData,
   type Transaction,
 } from "../lib/types";
+import { useProfile } from "../lib/useProfile";
 
 const AGENT_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3004";
 
@@ -31,6 +32,13 @@ interface AgentInfo {
 }
 
 export default function Dashboard() {
+  const { recipient } = useProfile();
+  const recipientInitials = recipient.name
+    .split(" ")
+    .map((chunk) => chunk[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -270,9 +278,12 @@ export default function Dashboard() {
             <div className="flex items-center gap-2">
               <div className="text-right text-xs">
                 <div className="text-slate-500">Care Recipient</div>
-                <div className="font-medium">Rosa Garcia, 78</div>
+                <div className="font-medium">
+                  {recipient.name}
+                  {typeof recipient.age === "number" ? `, ${recipient.age}` : ""}
+                </div>
               </div>
-              <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center text-amber-700 text-sm font-medium">RG</div>
+              <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center text-amber-700 text-sm font-medium">{recipientInitials}</div>
             </div>
           </div>
         </div>
@@ -342,7 +353,7 @@ export default function Dashboard() {
           <div className="space-y-6">
             <div className="bg-white rounded-xl border border-slate-200 p-6">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-sm font-semibold text-slate-700">Rosa&apos;s Medications</h2>
+                <h2 className="text-sm font-semibold text-slate-700">{recipient.name}&apos;s Medications</h2>
                 {agentResult?.toolCalls.some(t => t.tool === "compare_pharmacy_prices") && (
                   <button
                     onClick={() => {
@@ -353,7 +364,7 @@ export default function Dashboard() {
                       downloadMedicationPDF({
                         priceResults,
                         interactionResult: interactionResult ? DrugInteractionResultSchema.parse(interactionResult) : undefined,
-                      });
+                      }, { recipient });
                     }}
                     className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
                   >
@@ -401,7 +412,12 @@ export default function Dashboard() {
                     <h2 className="text-sm font-semibold text-slate-700">Bill Audit Results</h2>
                     <div className="flex items-center gap-2">
                       <button
-                        onClick={() => downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), { errorsOnly: billShowErrorsOnly })}
+                        onClick={() =>
+                          downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), {
+                            errorsOnly: billShowErrorsOnly,
+                            recipient,
+                          })
+                        }
                         className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
                       >
                         Download PDF
@@ -420,12 +436,17 @@ export default function Dashboard() {
                       {billShowErrorsOnly ? "Show all items" : "Show errors only"}
                     </button>
                   </div>
-                  <div className="space-y-2">
+                  <div className="overflow-x-auto rounded-lg shadow-[inset_-10px_0_12px_-12px_rgba(15,23,42,0.25)]">
+                    <div className="space-y-2 min-w-[640px]">
                     {t.result.lineItems.filter((item: any) => !billShowErrorsOnly || item.status !== "valid").map((item: any, j: number) => (
                       <div key={j} className={`flex items-center justify-between p-3 rounded-lg text-sm ${item.status === "valid" ? "bg-slate-50" : item.status === "duplicate" ? "bg-red-50 border border-red-200" : "bg-amber-50 border border-amber-200"}`}>
                         <div className="flex-1">
                           <div className="font-medium">{item.description}</div>
-                          <div className="text-xs text-slate-500">CPT: {item.cptCode}</div>
+                          <div className="hidden md:block text-xs text-slate-500">CPT: {item.cptCode}</div>
+                          <details className="md:hidden mt-1">
+                            <summary className="cursor-pointer text-xs text-slate-500">More details</summary>
+                            <div className="text-xs text-slate-500 mt-1">CPT: {item.cptCode || "N/A"}</div>
+                          </details>
                           {item.errorDescription && <div className="text-xs text-red-600 mt-1">{item.errorDescription}</div>}
                         </div>
                         <div className="text-right ml-4">
@@ -434,6 +455,7 @@ export default function Dashboard() {
                         </div>
                       </div>
                     ))}
+                    </div>
                   </div>
                   <p className="mt-4 text-sm font-medium text-slate-700">{t.result.recommendation}</p>
                 </div>
@@ -446,7 +468,7 @@ export default function Dashboard() {
 
         {activeTab === "policy" && (
           <div className="bg-white rounded-xl border border-slate-200 p-6 max-w-lg">
-            <h2 className="text-sm font-semibold text-slate-700 mb-4">Spending Policy for Rosa</h2>
+            <h2 className="text-sm font-semibold text-slate-700 mb-4">Spending Policy for {recipient.name}</h2>
             <p className="text-xs text-slate-500 mb-6">These limits are enforced by Soroban smart contracts on Stellar. The agent cannot exceed them.</p>
             <div className="space-y-4">
               {([["dailyLimit","Daily Spending Limit ($)"],["monthlyLimit","Monthly Spending Limit ($)"],["medicationMonthlyBudget","Medication Monthly Budget ($)"],["billMonthlyBudget","Bill Monthly Budget ($)"],["approvalThreshold","Caregiver Approval Threshold ($)"]] as const).map(([key, label]) => (
@@ -484,7 +506,7 @@ export default function Dashboard() {
               <h2 className="text-sm font-semibold text-slate-700">Transaction Log</h2>
               <div className="flex items-center gap-3">
                 {allTransactions.length > 0 && (
-                  <button onClick={() => downloadTransactionPDF(allTransactions, spending)} className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all">Download Report</button>
+                  <button onClick={() => downloadTransactionPDF(allTransactions, spending, { recipient })} className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all">Download Report</button>
                 )}
                 <button onClick={resetAgent} className="text-xs text-red-500 hover:text-red-700 hover:underline active:text-red-800 cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500 rounded px-1">Reset All</button>
               </div>
@@ -497,9 +519,10 @@ export default function Dashboard() {
             </div>
             <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
               {allTransactions.length === 0 ? <div className="p-8 text-center text-sm text-slate-400">No transactions yet</div> : (
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto shadow-[inset_-10px_0_12px_-12px_rgba(15,23,42,0.25)]">
+                <table className="w-full min-w-[640px] text-sm">
                   <thead className="bg-slate-50 border-b border-slate-200"><tr>
-                    <th className="text-left px-4 py-2 text-xs font-medium text-slate-500">Time</th>
+                    <th className="hidden md:table-cell text-left px-4 py-2 text-xs font-medium text-slate-500">Time</th>
                     <th className="text-left px-4 py-2 text-xs font-medium text-slate-500">Type</th>
                     <th className="text-left px-4 py-2 text-xs font-medium text-slate-500">Description</th>
                     <th className="text-right px-4 py-2 text-xs font-medium text-slate-500">Amount</th>
@@ -508,7 +531,7 @@ export default function Dashboard() {
                   </tr></thead>
                   <tbody>{[...allTransactions].reverse().map(tx => (
                     <tr key={tx.id} className="border-b border-slate-100 last:border-0">
-                      <td className="px-4 py-2 text-xs text-slate-400">{new Date(tx.timestamp).toLocaleTimeString()}</td>
+                      <td className="hidden md:table-cell px-4 py-2 text-xs text-slate-400">{new Date(tx.timestamp).toLocaleTimeString()}</td>
                       <td className="px-4 py-2"><span className={`px-2 py-0.5 rounded text-xs font-medium ${tx.type === "medication" ? "bg-blue-100 text-blue-700" : tx.type === "bill" ? "bg-purple-100 text-purple-700" : "bg-slate-100 text-slate-600"}`}>{tx.type}</span></td>
                       <td className="px-4 py-2 text-xs">{tx.description}</td>
                       <td className="px-4 py-2 text-right text-xs font-mono">${tx.amount < 0.01 ? tx.amount.toFixed(4) : tx.amount.toFixed(2)}</td>
@@ -517,6 +540,7 @@ export default function Dashboard() {
                     </tr>
                   ))}</tbody>
                 </table>
+                </div>
               )}
             </div>
           </div>
@@ -587,10 +611,10 @@ export default function Dashboard() {
             <div className="bg-white rounded-xl border border-slate-200 p-6">
               <h2 className="text-sm font-semibold text-slate-700 mb-4">Care Recipient</h2>
               <div className="grid grid-cols-2 gap-4">
-                <div><label className="block text-xs font-medium text-slate-600 mb-1">Name</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">Rosa Garcia</div></div>
-                <div><label className="block text-xs font-medium text-slate-600 mb-1">Age</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">78</div></div>
+                <div><label className="block text-xs font-medium text-slate-600 mb-1">Name</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">{recipient.name}</div></div>
+                <div><label className="block text-xs font-medium text-slate-600 mb-1">Age</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">{recipient.age ?? "N/A"}</div></div>
                 <div className="col-span-2"><label className="block text-xs font-medium text-slate-600 mb-1">Medications</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">Lisinopril, Metformin, Atorvastatin, Amlodipine</div></div>
-                <div><label className="block text-xs font-medium text-slate-600 mb-1">Primary Doctor</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">Dr. Chen, General Hospital</div></div>
+                <div><label className="block text-xs font-medium text-slate-600 mb-1">Primary Doctor</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">Dr. Chen, {recipient.facility || "General Hospital"}</div></div>
                 <div><label className="block text-xs font-medium text-slate-600 mb-1">Insurance</label><div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">Medicare Part D</div></div>
               </div>
             </div>

--- a/dashboard/src/app/pdf.ts
+++ b/dashboard/src/app/pdf.ts
@@ -2,6 +2,7 @@ import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import type { BillAuditResult, DrugInteractionResult, PharmacyCompareResult, SpendingData, Transaction } from "../lib/types";
 import { DEFAULT_PDF_THEME, type PdfTheme } from "../lib/pdf-theme";
+import type { RecipientProfile } from "../lib/types";
 
 type AutoTableDoc = jsPDF & { lastAutoTable?: { finalY: number } };
 
@@ -27,6 +28,11 @@ function formatTxHashDisplay(hash?: string): { display: string; decodeFailed: bo
   }
 
   return { display: `${hash.slice(0, 16)}... ?`, decodeFailed: true };
+}
+
+function formatRecipient(recipient: RecipientProfile): string {
+  const age = typeof recipient.age === "number" ? `, ${recipient.age}` : "";
+  return `${recipient.name}${age}`;
 }
 
 function addHeader(doc: jsPDF, title: string, subtitle: string, theme: PdfTheme) {
@@ -62,18 +68,31 @@ function addFooter(doc: jsPDF) {
 
 export function downloadBillAuditPDF(
   auditResult: BillAuditResult,
-  options?: { errorsOnly?: boolean; theme?: PdfTheme }
+  options?: { errorsOnly?: boolean; theme?: PdfTheme; recipient?: RecipientProfile }
 ) {
   const theme = options?.theme ?? DEFAULT_PDF_THEME;
   const errorsOnly = Boolean(options?.errorsOnly);
+  const recipient = options?.recipient ?? {
+    name: "Rosa Garcia",
+    age: 78,
+    facility: "General Hospital",
+  };
+  const recipientLabel = formatRecipient(recipient);
 
   const allItems = auditResult.lineItems;
   const filteredItems = errorsOnly ? allItems.filter((item) => item.status !== "valid") : allItems;
   const subtitle = errorsOnly
-    ? `Patient: Rosa Garcia | Facility: General Hospital | ${filteredItems.length} of ${allItems.length} items shown — errors only`
-    : "Patient: Rosa Garcia | Facility: General Hospital";
+    ? `Patient: ${recipientLabel} | Facility: ${recipient.facility || "N/A"} | ${filteredItems.length} of ${allItems.length} items shown — errors only`
+    : `Patient: ${recipientLabel} | Facility: ${recipient.facility || "N/A"}`;
 
   const doc: AutoTableDoc = new jsPDF();
+  doc.setProperties({
+    title: "CareGuard Medical Bill Audit Report",
+    subject: `Bill audit for ${recipient.name}`,
+    author: "CareGuard",
+    keywords: `${recipient.name},bill,audit,stellar`,
+    creator: `CareGuard ${new Date().toISOString()}`,
+  });
   addHeader(doc, "Medical Bill Audit Report", subtitle, theme);
 
   // Summary boxes
@@ -143,11 +162,28 @@ export function downloadBillAuditPDF(
 
 export function downloadMedicationPDF(
   params: { priceResults: PharmacyCompareResult[]; interactionResult?: DrugInteractionResult },
-  options?: { theme?: PdfTheme }
+  options?: { theme?: PdfTheme; recipient?: RecipientProfile }
 ) {
   const theme = options?.theme ?? DEFAULT_PDF_THEME;
+  const recipient = options?.recipient ?? {
+    name: "Rosa Garcia",
+    age: 78,
+    facility: "General Hospital",
+  };
   const doc: AutoTableDoc = new jsPDF();
-  addHeader(doc, "Medication Price Comparison Report", "Patient: Rosa Garcia | 4 Medications Compared", theme);
+  doc.setProperties({
+    title: "CareGuard Medication Price Comparison Report",
+    subject: `Medication comparison for ${recipient.name}`,
+    author: "CareGuard",
+    keywords: `${recipient.name},medication,prices,stellar`,
+    creator: `CareGuard ${new Date().toISOString()}`,
+  });
+  addHeader(
+    doc,
+    "Medication Price Comparison Report",
+    `Patient: ${formatRecipient(recipient)} | ${params.priceResults.length} Medications Compared`,
+    theme
+  );
 
   let y = 58;
   const priceResults = params.priceResults.filter(r => r.cheapest);
@@ -215,11 +251,28 @@ export function downloadMedicationPDF(
 export function downloadTransactionPDF(
   transactions: Transaction[],
   spending: SpendingData | null,
-  options?: { theme?: PdfTheme }
+  options?: { theme?: PdfTheme; recipient?: RecipientProfile }
 ) {
   const theme = options?.theme ?? DEFAULT_PDF_THEME;
+  const recipient = options?.recipient ?? {
+    name: "Rosa Garcia",
+    age: 78,
+    facility: "General Hospital",
+  };
   const doc: AutoTableDoc = new jsPDF();
-  addHeader(doc, "Transaction Report", `Patient: Rosa Garcia | ${transactions.length} Transactions`, theme);
+  doc.setProperties({
+    title: "CareGuard Transaction Report",
+    subject: `Transactions for ${recipient.name}`,
+    author: "CareGuard",
+    keywords: `${recipient.name},transactions,stellar`,
+    creator: `CareGuard ${new Date().toISOString()}`,
+  });
+  addHeader(
+    doc,
+    "Transaction Report",
+    `Patient: ${formatRecipient(recipient)} | ${transactions.length} Transactions`,
+    theme
+  );
 
   let y = 58;
 

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -93,3 +93,9 @@ export const SpendingDataSchema = z.object({
 
 export type SpendingData = z.infer<typeof SpendingDataSchema>;
 
+export type RecipientProfile = {
+  name: string;
+  age?: number;
+  facility?: string;
+};
+

--- a/dashboard/src/lib/useProfile.ts
+++ b/dashboard/src/lib/useProfile.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import type { RecipientProfile } from "./types";
+
+const AGENT_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3004";
+
+const DEFAULT_PROFILE: RecipientProfile = {
+  name: "Rosa Garcia",
+  age: 78,
+  facility: "General Hospital",
+};
+
+export function useProfile() {
+  const [recipient, setRecipient] = useState<RecipientProfile>(DEFAULT_PROFILE);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchProfile = async () => {
+      try {
+        const res = await fetch(`${AGENT_URL}/agent/profile`);
+        if (!res.ok) return;
+        const data = (await res.json()) as Partial<RecipientProfile>;
+        if (!mounted) return;
+        setRecipient({
+          name: data.name?.trim() || DEFAULT_PROFILE.name,
+          age: typeof data.age === "number" ? data.age : DEFAULT_PROFILE.age,
+          facility: data.facility?.trim() || DEFAULT_PROFILE.facility,
+        });
+      } catch {
+        // Keep default profile for dashboard demo mode.
+      }
+    };
+    fetchProfile();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return { recipient };
+}

--- a/dashboard/tests/e2e/agent-task.spec.ts
+++ b/dashboard/tests/e2e/agent-task.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+import { mockDashboardApis } from "./helpers";
+
+test("compare medication task updates UI", async ({ page }) => {
+  await mockDashboardApis(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Compare Medication Prices" }).click();
+  await expect(page.getByText("Compared prices and found cheaper options.")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("tab", { name: "Medications" }).click();
+  await expect(page.getByText("Lisinopril")).toBeVisible();
+  await expect(page.getByText("Save $11.5/mo")).toBeVisible();
+});

--- a/dashboard/tests/e2e/helpers.ts
+++ b/dashboard/tests/e2e/helpers.ts
@@ -1,0 +1,58 @@
+import { Page } from "@playwright/test";
+import profile from "../fixtures/profile.json";
+import spending from "../fixtures/spending.json";
+import transactions from "../fixtures/transactions.json";
+import agentRun from "../fixtures/agent-run.json";
+
+export async function mockDashboardApis(page: Page) {
+  await page.route("**/agent/profile", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(profile) });
+  });
+
+  await page.route("**/agent/spending", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(spending) });
+  });
+
+  await page.route("**/agent/transactions", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(transactions) });
+  });
+
+  await page.route("**/agent/run", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(agentRun) });
+  });
+
+  await page.route("**/agent/policy", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.route("**/agent/reset", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.route("**/horizon-testnet.stellar.org/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        balances: [
+          { asset_code: "USDC", balance: "123.45" },
+          { asset_type: "native", balance: "42.0" },
+        ],
+      }),
+    });
+  });
+
+  const rootPayload = JSON.stringify({
+    service: "agent",
+    agentWallet: "GBQTESTWALLET123",
+    llm: "mock-llm",
+    network: "stellar:testnet",
+    paused: false,
+  });
+  await page.route("**localhost:3004/", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: rootPayload });
+  });
+  await page.route("**127.0.0.1:3004/", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: rootPayload });
+  });
+}

--- a/dashboard/tests/e2e/mobile-responsive.spec.ts
+++ b/dashboard/tests/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+import { mockDashboardApis } from "./helpers";
+
+const viewports = [
+  { name: "iPhone SE", width: 375, height: 667 },
+  { name: "iPhone 14 Pro", width: 393, height: 852 },
+  { name: "Pixel 5", width: 393, height: 851 },
+  { name: "iPad", width: 768, height: 1024 },
+];
+
+for (const viewport of viewports) {
+  test(`activity and bill tables are scrollable on ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockDashboardApis(page);
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Audit Hospital Bill" }).click();
+    await page.getByRole("tab", { name: "Bills" }).click();
+    await expect(page.locator(".overflow-x-auto").first()).toBeVisible();
+
+    await page.getByRole("tab", { name: "Activity" }).click();
+    await expect(page.locator("table.min-w-\\[640px\\]")).toBeVisible();
+  });
+}

--- a/dashboard/tests/e2e/pdf-download.spec.ts
+++ b/dashboard/tests/e2e/pdf-download.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs/promises";
+import pdfParse from "pdf-parse";
+import { mockDashboardApis } from "./helpers";
+
+test("pdf download buttons trigger browser downloads", async ({ page }) => {
+  await mockDashboardApis(page);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Compare Medication Prices" }).click();
+  await page.getByRole("tab", { name: "Medications" }).click();
+
+  const medDownload = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Download PDF" }).click();
+  const medPdf = await medDownload;
+  const medPath = await medPdf.path();
+  expect(medPath).toBeTruthy();
+  if (medPath) {
+    const buffer = await fs.readFile(medPath);
+    const parsed = await pdfParse(buffer);
+    expect(parsed.text).toContain("Ada Lovelace");
+  }
+
+  await page.getByRole("tab", { name: "Activity" }).click();
+  const txDownload = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Download Report" }).click();
+  await expect(await txDownload).toBeTruthy();
+});

--- a/dashboard/tests/e2e/policy.spec.ts
+++ b/dashboard/tests/e2e/policy.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+import { mockDashboardApis } from "./helpers";
+
+test("policy save sends API request", async ({ page }) => {
+  let policyCalls = 0;
+  await mockDashboardApis(page);
+  await page.route("**/agent/policy", async (route) => {
+    policyCalls += 1;
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.goto("/?tab=policy");
+  await page.locator("input[type='number']").first().fill("120");
+  await page.getByRole("button", { name: "Update Policy" }).click();
+  await expect.poll(() => policyCalls).toBeGreaterThan(0);
+});

--- a/dashboard/tests/e2e/security-headers.spec.ts
+++ b/dashboard/tests/e2e/security-headers.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "@playwright/test";
+import { mockDashboardApis } from "./helpers";
+
+test("security headers are present", async ({ page }) => {
+  await mockDashboardApis(page);
+  const response = await page.goto("/");
+  const headers = response?.headers() ?? {};
+
+  expect(headers["x-frame-options"]).toBe("DENY");
+  expect(headers["x-content-type-options"]).toBe("nosniff");
+  expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  expect(headers["permissions-policy"]).toContain("camera=()");
+  expect(headers["content-security-policy-report-only"]).toContain("default-src 'self'");
+});

--- a/dashboard/tests/e2e/smoke.spec.ts
+++ b/dashboard/tests/e2e/smoke.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+import { mockDashboardApis } from "./helpers";
+
+test("all dashboard tabs render without crashing", async ({ page }) => {
+  await mockDashboardApis(page);
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "CareGuard" })).toBeVisible();
+  await expect(page.getByText("Ada Lovelace")).toBeVisible();
+
+  const tabs = ["Overview", "Medications", "Bills", "Policy", "Wallet", "Activity", "Settings"];
+  for (const tab of tabs) {
+    await page.getByRole("tab", { name: tab }).click();
+    await expect(page.getByRole("tab", { name: tab })).toHaveAttribute("aria-selected", "true");
+  }
+});

--- a/dashboard/tests/e2e/wallet.spec.ts
+++ b/dashboard/tests/e2e/wallet.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "@playwright/test";
+import { mockDashboardApis } from "./helpers";
+
+test("wallet tab shows mocked horizon balances", async ({ page }) => {
+  await mockDashboardApis(page);
+  await page.goto("/?tab=wallet");
+
+  await expect(page.getByText("$123.45")).toBeVisible();
+  await expect(page.getByText("42.00")).toBeVisible();
+});

--- a/dashboard/tests/fixtures/agent-run.json
+++ b/dashboard/tests/fixtures/agent-run.json
@@ -1,0 +1,55 @@
+{
+  "response": "Compared prices and found cheaper options.",
+  "toolCalls": [
+    {
+      "tool": "compare_pharmacy_prices",
+      "input": {},
+      "result": {
+        "drug": "Lisinopril",
+        "prices": [
+          {
+            "pharmacyName": "Costco",
+            "price": 12.5,
+            "distance": "2mi",
+            "inStock": true
+          },
+          {
+            "pharmacyName": "CVS",
+            "price": 24.0,
+            "distance": "1mi",
+            "inStock": true
+          }
+        ],
+        "cheapest": {
+          "pharmacyName": "Costco",
+          "price": 12.5,
+          "distance": "2mi",
+          "inStock": true
+        },
+        "potentialSavings": 11.5,
+        "savingsPercent": 47.9
+      }
+    }
+  ],
+  "spending": {
+    "policy": {
+      "dailyLimit": 100,
+      "monthlyLimit": 500,
+      "medicationMonthlyBudget": 300,
+      "billMonthlyBudget": 500,
+      "approvalThreshold": 75
+    },
+    "spending": {
+      "medications": 42.5,
+      "bills": 120,
+      "serviceFees": 0.021,
+      "total": 162.521
+    },
+    "budgetRemaining": {
+      "medications": 257.5,
+      "bills": 380
+    },
+    "transactionCount": 2,
+    "recentTransactions": []
+  }
+}

--- a/dashboard/tests/fixtures/profile.json
+++ b/dashboard/tests/fixtures/profile.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ada Lovelace",
+  "age": 82,
+  "facility": "Memorial Clinic"
+}

--- a/dashboard/tests/fixtures/spending.json
+++ b/dashboard/tests/fixtures/spending.json
@@ -1,0 +1,21 @@
+{
+  "policy": {
+    "dailyLimit": 100,
+    "monthlyLimit": 500,
+    "medicationMonthlyBudget": 300,
+    "billMonthlyBudget": 500,
+    "approvalThreshold": 75
+  },
+  "spending": {
+    "medications": 42.5,
+    "bills": 120,
+    "serviceFees": 0.021,
+    "total": 162.521
+  },
+  "budgetRemaining": {
+    "medications": 257.5,
+    "bills": 380
+  },
+  "transactionCount": 2,
+  "recentTransactions": []
+}

--- a/dashboard/tests/fixtures/transactions.json
+++ b/dashboard/tests/fixtures/transactions.json
@@ -1,0 +1,25 @@
+{
+  "transactions": [
+    {
+      "id": "tx-1",
+      "timestamp": "2026-04-27T10:00:00.000Z",
+      "type": "medication",
+      "description": "Lisinopril order",
+      "amount": 12.5,
+      "recipient": "Pharmacy",
+      "stellarTxHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "status": "completed",
+      "category": "medication"
+    },
+    {
+      "id": "tx-2",
+      "timestamp": "2026-04-27T11:00:00.000Z",
+      "type": "service_fee",
+      "description": "Price comparison API",
+      "amount": 0.002,
+      "recipient": "x402",
+      "status": "completed",
+      "category": "service"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- make recipient data dynamic across dashboard chrome and all PDF exports by introducing a profile hook and passing recipient details into PDF builders
- add report-only CSP and baseline security headers in Next.js config, with policy notes for future strict CSP rollout
- improve mobile UX for bill/activity tables with horizontal wrappers, minimum table width, and compact details for hidden low-priority columns
- add Playwright E2E scaffolding, fixtures, core smoke/policy/agent/pdf/wallet/security/mobile tests, and CI workflow for dashboard regressions

## Test Plan
- npm run lint (dashboard)
- run Playwright suite via `npm run test:e2e` in dashboard

Closes #153
Closes #154
Closes #152
Closes #148

Made with [Cursor](https://cursor.com)