### PR TITLE
fix: constrain policy number inputs

### DIFF
--- a/dashboard/src/__tests__/policy-schema.test.ts
+++ b/dashboard/src/__tests__/policy-schema.test.ts
@@ -22,17 +22,22 @@ describe("validatePolicy", () => {
     expect(r.errors.find((e) => e.field === "dailyLimit")).toBeDefined();
   });
 
-  it("accepts zero values", () => {
+  it("rejects zero values", () => {
     const r = validatePolicy({ ...valid, monthlyLimit: 0 });
-    expect(r.isValid).toBe(true);
-  });
-
-  it("rejects values over 10000", () => {
-    const r = validatePolicy({ ...valid, monthlyLimit: 10001 });
     expect(r.isValid).toBe(false);
     expect(
       r.errors.some(
-        (e) => e.field === "monthlyLimit" && /10000/.test(e.message),
+        (e) => e.field === "monthlyLimit" && /greater than 0/.test(e.message),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects values over 50000", () => {
+    const r = validatePolicy({ ...valid, monthlyLimit: 50001 });
+    expect(r.isValid).toBe(false);
+    expect(
+      r.errors.some(
+        (e) => e.field === "monthlyLimit" && /50000/.test(e.message),
       ),
     ).toBe(true);
   });

--- a/dashboard/src/__tests__/policy-tab.test.tsx
+++ b/dashboard/src/__tests__/policy-tab.test.tsx
@@ -11,8 +11,8 @@
  *  5. Negative value rejected client-side (validatePolicy via form validation)
  */
 
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { PolicyTab } from "../components/tabs/policy-tab";
 import type { PolicyTabProps } from "../components/tabs/policy-tab";
 
@@ -48,6 +48,16 @@ describe("PolicyTab — rendering (Issue #47)", () => {
     expect(screen.getByLabelText(/Medication Monthly Budget/i)).toBeTruthy();
     expect(screen.getByLabelText(/Bill Monthly Budget/i)).toBeTruthy();
     expect(screen.getByLabelText(/Caregiver Approval Threshold/i)).toBeTruthy();
+  });
+
+  it("renders policy inputs with the requested numeric constraints", () => {
+    render(<PolicyTab {...buildProps()} />);
+
+    for (const input of screen.getAllByRole("spinbutton") as HTMLInputElement[]) {
+      expect(input.min).toBe("1");
+      expect(input.max).toBe("50000");
+      expect(input.step).toBe("1");
+    }
   });
 
   it("populates fields with values from spending.policy (the policyForm prop)", () => {
@@ -196,11 +206,7 @@ describe("PolicyTab — negative value rejected client-side (Issue #47)", () => 
     const submitBtn = screen.getByRole("button", { name: /Update Policy/i }) as HTMLButtonElement;
     expect(submitBtn.disabled).toBe(true);
 
-    // An error message must be visible
-    await waitFor(() => {
-      const errorEl = document.querySelector("[aria-invalid='true']");
-      expect(errorEl).not.toBeNull();
-    });
+    expect(await screen.findByText(/must be greater than 0/i)).toBeTruthy();
   });
 
   it("'Update Policy' button is enabled for a fully valid policy", () => {
@@ -218,7 +224,7 @@ describe("PolicyTab — negative value rejected client-side (Issue #47)", () => 
 
 describe("PolicyTab — policySaved prop drives button appearance (Issue #47)", () => {
   it("shows 'Policy Saved' (green) when policySaved is true", () => {
-    const { container } = render(<PolicyTab {...buildProps({ policySaved: true })} />);
+    render(<PolicyTab {...buildProps({ policySaved: true })} />);
     const btn = screen.getByRole("button", { name: /Policy Saved/i });
     expect(btn).toBeTruthy();
     // The button should have the green background class
@@ -226,7 +232,7 @@ describe("PolicyTab — policySaved prop drives button appearance (Issue #47)", 
   });
 
   it("shows 'Update Policy' (blue) when policySaved is false", () => {
-    const { container } = render(<PolicyTab {...buildProps({ policySaved: false })} />);
+    render(<PolicyTab {...buildProps({ policySaved: false })} />);
     const btn = screen.getByRole("button", { name: /Update Policy/i });
     expect(btn).toBeTruthy();
     expect(btn.className).toContain("bg-sky-500");

--- a/dashboard/src/components/primitives/card.tsx
+++ b/dashboard/src/components/primitives/card.tsx
@@ -2,7 +2,7 @@ export interface CardProps {
   label: string;
   value: string;
   sub: string;
-  color: "sky" | "green" | "amber" | "slate";
+  color: "sky" | "green" | "amber" | "slate" | "purple";
 }
 
 const COLORS: Record<CardProps["color"], string> = {
@@ -10,6 +10,7 @@ const COLORS: Record<CardProps["color"], string> = {
   green: "border-green-200 bg-green-50",
   amber: "border-amber-200 bg-amber-50",
   slate: "border-slate-200 bg-white",
+  purple: "border-purple-200 bg-purple-50",
 };
 
 export function Card({ label, value, sub, color }: CardProps) {

--- a/dashboard/src/components/tabs/policy-tab.tsx
+++ b/dashboard/src/components/tabs/policy-tab.tsx
@@ -3,6 +3,9 @@
 import { useMemo, useState } from "react";
 import type { RecipientProfile } from "../../lib/types";
 import {
+  POLICY_AMOUNT_MAX,
+  POLICY_AMOUNT_MIN,
+  POLICY_AMOUNT_STEP,
   validatePolicy,
   type PolicyFieldError,
   type SpendingPolicyInput,
@@ -96,9 +99,9 @@ export function PolicyTab({
                 id={inputId}
                 type="number"
                 inputMode="decimal"
-                min="0"
-                max="10000"
-                step="0.01"
+                min={POLICY_AMOUNT_MIN}
+                max={POLICY_AMOUNT_MAX}
+                step={POLICY_AMOUNT_STEP}
                 value={Number.isFinite(policyForm[key]) ? policyForm[key] : ""}
                 aria-invalid={Boolean(errMsg)}
                 aria-describedby={errMsg || warnMsg ? errorId : undefined}

--- a/dashboard/src/lib/schemas.ts
+++ b/dashboard/src/lib/schemas.ts
@@ -21,6 +21,10 @@ export type PolicyValidation = {
   isValid: boolean;
 };
 
+export const POLICY_AMOUNT_MIN = 1;
+export const POLICY_AMOUNT_MAX = 50000;
+export const POLICY_AMOUNT_STEP = 1;
+
 const FIELD_LABEL: Record<keyof SpendingPolicyInput, string> = {
   dailyLimit: "Daily limit",
   monthlyLimit: "Monthly limit",
@@ -55,10 +59,10 @@ export function validatePolicy(input: unknown): PolicyValidation {
   for (const f of fields) {
     if (!Number.isFinite(v[f])) {
       errors.push({ field: f, message: `${FIELD_LABEL[f]} must be a finite number` });
-    } else if (v[f] < 0) {
-      errors.push({ field: f, message: `${FIELD_LABEL[f]} cannot be negative` });
-    } else if (v[f] > 10000) {
-      errors.push({ field: f, message: `${FIELD_LABEL[f]} cannot exceed 10000` });
+    } else if (v[f] < POLICY_AMOUNT_MIN) {
+      errors.push({ field: f, message: `${FIELD_LABEL[f]} must be greater than 0` });
+    } else if (v[f] > POLICY_AMOUNT_MAX) {
+      errors.push({ field: f, message: `${FIELD_LABEL[f]} cannot exceed ${POLICY_AMOUNT_MAX}` });
     }
   }
 

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/dashboard/tests/e2e/policy-validation.spec.ts
+++ b/dashboard/tests/e2e/policy-validation.spec.ts
@@ -16,10 +16,10 @@ test("Policy form blocks negative values and disables Update Policy", async ({ p
   await page.goto("/?tab=policy");
 
   const dailyLimit = page.locator("#policy-dailyLimit");
-  await dailyLimit.fill("-1");
+  await dailyLimit.fill("-100");
   await dailyLimit.blur();
 
-  await expect(page.getByText(/cannot be negative/i)).toBeVisible();
+  await expect(page.getByText(/must be greater than 0/i)).toBeVisible();
 
   const updateButton = page.getByRole("button", { name: "Update Policy" });
   await expect(updateButton).toBeDisabled();


### PR DESCRIPTION
Closes #211

## Summary
Constrain policy number inputs with `min={1}`, `max={50000}`, and `step={1}`, add validation and inline errors for invalid low values, extend unit and Playwright coverage, and include the missing dashboard `cn` utility/card color type needed for the dashboard build.

## Verification
- `npx vitest run dashboard/src/__tests__/policy-schema.test.ts dashboard/src/__tests__/policy-tab.test.tsx`
- `npx eslint src/lib/schemas.ts src/components/tabs/policy-tab.tsx src/__tests__/policy-schema.test.ts src/__tests__/policy-tab.test.tsx tests/e2e/policy-validation.spec.ts src/lib/utils.ts src/components/primitives/card.tsx`
- `npm run build` in `dashboard/`
- `npx playwright test tests/e2e/policy-validation.spec.ts --project=chromium` in `dashboard/`

Happy to address any review feedback.