### PR TITLE
Track x402 transaction hash extraction failures

### DIFF
--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -15,7 +15,8 @@ import { createEd25519Signer, ExactStellarScheme } from "@x402/stellar";
 import { Mppx } from "mppx/client";
 import { stellar as stellarCharge } from "@stellar/mpp/charge/client";
 import type { SpendingPolicy, Transaction } from "../shared/types.ts";
-export { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
+import { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
+export { SPENDING_TIMEZONE, getLocalDateStr };
 
 // Environment
 const AGENT_SECRET_KEY = process.env.AGENT_SECRET_KEY;
@@ -31,16 +32,43 @@ if (!AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");
 const agentKeypair = Keypair.fromSecret(AGENT_SECRET_KEY);
 const horizonServer = new Horizon.Server(HORIZON_URL);
 
+type TxHashExtraction = {
+  stellarTxHash?: string;
+  txHashStatus: "extracted" | "extraction_failed";
+};
+
+let x402TxExtractionFailedTotal = 0;
+
+export function getX402TxExtractionFailedTotal() {
+  return x402TxExtractionFailedTotal;
+}
+
 // Helper: extract real Stellar tx hash from x402 PAYMENT-RESPONSE header
-function extractX402TxHash(response: Response): string | undefined {
+function extractX402TxHash(response: Response, responseBody?: unknown): TxHashExtraction {
   const header = response.headers.get("PAYMENT-RESPONSE") || response.headers.get("payment-response") || response.headers.get("X-PAYMENT-RESPONSE");
-  if (!header) return undefined;
+  const headers = Object.fromEntries(response.headers.entries());
+  const fail = (reason: string): TxHashExtraction => {
+    x402TxExtractionFailedTotal += 1;
+    console.warn("[x402] tx hash extraction failed", {
+      reason,
+      headers,
+      body: responseBody,
+      metric: "x402_tx_extraction_failed_total",
+      value: x402TxExtractionFailedTotal,
+    });
+    return { stellarTxHash: "extraction_failed", txHashStatus: "extraction_failed" };
+  };
+
+  if (!header) return fail("missing payment response header");
   try {
     const decoded = decodePaymentResponseHeader(header);
-    return decoded.transaction || undefined;
+    const txHash = decoded.transaction || undefined;
+    if (!txHash) return fail("decoded payment response did not include transaction");
+    return { stellarTxHash: txHash, txHashStatus: "extracted" };
   } catch {
     // If decode fails, the header itself might be a raw hash
-    return header.length === 64 ? header : undefined;
+    if (header.length === 64) return { stellarTxHash: header, txHashStatus: "extracted" };
+    return fail("payment response header could not be decoded");
   }
 }
 
@@ -147,7 +175,7 @@ export async function comparePharmacyPrices(drugName: string, zipCode: string = 
   const data = await response.json();
 
   // Extract real Stellar tx hash from x402 payment response header
-  const txHash = extractX402TxHash(response);
+  const txHash = extractX402TxHash(response, data);
 
   spendingTracker.serviceFees += 0.002;
   spendingTracker.transactions.push({
@@ -157,7 +185,8 @@ export async function comparePharmacyPrices(drugName: string, zipCode: string = 
     description: `x402 query: pharmacy prices for ${drugName}`,
     amount: 0.002,
     recipient: data.protocol?.payTo || "pharmacy-price-api",
-    stellarTxHash: txHash,
+    stellarTxHash: txHash.stellarTxHash,
+    txHashStatus: txHash.txHashStatus,
     status: "completed",
     category: "service_fees",
   });
@@ -259,7 +288,7 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
 
   const data = await response.json();
 
-  const txHash = extractX402TxHash(response);
+  const txHash = extractX402TxHash(response, data);
 
   spendingTracker.serviceFees += 0.01;
   spendingTracker.transactions.push({
@@ -269,7 +298,8 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
     description: "x402 query: medical bill audit",
     amount: 0.01,
     recipient: data.protocol?.payTo || "bill-audit-api",
-    stellarTxHash: txHash,
+    stellarTxHash: txHash.stellarTxHash,
+    txHashStatus: txHash.txHashStatus,
     status: "completed",
     category: "service_fees",
   });
@@ -292,7 +322,7 @@ export async function checkDrugInteractions(medications: string[]) {
 
   const data = await response.json();
 
-  const txHash = extractX402TxHash(response);
+  const txHash = extractX402TxHash(response, data);
 
   spendingTracker.serviceFees += 0.001;
   spendingTracker.transactions.push({
@@ -302,7 +332,8 @@ export async function checkDrugInteractions(medications: string[]) {
     description: `x402 query: drug interactions for ${medications.join(", ")}`,
     amount: 0.001,
     recipient: data.protocol?.payTo || "drug-interaction-api",
-    stellarTxHash: txHash,
+    stellarTxHash: txHash.stellarTxHash,
+    txHashStatus: txHash.txHashStatus,
     status: "completed",
     category: "service_fees",
   });

--- a/dashboard/src/components/primitives/tx-link.tsx
+++ b/dashboard/src/components/primitives/tx-link.tsx
@@ -2,9 +2,25 @@ const EXPLORER_URL = "https://stellar.expert/explorer/testnet/tx";
 
 export interface TxLinkProps {
   hash?: string;
+  status?: "extracted" | "extraction_failed";
 }
 
-export function TxLink({ hash }: TxLinkProps) {
+export function TxLink({ hash, status }: TxLinkProps) {
+  if (status === "extraction_failed") {
+    return (
+      <span className="inline-flex items-center gap-1 justify-end">
+        <span className="text-xs text-amber-600 font-medium">pending</span>
+        <span
+          className="text-[10px] leading-none text-amber-700 bg-amber-100 border border-amber-300 rounded-full w-4 h-4 inline-flex items-center justify-center"
+          title="The x402 payment completed, but CareGuard could not extract a Stellar transaction hash from the payment response."
+          aria-label="Transaction hash extraction failed"
+        >
+          !
+        </span>
+      </span>
+    );
+  }
+
   if (!hash) return <span className="text-xs text-slate-300">-</span>;
 
   let displayHash = hash;

--- a/dashboard/src/components/tabs/activity-tab.tsx
+++ b/dashboard/src/components/tabs/activity-tab.tsx
@@ -262,7 +262,7 @@ export function ActivityTab({
                         </span>
                       </td>
                       <td className="px-4 py-2 text-right">
-                        <TxLink hash={tx.stellarTxHash} />
+                        <TxLink hash={tx.stellarTxHash} status={tx.txHashStatus} />
                       </td>
                     </tr>
                   ))}

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -63,6 +63,7 @@ export const TransactionSchema = z.object({
   amount: z.number(),
   recipient: z.string(),
   stellarTxHash: z.string().optional(),
+  txHashStatus: z.enum(["extracted", "extraction_failed"]).optional(),
   mppOrderId: z.string().optional(),
   status: z.string(),
   category: z.string(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -62,6 +62,7 @@ export interface Transaction {
   amount: number;
   recipient: string;
   stellarTxHash?: string;
+  txHashStatus?: "extracted" | "extraction_failed";
   mppOrderId?: string;
   status: "pending" | "approved" | "completed" | "blocked" | "disputed";
   category: string;


### PR DESCRIPTION
## Summary
- Track x402 transaction hash extraction with explicit `txHashStatus` metadata
- Return an `extraction_failed` sentinel instead of silently storing an undefined hash
- Show a yellow dashboard warning state when a payment completed but no Stellar transaction hash could be extracted
- Log response headers/body context and increment an in-process `x402_tx_extraction_failed_total` counter

## Validation
- `npm ci --legacy-peer-deps`
- `npm test -- agent/__tests__/tools.test.ts`
- `git diff --check`

Note: full `npm run build` still fails on pre-existing repo-wide TypeScript issues unrelated to this patch, including pagination tests, agent/server.ts, Playwright types, root server.ts, and service imports.

Closes #191