### PR TITLE
fix: reserve x402 service fees until settlement confirms

### DIFF
--- a/agent/__tests__/health.test.ts
+++ b/agent/__tests__/health.test.ts
@@ -17,8 +17,10 @@ vi.mock("../tools.ts", () => ({
   checkSpendingPolicy: vi.fn(),
   getSpendingSummary: vi.fn(() => ({ spending: {}, policy: {} })),
   setSpendingPolicy: vi.fn(),
-  getSpendingTracker: vi.fn(() => ({ transactions: [] })),
+  getSpendingTracker: vi.fn(() => ({ transactions: [], pendingServiceFees: 0 })),
   resetSpendingTracker: vi.fn(),
+  reconcilePendingServiceFees: vi.fn(),
+  saveSpending: vi.fn(),
   TOOL_DEFINITIONS: [],
 }));
 vi.mock("../../shared/x402-middleware.ts", () => ({

--- a/agent/__tests__/x402-service-fees.test.ts
+++ b/agent/__tests__/x402-service-fees.test.ts
@@ -1,0 +1,136 @@
+// vi.hoisted runs before any vi.mock factory — sets env vars + captures mutable refs
+const { mockX402Fetch, mockDecodePaymentResponseHeader, mockHorizonTransactionCall } = vi.hoisted(() => {
+  process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+  return {
+    mockX402Fetch: vi.fn(),
+    mockDecodePaymentResponseHeader: vi.fn(),
+    mockHorizonTransactionCall: vi.fn(),
+  };
+});
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("fs", () => ({
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("@stellar/stellar-sdk", () => ({
+  Keypair: { fromSecret: vi.fn().mockReturnValue({ publicKey: () => "GPUB123", sign: vi.fn() }) },
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  TransactionBuilder: vi.fn().mockReturnValue({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockReturnValue({ sign: vi.fn() }),
+  }),
+  Operation: { payment: vi.fn() },
+  Asset: vi.fn(),
+  Horizon: {
+    Server: vi.fn().mockReturnValue({
+      loadAccount: vi.fn(),
+      submitTransaction: vi.fn(),
+      transactions: vi.fn().mockReturnValue({
+        transaction: vi.fn().mockReturnValue({
+          call: mockHorizonTransactionCall,
+        }),
+      }),
+    }),
+  },
+}));
+vi.mock("@x402/stellar", () => ({
+  createEd25519Signer: vi.fn().mockReturnValue({}),
+  ExactStellarScheme: vi.fn(),
+}));
+vi.mock("@x402/fetch", () => ({
+  wrapFetchWithPayment: vi.fn().mockReturnValue(mockX402Fetch),
+  x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }),
+  decodePaymentResponseHeader: mockDecodePaymentResponseHeader,
+}));
+vi.mock("@stellar/mpp/charge/client", () => ({ stellar: vi.fn().mockReturnValue({}) }));
+vi.mock("mppx/client", () => ({ Mppx: { create: vi.fn().mockReturnValue({ fetch: vi.fn() }) } }));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  comparePharmacyPrices,
+  auditBill,
+  checkDrugInteractions,
+  getSpendingSummary,
+  getSpendingTracker,
+  reconcilePendingServiceFees,
+  resetSpendingTracker,
+} from "../tools.ts";
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    headers: {
+      get: (name: string) => {
+        const hit = Object.entries(headers).find(([k]) => k.toLowerCase() === name.toLowerCase());
+        return hit?.[1] ?? null;
+      },
+    },
+  } as any;
+}
+
+describe("x402 service fee settlement tracking", () => {
+  beforeEach(() => {
+    resetSpendingTracker();
+    mockX402Fetch.mockReset();
+    mockDecodePaymentResponseHeader.mockReset();
+    mockHorizonTransactionCall.mockReset();
+  });
+
+  it("records service fees as pending settlement when response has no tx hash", async () => {
+    mockX402Fetch.mockResolvedValueOnce(jsonResponse({ protocol: { payTo: "pharmacy-price-api" }, prices: [] }));
+
+    await comparePharmacyPrices("Metformin", "90210");
+
+    const tracker = getSpendingTracker() as any;
+    expect(tracker.serviceFees).toBe(0);
+    expect(tracker.pendingServiceFees).toBe(0.002);
+    expect(tracker.transactions).toHaveLength(1);
+    expect(tracker.transactions[0].status).toBe("pending_settlement");
+    expect(tracker.transactions[0].stellarTxHash).toBeUndefined();
+  });
+
+  it("reconciliation confirms a pending fee when Horizon can find the tx hash", async () => {
+    mockDecodePaymentResponseHeader.mockReturnValueOnce({ transaction: "txhash-123" });
+    mockX402Fetch.mockResolvedValueOnce(
+      jsonResponse({ protocol: { payTo: "bill-audit-api" }, ok: true }, { "PAYMENT-RESPONSE": "encoded" })
+    );
+    mockHorizonTransactionCall.mockResolvedValueOnce({ id: "txhash-123" });
+
+    await auditBill([{ description: "x", cptCode: "123", quantity: 1, chargedAmount: 50 }]);
+    await reconcilePendingServiceFees();
+
+    const tracker = getSpendingTracker() as any;
+    expect(tracker.pendingServiceFees).toBe(0);
+    expect(tracker.serviceFees).toBe(0.01);
+    expect(tracker.transactions[0].status).toBe("completed");
+    expect(tracker.transactions[0].stellarTxHash).toBe("txhash-123");
+  });
+
+  it("reconciliation marks old unresolved pending fees as failed without double-counting", async () => {
+    mockDecodePaymentResponseHeader.mockReturnValueOnce({ transaction: "txhash-missing" });
+    mockX402Fetch.mockResolvedValueOnce(
+      jsonResponse({ protocol: { payTo: "drug-interaction-api" }, ok: true }, { "PAYMENT-RESPONSE": "encoded" })
+    );
+    mockHorizonTransactionCall.mockRejectedValueOnce({ response: { status: 404 } });
+
+    await checkDrugInteractions(["Aspirin", "Warfarin"]);
+    const trackerBefore = getSpendingTracker() as any;
+    trackerBefore.transactions[0].timestamp = new Date(Date.now() - 6 * 60 * 1000).toISOString();
+
+    await reconcilePendingServiceFees();
+
+    const summary = getSpendingSummary() as any;
+    const tracker = getSpendingTracker() as any;
+    expect(tracker.pendingServiceFees).toBe(0);
+    expect(tracker.serviceFees).toBe(0);
+    expect(tracker.transactions[0].status).toBe("failed");
+    expect(summary.spending.pendingServiceFees).toBe(0);
+    expect(summary.spending.serviceFees).toBe(0);
+  });
+});

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -26,6 +26,8 @@ import {
   setSpendingPolicy,
   getSpendingTracker,
   resetSpendingTracker,
+  reconcilePendingServiceFees,
+  saveSpending,
   TOOL_DEFINITIONS,
 } from "./tools.ts";
 
@@ -223,11 +225,13 @@ async function runAgent(task: string) {
 }
 
 // Metrics endpoint for Prometheus/Grafana
-app.get("/metrics", (_req, res) => {
+app.get("/metrics", async (_req, res) => {
+  await reconcilePendingServiceFees();
   const tracker = getSpendingTracker();
   const pendingCount = tracker.transactions.filter((t: any) => t.status === "pending").length;
+  const pendingSettlementCount = tracker.transactions.filter((t: any) => t.status === "pending_settlement").length;
   const completedCount = tracker.transactions.filter((t: any) => t.status === "completed").length;
-  const failedCount = tracker.transactions.filter((t: any) => t.status === "rejected").length;
+  const failedCount = tracker.transactions.filter((t: any) => t.status === "rejected" || t.status === "failed").length;
 
   const now = Date.now();
   const last24h = llmTokenHistory.filter((t) => now - t.timestamp < 86400000);
@@ -259,6 +263,7 @@ agent_llm_cost_usd ${estimatedCost.toFixed(4)}
 # TYPE agent_transactions_total counter
 agent_transactions_total{status="completed"} ${completedCount}
 agent_transactions_total{status="pending"} ${pendingCount}
+agent_transactions_total{status="pending_settlement"} ${pendingSettlementCount}
 agent_transactions_total{status="rejected"} ${failedCount}
 
 # HELP agent_spending_usd Spending by category
@@ -266,6 +271,10 @@ agent_transactions_total{status="rejected"} ${failedCount}
 agent_spending_usd{category="medications"} ${tracker.medications}
 agent_spending_usd{category="bills"} ${tracker.bills}
 agent_spending_usd{category="service_fees"} ${tracker.serviceFees}
+
+# HELP x402_unconfirmed_fees_usdc Unconfirmed x402 service fees awaiting on-chain settlement
+# TYPE x402_unconfirmed_fees_usdc gauge
+x402_unconfirmed_fees_usdc ${tracker.pendingServiceFees || 0}
 
 # HELP agent_stellar_tx_success_total Successful Stellar transactions
 # TYPE agent_stellar_tx_success_total counter
@@ -314,7 +323,8 @@ app.get("/agent/wallet", async (req, res) => {
 });
 
 // Pending approvals
-app.get("/agent/pending-approvals", (_req, res) => {
+app.get("/agent/pending-approvals", async (_req, res) => {
+  await reconcilePendingServiceFees();
   const tracker = getSpendingTracker();
   const pending = tracker.transactions.filter((t: any) => t.status === "pending");
   res.json({ approvals: pending });
@@ -408,8 +418,8 @@ app.post("/agent/run", async (req, res) => {
   }
 });
 
-app.get("/agent/spending", (_req, res) => { res.json(getSpendingSummary()); });
-app.get("/agent/transactions", (_req, res) => { res.json(getSpendingTracker()); });
+app.get("/agent/spending", async (_req, res) => { await reconcilePendingServiceFees(); res.json(getSpendingSummary()); });
+app.get("/agent/transactions", async (_req, res) => { await reconcilePendingServiceFees(); res.json(getSpendingTracker()); });
 function validatePolicyPayload(body: any): { ok: true; policy: any } | { ok: false; errors: string[] } {
   const errors: string[] = [];
   if (!body || typeof body !== "object") return { ok: false, errors: ["body must be a JSON object"] };

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -25,6 +25,7 @@ const DRUG_INTERACTION_API = process.env.DRUG_INTERACTION_API_URL || "http://loc
 const PHARMACY_PAYMENT_API = process.env.PHARMACY_PAYMENT_API_URL || "http://localhost:3005";
 const USDC_ISSUER = process.env.USDC_ISSUER || "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
+const X402_SETTLEMENT_GRACE_MS = 5 * 60 * 1000;
 
 if (!AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");
 
@@ -79,15 +80,23 @@ interface SpendingTracker {
   medications: number;
   bills: number;
   serviceFees: number;
+  pendingServiceFees: number;
   transactions: Transaction[];
 }
 
 function loadSpending(): SpendingTracker {
-  if (!existsSync(SPENDING_FILE)) return { medications: 0, bills: 0, serviceFees: 0, transactions: [] };
-  return JSON.parse(readFileSync(SPENDING_FILE, "utf-8"));
+  if (!existsSync(SPENDING_FILE)) return { medications: 0, bills: 0, serviceFees: 0, pendingServiceFees: 0, transactions: [] };
+  const parsed = JSON.parse(readFileSync(SPENDING_FILE, "utf-8"));
+  return {
+    medications: parsed.medications || 0,
+    bills: parsed.bills || 0,
+    serviceFees: parsed.serviceFees || 0,
+    pendingServiceFees: parsed.pendingServiceFees || 0,
+    transactions: parsed.transactions || [],
+  };
 }
 
-function saveSpending(data: SpendingTracker) {
+export function saveSpending(data: SpendingTracker) {
   writeFileSync(SPENDING_FILE, JSON.stringify(data, null, 2));
 }
 
@@ -128,8 +137,62 @@ export function setSpendingPolicy(policy: SpendingPolicy) {
 }
 export function getSpendingTracker() { return { ...spendingTracker, policy: currentPolicy }; }
 export function resetSpendingTracker() {
-  spendingTracker = { medications: 0, bills: 0, serviceFees: 0, transactions: [] };
+  spendingTracker = { medications: 0, bills: 0, serviceFees: 0, pendingServiceFees: 0, transactions: [] };
   saveSpending(spendingTracker);
+}
+
+function reserveX402ServiceFee(amount: number, description: string, recipient: string, stellarTxHash?: string) {
+  const tx: Transaction = {
+    id: `tx-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    type: "service_fee",
+    description,
+    amount,
+    recipient,
+    stellarTxHash,
+    status: "pending_settlement",
+    category: "service_fees",
+  };
+
+  spendingTracker.pendingServiceFees += amount;
+  spendingTracker.transactions.push(tx);
+  saveSpending(spendingTracker);
+  return tx;
+}
+
+export async function reconcilePendingServiceFees(now = Date.now()) {
+  let updated = false;
+
+  for (const tx of spendingTracker.transactions) {
+    if (tx.type !== "service_fee" || tx.status !== "pending_settlement") continue;
+    if (!tx.stellarTxHash) continue;
+
+    try {
+      await horizonServer.transactions().transaction(tx.stellarTxHash).call();
+      tx.status = "completed";
+      spendingTracker.pendingServiceFees = Math.max(0, spendingTracker.pendingServiceFees - tx.amount);
+      spendingTracker.serviceFees += tx.amount;
+      updated = true;
+      continue;
+    } catch (err: any) {
+      const status = err?.response?.status || err?.status;
+      const isNotFound = status === 404;
+      const isPastGrace = now - new Date(tx.timestamp).getTime() >= X402_SETTLEMENT_GRACE_MS;
+
+      if (isNotFound && isPastGrace) {
+        tx.status = "failed";
+        spendingTracker.pendingServiceFees = Math.max(0, spendingTracker.pendingServiceFees - tx.amount);
+        updated = true;
+      }
+    }
+  }
+
+  if (updated) saveSpending(spendingTracker);
+  return {
+    pendingServiceFees: spendingTracker.pendingServiceFees,
+    settledServiceFees: spendingTracker.serviceFees,
+    transactionsUpdated: updated,
+  };
 }
 
 // --- Tool: Compare pharmacy prices (pays via x402) ---
@@ -146,22 +209,13 @@ export async function comparePharmacyPrices(drugName: string, zipCode: string = 
 
   const data = await response.json();
 
-  // Extract real Stellar tx hash from x402 payment response header
-  const txHash = extractX402TxHash(response);
-
-  spendingTracker.serviceFees += 0.002;
-  spendingTracker.transactions.push({
-    id: `tx-${Date.now()}`,
-    timestamp: new Date().toISOString(),
-    type: "service_fee",
-    description: `x402 query: pharmacy prices for ${drugName}`,
-    amount: 0.002,
-    recipient: data.protocol?.payTo || "pharmacy-price-api",
-    stellarTxHash: txHash,
-    status: "completed",
-    category: "service_fees",
-  });
-  saveSpending(spendingTracker);
+  // Reserve first; settlement is confirmed later by reconciliation against Horizon.
+  reserveX402ServiceFee(
+    0.002,
+    `x402 query: pharmacy prices for ${drugName}`,
+    data.protocol?.payTo || "pharmacy-price-api",
+    extractX402TxHash(response)
+  );
 
   return data;
 }
@@ -259,21 +313,12 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
 
   const data = await response.json();
 
-  const txHash = extractX402TxHash(response);
-
-  spendingTracker.serviceFees += 0.01;
-  spendingTracker.transactions.push({
-    id: `tx-${Date.now()}`,
-    timestamp: new Date().toISOString(),
-    type: "service_fee",
-    description: "x402 query: medical bill audit",
-    amount: 0.01,
-    recipient: data.protocol?.payTo || "bill-audit-api",
-    stellarTxHash: txHash,
-    status: "completed",
-    category: "service_fees",
-  });
-  saveSpending(spendingTracker);
+  reserveX402ServiceFee(
+    0.01,
+    "x402 query: medical bill audit",
+    data.protocol?.payTo || "bill-audit-api",
+    extractX402TxHash(response)
+  );
 
   return data;
 }
@@ -292,21 +337,12 @@ export async function checkDrugInteractions(medications: string[]) {
 
   const data = await response.json();
 
-  const txHash = extractX402TxHash(response);
-
-  spendingTracker.serviceFees += 0.001;
-  spendingTracker.transactions.push({
-    id: `tx-${Date.now()}`,
-    timestamp: new Date().toISOString(),
-    type: "service_fee",
-    description: `x402 query: drug interactions for ${medications.join(", ")}`,
-    amount: 0.001,
-    recipient: data.protocol?.payTo || "drug-interaction-api",
-    stellarTxHash: txHash,
-    status: "completed",
-    category: "service_fees",
-  });
-  saveSpending(spendingTracker);
+  reserveX402ServiceFee(
+    0.001,
+    `x402 query: drug interactions for ${medications.join(", ")}`,
+    data.protocol?.payTo || "drug-interaction-api",
+    extractX402TxHash(response)
+  );
 
   return data;
 }
@@ -478,13 +514,14 @@ export async function payBill(providerId: string, providerName: string, descript
 
 // --- Tool: Get spending summary ---
 export function getSpendingSummary() {
-  const total = spendingTracker.medications + spendingTracker.bills + spendingTracker.serviceFees;
+  const total = spendingTracker.medications + spendingTracker.bills + spendingTracker.serviceFees + spendingTracker.pendingServiceFees;
   return {
     policy: currentPolicy,
     spending: {
       medications: +spendingTracker.medications.toFixed(2),
       bills: +spendingTracker.bills.toFixed(2),
       serviceFees: +spendingTracker.serviceFees.toFixed(4),
+      pendingServiceFees: +spendingTracker.pendingServiceFees.toFixed(4),
       total: +total.toFixed(2),
     },
     budgetRemaining: {

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -82,6 +82,7 @@ export const SpendingDataSchema = z.object({
     medications: z.number(),
     bills: z.number(),
     serviceFees: z.number(),
+    pendingServiceFees: z.number(),
     total: z.number(),
   }),
   budgetRemaining: z.object({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -63,7 +63,7 @@ export interface Transaction {
   recipient: string;
   stellarTxHash?: string;
   mppOrderId?: string;
-  status: "pending" | "approved" | "completed" | "blocked" | "disputed";
+  status: "pending" | "approved" | "completed" | "blocked" | "disputed" | "pending_settlement" | "failed" | "rejected";
   category: string;
 }
 
@@ -86,6 +86,7 @@ export interface CareRecipient {
     medications: number;
     bills: number;
     serviceFees: number;
+    pendingServiceFees: number;
     total: number;
   };
   savingsAchieved: number;


### PR DESCRIPTION
## Summary
- switch x402 service-fee accounting to a reserve -> confirm flow instead of marking fees settled immediately
- add pending settlement tracking plus x402_unconfirmed_fees_usdc
- add reconciliation that confirms tx hashes against Horizon and expires unresolved rows after a grace window
- extend types and add focused tests for missing tx hash / confirmed settlement / stale pending failure

## Why
Issue #192 points out that service fees are currently debited from spendingTracker.serviceFees before on-chain settlement is actually confirmed. This patch keeps those fees in pendingServiceFees until Horizon can confirm the tx hash.

## Notes
- I did **not** run the repository test/build commands because the automation policy forbids running unreviewed external code from unknown repos.
- This PR is therefore a static patch + test addition, opened as **draft** for maintainer review / CI validation.

Closes #192