### PR TITLE
fix: require canonical Stellar USDC issuer

### DIFF
--- a/agent/__tests__/tools.test.ts
+++ b/agent/__tests__/tools.test.ts
@@ -44,7 +44,7 @@ vi.mock("mppx/client", () => ({
 }));
 
 import { describe, it, expect, vi } from "vitest";
-import { payForMedication, payBill, checkSpendingPolicy } from "../tools.ts";
+import { payForMedication, payBill, checkSpendingPolicy, resolveUSDCIssuer, selectUSDCBalance } from "../tools.ts";
 
 describe("Amount Validation (Issue #249)", () => {
   it("should reject Infinity as payment amount", async () => {
@@ -114,5 +114,23 @@ describe("Spending Policy", () => {
   it("should allow valid amounts within policy", () => {
     const policy = checkSpendingPolicy(50, "medications");
     expect(policy.allowed).toBe(true);
+  });
+});
+
+describe("Canonical USDC issuer selection", () => {
+  it("selects the USDC balance with the configured issuer when multiple USDC assets exist", () => {
+    const balances = [
+      { asset_code: "USDC", asset_issuer: "GPHISHINGISSUER", balance: "9999.0000000" },
+      { asset_code: "EURC", asset_issuer: "GCANONICALISSUER", balance: "25.0000000" },
+      { asset_code: "USDC", asset_issuer: "GCANONICALISSUER", balance: "12.5000000" },
+    ];
+
+    expect(selectUSDCBalance(balances, "GCANONICALISSUER")?.balance).toBe("12.5000000");
+  });
+
+  it("rejects public-network boot without an explicit USDC issuer", () => {
+    expect(() => resolveUSDCIssuer({ STELLAR_NETWORK: "public" })).toThrow(
+      "USDC_ISSUER required when STELLAR_NETWORK=public",
+    );
   });
 });

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -26,6 +26,8 @@ import {
   setSpendingPolicy,
   getSpendingTracker,
   resetSpendingTracker,
+  resolveUSDCIssuer,
+  selectUSDCBalance,
   TOOL_DEFINITIONS,
 } from "./tools.ts";
 
@@ -33,6 +35,11 @@ const PORT = parseInt(process.env.AGENT_PORT || "3004");
 
 if (!process.env.LLM_API_KEY) throw new Error("LLM_API_KEY required in .env");
 if (!process.env.AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");
+if (process.env.STELLAR_NETWORK === "public" && !process.env.USDC_ISSUER) {
+  throw new Error("USDC_ISSUER required when STELLAR_NETWORK=public");
+}
+
+const USDC_ISSUER = resolveUSDCIssuer();
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL || "https://api.groq.com/openai/v1";
 const LLM_MODEL = process.env.LLM_MODEL || "llama-3.3-70b-versatile";
@@ -299,7 +306,7 @@ app.get("/agent/wallet", async (req, res) => {
   }
   try {
     const account = await horizonServer.loadAccount(address);
-    const usdc = account.balances.find((b: any) => b.asset_code === "USDC" && b.asset_issuer === process.env.USDC_ISSUER);
+    const usdc = selectUSDCBalance(account.balances as any[], USDC_ISSUER);
     const xlm = account.balances.find((b: any) => b.asset_type === "native");
     const data = {
       usdc: usdc ? parseFloat((usdc as any).balance).toFixed(2) : "0.00",
@@ -460,7 +467,7 @@ app.get("/agent/profile", (_req, res) => { res.json(DEFAULT_PROFILE); });
 async function verifyWallet() {
   try {
     const account = await horizonServer.loadAccount(agentKeypair.publicKey());
-    const usdcBalance = account.balances.find((b: any) => b.asset_code === "USDC" && b.asset_issuer === process.env.USDC_ISSUER);
+    const usdcBalance = selectUSDCBalance(account.balances as any[], USDC_ISSUER);
     if (!usdcBalance) {
       console.error(`\n❌ Agent wallet has no USDC trustline.`);
       console.error(`   Fund at https://faucet.circle.com (Stellar Testnet)`);

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -15,6 +15,7 @@ import { createEd25519Signer, ExactStellarScheme } from "@x402/stellar";
 import { Mppx } from "mppx/client";
 import { stellar as stellarCharge } from "@stellar/mpp/charge/client";
 import type { SpendingPolicy, Transaction } from "../shared/types.ts";
+import { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
 export { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
 
 // Environment
@@ -23,7 +24,31 @@ const PHARMACY_API = process.env.PHARMACY_API_URL || "http://localhost:3001";
 const BILL_AUDIT_API = process.env.BILL_AUDIT_API_URL || "http://localhost:3002";
 const DRUG_INTERACTION_API = process.env.DRUG_INTERACTION_API_URL || "http://localhost:3003";
 const PHARMACY_PAYMENT_API = process.env.PHARMACY_PAYMENT_API_URL || "http://localhost:3005";
-const USDC_ISSUER = process.env.USDC_ISSUER || "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+export const TESTNET_USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+export type StellarBalanceLine = {
+  asset_type?: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  balance?: string;
+};
+
+export function resolveUSDCIssuer(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.STELLAR_NETWORK === "public" && !env.USDC_ISSUER) {
+    throw new Error("USDC_ISSUER required when STELLAR_NETWORK=public");
+  }
+  return env.USDC_ISSUER || TESTNET_USDC_ISSUER;
+}
+
+export function isCanonicalUSDCBalance(balance: StellarBalanceLine, issuer = resolveUSDCIssuer()): boolean {
+  return balance.asset_code === "USDC" && balance.asset_issuer === issuer;
+}
+
+export function selectUSDCBalance(balances: StellarBalanceLine[], issuer = resolveUSDCIssuer()): StellarBalanceLine | undefined {
+  return balances.find((balance) => isCanonicalUSDCBalance(balance, issuer));
+}
+
+const USDC_ISSUER = resolveUSDCIssuer();
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 
 if (!AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");

--- a/docs/security/asset-spoofing.md
+++ b/docs/security/asset-spoofing.md
@@ -1,0 +1,26 @@
+# Stellar Asset Spoofing Guardrail
+
+CareGuard treats Stellar asset issuer identity as part of the payment safety boundary.
+
+On Stellar, `asset_code` is not globally unique. A malicious or mistaken issuer can create an asset that also uses the code `USDC`, so wallet balance checks must never trust `asset_code === "USDC"` on its own.
+
+## Required matching rule
+
+Any code that selects a USDC balance must match both fields:
+
+```ts
+asset_code === "USDC" && asset_issuer === USDC_ISSUER
+```
+
+The canonical issuer comes from `USDC_ISSUER`. Testnet may fall back to the repo's documented Circle testnet issuer, but production/public-network boot requires an explicit `USDC_ISSUER` value so deployment cannot silently trust a default.
+
+## Threat model
+
+If CareGuard matched only `asset_code`, a wallet holding both real Circle USDC and a spoofed `USDC` trustline could display or route against the wrong asset. That can lead to false balance checks, failed payments, or transfers using a non-canonical token.
+
+## Operational checklist
+
+- Set `USDC_ISSUER` in every deployment environment.
+- Treat missing `USDC_ISSUER` on `STELLAR_NETWORK=public` as a startup failure.
+- Keep tests that include at least two `USDC` balance entries with different issuers.
+- When adding new Stellar payment paths, reuse the shared USDC issuer-selection helper instead of open-coding `asset_code` checks.

--- a/server.ts
+++ b/server.ts
@@ -50,6 +50,8 @@ import {
   setSpendingPolicy,
   getSpendingTracker,
   resetSpendingTracker,
+  resolveUSDCIssuer,
+  selectUSDCBalance,
   TOOL_DEFINITIONS,
 } from "./agent/tools.ts";
 
@@ -68,6 +70,7 @@ const envSchema = z.object({
   LLM_MODEL: z.string().min(1).optional(),
   OZ_FACILITATOR_API_KEY: z.string().min(1).optional(),
   X402_FACILITATOR_URL: z.string().min(1).optional(),
+  USDC_ISSUER: z.string().min(1).optional(),
 });
 
 const env = envSchema.safeParse(process.env);
@@ -87,6 +90,13 @@ if (env.data.STELLAR_NETWORK === "public" && !env.data.OZ_FACILITATOR_API_KEY) {
   process.exit(1);
 }
 
+if (env.data.STELLAR_NETWORK === "public" && !env.data.USDC_ISSUER) {
+  console.error(
+    "Missing/invalid env: USDC_ISSUER — required when STELLAR_NETWORK=public",
+  );
+  process.exit(1);
+}
+
 if (env.data.STELLAR_NETWORK !== "public" && !env.data.OZ_FACILITATOR_API_KEY) {
   console.warn(
     "  ⚠ OZ_FACILITATOR_API_KEY not set — x402 routes will fail until configured",
@@ -96,6 +106,7 @@ if (env.data.STELLAR_NETWORK !== "public" && !env.data.OZ_FACILITATOR_API_KEY) {
 const PORT = env.data.PORT;
 const LLM_BASE_URL = env.data.LLM_BASE_URL || "https://api.groq.com/openai/v1";
 const LLM_MODEL = env.data.LLM_MODEL || "llama-3.3-70b-versatile";
+const USDC_ISSUER = resolveUSDCIssuer(env.data as unknown as NodeJS.ProcessEnv);
 const NETWORK = (
   env.data.STELLAR_NETWORK === "public" ? "stellar:public" : "stellar:testnet"
 ) as `${string}:${string}`;
@@ -1088,7 +1099,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     console.log(`   Wallet: ${agentKeypair.publicKey()}`);
     try {
       const acc = await horizonServer.loadAccount(agentKeypair.publicKey());
-      const usdc = acc.balances.find((b: any) => b.asset_code === "USDC");
+      const usdc = selectUSDCBalance(acc.balances as any[], USDC_ISSUER);
       console.log(`   USDC: ${usdc?.balance || "0"}`);
     } catch {
       console.log("   USDC: unable to check");


### PR DESCRIPTION
## Summary

Fixes #198 by making Stellar USDC balance selection issuer-aware instead of matching only `asset_code === "USDC"`.

## Changes

- Adds shared `resolveUSDCIssuer`, `isCanonicalUSDCBalance`, and `selectUSDCBalance` helpers.
- Keeps the existing Circle testnet USDC issuer fallback for non-public/testnet usage.
- Fails production/public-network boot when `USDC_ISSUER` is missing.
- Uses the shared issuer-aware selector in wallet/profile/startup balance reads.
- Adds Vitest coverage for multiple `USDC` balances with different issuers.
- Documents the Stellar asset-spoofing threat model in `docs/security/asset-spoofing.md`.

## Verification

- `npm test -- --run agent/__tests__/tools.test.ts` — passed, 13 tests.
- `git diff --check` — passed (line-ending warnings only).
- `npm run build` — still fails on existing unrelated repo-wide TypeScript issues in pagination tests, `agent/server.ts` app/saveSpending/rejected-status types, missing Playwright types, `server.ts` existing `cors`/network type issues, and shared x402 middleware `NETWORK` exports. The USDC issuer helper errors from this patch are clean after the follow-up import/cast fix.

No private keys, live Horizon payments, wallet signatures, or transfers were used.
