### PR TITLE
Fix docs issues #127 and #131 (dashboard README + architecture doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Every payment is a real Stellar testnet transaction verifiable on [stellar.exper
 
 ## Architecture
 
+For a full runtime flow diagram, module map, and integration details, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                   CAREGIVER DASHBOARD (Next.js)              │

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,36 +1,72 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# CareGuard Dashboard
 
-## Getting Started
+CareGuard's dashboard is the caregiver control plane for the AI agent. It lets you run autonomous tasks, inspect spending, adjust policy guardrails, and export human-readable PDF reports.
 
-First, run the development server:
+## This Is NOT the Next.js You Know
+
+This project uses Next.js 16. Before contributing, read the Next.js docs shipped in `node_modules/next/dist/docs/` and follow breaking-change guidance.
+
+## Prerequisites
+
+- Node.js 22+
+- pnpm
+- CareGuard backend running (`npm run dev` from the repo root)
+
+## Local Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create `dashboard/.env.local`:
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:3004
+```
+
+3. Start the dashboard:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+4. Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Tab to Endpoint Map (7 Tabs)
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Tab | What it does | Primary endpoints |
+| --- | --- | --- |
+| `overview` | Run agent workflows and track totals | `POST /agent/run`, `GET /agent/spending` |
+| `medications` | View medication compare/interaction results | Reads from `POST /agent/run` result payload (tool outputs) |
+| `bills` | View bill audit results and download bill PDF | Reads from `POST /agent/run` result payload, exports via `src/app/pdf.ts` |
+| `policy` | Update spending limits and approval threshold | `POST /agent/policy`, `GET /agent/spending` |
+| `wallet` | Show agent wallet and balances | `GET /`, `GET https://horizon-testnet.stellar.org/accounts/:wallet` |
+| `activity` | Browse transaction log, reset state, download report | `GET /agent/transactions`, `POST /agent/reset`, exports via `src/app/pdf.ts` |
+| `settings` | Pause/resume autonomous actions | `POST /agent/pause`, `POST /agent/resume` |
 
-## Learn More
+Note: background refresh uses `GET /`, `GET /agent/spending`, and `GET /agent/transactions`.
 
-To learn more about Next.js, take a look at the following resources:
+## PDF Reports
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Generated client-side from `dashboard/src/app/pdf.ts`.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- `careguard-medication-report.pdf`
+  - Sample output: monthly medication savings summary, per-pharmacy price tables, drug interaction section.
+- `careguard-bill-audit-report.pdf`
+  - Sample output: total charged vs corrected amount, overcharge totals, line-item status table.
+- `careguard-transaction-report.pdf`
+  - Sample output: medications/bills/service-fees summary and transaction ledger with Stellar Tx references.
 
-## Deploy on Vercel
+## Deployment
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+- Production deployment runbook: [docs/deploy.md](../docs/deploy.md)
+- One-click dashboard deploy:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/harystyleseze/careguard&project-name=careguard-dashboard&root-directory=dashboard)
+
+## Related Docs
+
+- Root quick start: [../QUICKSTART.md](../QUICKSTART.md)
+- Architecture details: [../docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# CareGuard Architecture
+
+This document explains the runtime flow, module boundaries, integrations, and core data shapes used by CareGuard.
+
+## Runtime Flow
+
+```mermaid
+flowchart TD
+  A[Caregiver dashboard request] --> B[HTTP /agent/run]
+  B --> C[runAgent task loop]
+  C --> D[Tool call executeTool]
+  D --> E1[x402 APIs: /pharmacy/compare, /bill/audit, /drug/interactions]
+  D --> E2[MPP charge: /pharmacy/order]
+  D --> E3[Direct Stellar USDC transfer]
+  E1 --> F[Persist spending + transaction data]
+  E2 --> F
+  E3 --> F
+  F --> G[Return agent response + tool calls + spending summary]
+```
+
+## Module Map
+
+- `shared/`: cross-service types and middleware helpers.
+- `agent/`: AI agent runtime (`runAgent` loop) and tool implementations.
+- `services/`: standalone APIs for pharmacy pricing, bill audit, drug interactions, and pharmacy payment receiver.
+- `dashboard/`: Next.js 16 caregiver UI with seven tabs and PDF export.
+- `scripts/`: setup/bootstrap utilities (wallet creation, trustline/funding prep).
+
+## Integration Points
+
+- LLM provider: Groq-compatible OpenAI API (`https://api.groq.com/openai/v1`), default model `llama-3.3-70b-versatile`.
+- OZ facilitator + x402 stack: `@x402/express`, `@x402/fetch`, `@x402/stellar` at `^2.11.0`.
+- MPP stack: `@stellar/mpp@^0.4.0`, `mppx@^0.6.5`.
+- Horizon: `https://horizon-testnet.stellar.org`.
+- Stellar SDK: `@stellar/stellar-sdk@^14.6.1`.
+- Circle USDC testnet faucet: <https://faucet.circle.com>.
+
+## Data Shapes
+
+`Transaction` (from `shared/types.ts`):
+
+```ts
+{
+  id: string;
+  timestamp: string;
+  type: "medication" | "bill" | "service_fee";
+  description: string;
+  amount: number;
+  recipient: string;
+  stellarTxHash?: string;
+  status: "pending" | "approved" | "completed" | "blocked" | "disputed";
+  category: string;
+}
+```
+
+`SpendingPolicy` (from `shared/types.ts`):
+
+```ts
+{
+  dailyLimit: number;
+  monthlyLimit: number;
+  medicationMonthlyBudget: number;
+  billMonthlyBudget: number;
+  approvalThreshold: number;
+}
+```
+
+`AuditLogEntry` (current dashboard activity-log shape; aligned with issue #72 direction):
+
+```ts
+{
+  id: string;
+  timestamp: number;
+  message: string;
+}
+```
+
+## Non-Goals
+
+This architecture document does not cover:
+
+- Full smart-contract enforcement design for Soroban policy guards.
+- Mobile-client specific architecture.
+- Production observability/alerting topology beyond current local-first logs.
+- Infrastructure-as-code details for hosting each service.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,26 @@
+# CareGuard Deployment
+
+This is the production deployment guide for CareGuard.
+
+## Dashboard (Vercel)
+
+1. Import the repository in Vercel.
+2. Set project root to `dashboard`.
+3. Configure environment variable:
+   - `NEXT_PUBLIC_API_URL` = your deployed CareGuard API base URL.
+4. Deploy.
+
+## Backend
+
+Deploy the root unified server (`server.ts`) on a Node.js host that supports outbound HTTPS and environment variables.
+
+Required environment variables include:
+
+- `LLM_API_KEY`
+- `AGENT_SECRET_KEY`
+- `PHARMACY_1_PUBLIC_KEY`
+- `BILL_PROVIDER_PUBLIC_KEY`
+- `MPP_SECRET_KEY`
+- `OZ_FACILITATOR_API_KEY` (required for public network)
+
+See `.env.example` and `README.md` for full setup context.


### PR DESCRIPTION
Closes #127
Closes #131
Closes #132
Closes #133

## Changes
- Replaced dashboard/README.md boilerplate with project-specific contributor docs
- Added prerequisites, local setup, .env.local example, and 7-tab endpoint map
- Documented PDF report outputs from dashboard/src/app/pdf.ts
- Added Next.js 16 breaking-change warning note and Vercel deploy button
- Added new docs/ARCHITECTURE.md with Mermaid runtime flow, module map, integration points, and data-shape examples
- Added docs/deploy.md and linked it from dashboard docs
- Linked root README.md Architecture section to the new architecture doc

## Testing
- Documentation-only change; no runtime code paths changed
