### PR TITLE
Harden x402 startup error handling

### DIFF
--- a/docs/services/x402.md
+++ b/docs/services/x402.md
@@ -1,0 +1,12 @@
+# x402 Middleware Startup Handling
+
+CareGuard applies x402 payment middleware to protected service routes. During startup, the facilitator can be temporarily unreachable or unable to report supported payment kinds. Those startup failures should not crash the process because the middleware retries on protected requests.
+
+The unhandled rejection handler only swallows recoverable x402 startup failures when one of these signals is present:
+
+- `X402FacilitatorError` or `HTTPFacilitatorError` class name.
+- `UND_ERR_CONNECT_TIMEOUT` from the underlying fetch client.
+- Current known startup strings such as `no supported payment kinds` or `Failed to initialize`.
+- A narrow fallback for bazaar/facilitator startup messages until the x402 client exposes a stable error code.
+
+Other unhandled rejections are still logged as unexpected errors. This avoids the old broad `message.includes("bazaar")` check, which could hide unrelated failures that merely mentioned the word `bazaar`.

--- a/shared/__tests__/x402-middleware.test.ts
+++ b/shared/__tests__/x402-middleware.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isRecoverableX402StartupError } from "../x402-middleware.ts";
+
+describe("isRecoverableX402StartupError", () => {
+  it("matches stable x402 facilitator error class names", () => {
+    class X402FacilitatorError extends Error {
+      name = "X402FacilitatorError";
+    }
+
+    expect(isRecoverableX402StartupError(new X402FacilitatorError("service unavailable"))).toBe(true);
+  });
+
+  it("keeps the current bazaar startup fallback narrow and visible", () => {
+    const error = new Error("Failed to initialize bazaar facilitator supported payment kinds");
+
+    expect(error.message).toMatchInlineSnapshot(
+      `"Failed to initialize bazaar facilitator supported payment kinds"`,
+    );
+    expect(isRecoverableX402StartupError(error)).toBe(true);
+  });
+
+  it("does not swallow unrelated unhandled rejections", () => {
+    expect(isRecoverableX402StartupError(new Error("database migration failed"))).toBe(false);
+  });
+});

--- a/shared/x402-middleware.ts
+++ b/shared/x402-middleware.ts
@@ -16,6 +16,27 @@ import { ExactStellarScheme } from "@x402/stellar/exact/server";
 const DEFAULT_FACILITATOR_URL = "https://channels.openzeppelin.com/x402/testnet";
 const OZ_FACILITATOR_URL = process.env.X402_FACILITATOR_URL || DEFAULT_FACILITATOR_URL;
 
+export function isRecoverableX402StartupError(reason: any) {
+  const name = reason?.name || reason?.constructor?.name || "";
+  const msg = reason?.message || String(reason);
+
+  if (name === "X402FacilitatorError" || name === "HTTPFacilitatorError") {
+    return true;
+  }
+
+  if (reason?.cause?.code === "UND_ERR_CONNECT_TIMEOUT") {
+    return true;
+  }
+
+  return (
+    msg.includes("no supported payment kinds") ||
+    msg.includes("Failed to initialize") ||
+    // TODO(#190): replace this fallback once @x402 exposes a stable error code
+    // for bazaar/facilitator startup failures across all supported clients.
+    /bazaar facilitator|facilitator.*bazaar/i.test(msg)
+  );
+}
+
 export function applyX402Middleware(
   app: Application,
   routes: Record<string, { accepts: { scheme: string; network: string; payTo: string; price: string }; description: string }>,
@@ -75,12 +96,7 @@ export function applyX402Middleware(
 // when the x402 facilitator is temporarily unreachable on startup.
 process.on("unhandledRejection", (reason: any) => {
   const msg = reason?.message || String(reason);
-  if (
-    msg.includes("no supported payment kinds") ||
-    msg.includes("Failed to initialize") ||
-    reason?.cause?.code === "UND_ERR_CONNECT_TIMEOUT" ||
-    msg.includes("bazaar")
-  ) {
+  if (isRecoverableX402StartupError(reason)) {
     console.warn(`  ⚠ x402 startup: ${msg.slice(0, 120)}`);
     return;
   }


### PR DESCRIPTION
## Summary
- Replace the broad `message.includes("bazaar")` startup check with `isRecoverableX402StartupError`
- Prefer stable x402 facilitator error class names and timeout codes
- Keep a narrow bazaar/facilitator fallback with a TODO linked to this issue
- Add Vitest coverage with an inline snapshot for the current fallback string
- Document the startup handling behavior in `docs/services/x402.md`

## Validation
- `npm test -- shared/__tests__/x402-middleware.test.ts`
- `git diff --check`

Closes #190