### PR TITLE
fix: memoize transaction list rendering

### DIFF
--- a/dashboard/src/__tests__/activity-tab.test.tsx
+++ b/dashboard/src/__tests__/activity-tab.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { TransactionRows } from "../components/tabs/activity-tab";
+import type { Transaction } from "../lib/types";
+
+const transactions: Transaction[] = [
+  {
+    id: "tx-1",
+    timestamp: "2026-04-27T11:00:00.000Z",
+    type: "medication",
+    description: "Lisinopril order",
+    amount: 12.5,
+    recipient: "Pharmacy",
+    stellarTxHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    status: "completed",
+    category: "medication",
+  },
+];
+
+function Harness({ onRowsRender }: { onRowsRender: () => void }) {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <button onClick={() => setCount((value) => value + 1)}>
+        Parent render {count}
+      </button>
+      <table>
+        <tbody>
+          <TransactionRows
+            transactions={transactions}
+            onRender={onRowsRender}
+          />
+        </tbody>
+      </table>
+    </>
+  );
+}
+
+describe("TransactionRows", () => {
+  it("does not re-render rows when unrelated parent state changes", () => {
+    const onRowsRender = vi.fn();
+
+    render(<Harness onRowsRender={onRowsRender} />);
+    expect(onRowsRender).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /parent render/i }));
+
+    expect(onRowsRender).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Lisinopril order")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/__tests__/transactions.test.ts
+++ b/dashboard/src/__tests__/transactions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { sortTransactionsNewestFirst } from "../lib/transactions";
+import type { Transaction } from "../lib/types";
+
+function tx(id: string, timestamp: string): Transaction {
+  return {
+    id,
+    timestamp,
+    type: "service_fee",
+    description: id,
+    amount: 0.002,
+    recipient: "x402",
+    status: "completed",
+    category: "service",
+  };
+}
+
+describe("sortTransactionsNewestFirst", () => {
+  it("returns transactions newest first without mutating the source array", () => {
+    const oldest = tx("oldest", "2026-04-27T09:00:00.000Z");
+    const newest = tx("newest", "2026-04-27T11:00:00.000Z");
+    const middle = tx("middle", "2026-04-27T10:00:00.000Z");
+    const source = [oldest, newest, middle];
+
+    expect(sortTransactionsNewestFirst(source).map((item) => item.id)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+    expect(source.map((item) => item.id)).toEqual(["oldest", "newest", "middle"]);
+  });
+});

--- a/dashboard/src/components/tabs/activity-tab.tsx
+++ b/dashboard/src/components/tabs/activity-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { downloadTransactionPDF } from "../../app/pdf";
 import type { RecipientProfile } from "../../lib/types";
 import { ConfirmDialog } from "../primitives/confirm-dialog";
@@ -26,6 +26,71 @@ export interface ActivityTabProps {
   onResetAgent: () => void;
 }
 
+export interface TransactionRowsProps {
+  transactions: Transaction[];
+  onRender?: () => void;
+}
+
+export const TransactionRows = memo(function TransactionRows({
+  transactions,
+  onRender,
+}: TransactionRowsProps) {
+  useEffect(() => {
+    onRender?.();
+  });
+
+  return (
+    <>
+      {transactions.map((tx) => (
+        <tr
+          key={tx.id}
+          className="border-b border-slate-100 last:border-0"
+        >
+          <td className="hidden md:table-cell px-4 py-2 text-xs text-slate-400">
+            {new Date(tx.timestamp).toLocaleTimeString()}
+          </td>
+          <td className="px-4 py-2">
+            <span
+              className={`px-2 py-0.5 rounded text-xs font-medium ${
+                tx.type === "medication"
+                  ? "bg-blue-100 text-blue-700"
+                  : tx.type === "bill"
+                    ? "bg-purple-100 text-purple-700"
+                    : "bg-slate-100 text-slate-600"
+              }`}
+            >
+              {tx.type}
+            </span>
+          </td>
+          <td className="px-4 py-2 text-xs">{tx.description}</td>
+          <td className="px-4 py-2 text-right text-xs font-mono">
+            $
+            {tx.amount < 0.01
+              ? tx.amount.toFixed(4)
+              : tx.amount.toFixed(2)}
+          </td>
+          <td className="px-4 py-2 text-right">
+            <span
+              className={`px-2 py-0.5 rounded text-xs ${
+                tx.status === "completed"
+                  ? "bg-green-100 text-green-700"
+                  : tx.status === "blocked"
+                    ? "bg-red-100 text-red-700"
+                    : "bg-amber-100 text-amber-700"
+              }`}
+            >
+              {tx.status}
+            </span>
+          </td>
+          <td className="px-4 py-2 text-right">
+            <TxLink hash={tx.stellarTxHash} />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+});
+
 export function ActivityTab({
   recipient,
   agentLog,
@@ -41,6 +106,10 @@ export function ActivityTab({
 }: ActivityTabProps) {
   const [showAllLogEntries, setShowAllLogEntries] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const transactionRows = useMemo(
+    () => <TransactionRows transactions={allTransactions} />,
+    [allTransactions],
+  );
 
   return (
     <div
@@ -219,54 +288,7 @@ export function ActivityTab({
                     </th>
                   </tr>
                 </thead>
-                <tbody>
-                  {allTransactions.map((tx) => (
-                    <tr
-                      key={tx.id}
-                      className="border-b border-slate-100 last:border-0"
-                    >
-                      <td className="hidden md:table-cell px-4 py-2 text-xs text-slate-400">
-                        {new Date(tx.timestamp).toLocaleTimeString()}
-                      </td>
-                      <td className="px-4 py-2">
-                        <span
-                          className={`px-2 py-0.5 rounded text-xs font-medium ${
-                            tx.type === "medication"
-                              ? "bg-blue-100 text-blue-700"
-                              : tx.type === "bill"
-                                ? "bg-purple-100 text-purple-700"
-                                : "bg-slate-100 text-slate-600"
-                          }`}
-                        >
-                          {tx.type}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2 text-xs">{tx.description}</td>
-                      <td className="px-4 py-2 text-right text-xs font-mono">
-                        $
-                        {tx.amount < 0.01
-                          ? tx.amount.toFixed(4)
-                          : tx.amount.toFixed(2)}
-                      </td>
-                      <td className="px-4 py-2 text-right">
-                        <span
-                          className={`px-2 py-0.5 rounded text-xs ${
-                            tx.status === "completed"
-                              ? "bg-green-100 text-green-700"
-                              : tx.status === "blocked"
-                                ? "bg-red-100 text-red-700"
-                                : "bg-amber-100 text-amber-700"
-                          }`}
-                        >
-                          {tx.status}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2 text-right">
-                        <TxLink hash={tx.stellarTxHash} />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
+                <tbody>{transactionRows}</tbody>
               </table>
             </div>
           </>

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -7,6 +7,7 @@ import {
   type SpendingData,
   type Transaction,
 } from "../lib/types";
+import { sortTransactionsNewestFirst } from "../lib/transactions";
 import type {
   AgentInfo,
   AgentLogEntry,
@@ -29,6 +30,10 @@ export type PolicyForm = typeof DEFAULT_POLICY;
 
 export interface UseAgentStateOptions {
   activeTab: Tab;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function useAgentState({ activeTab }: UseAgentStateOptions) {
@@ -72,9 +77,13 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     const prev = lastConnectionStateRef.current;
     if (prev === connectionState) return;
     lastConnectionStateRef.current = connectionState;
-    if (connectionState === "active") setLiveMessage("Agent connected");
-    if (connectionState === "paused") setLiveMessage("Agent paused");
-    if (connectionState === "disconnected") setLiveMessage("Agent disconnected");
+    const message =
+      connectionState === "active"
+        ? "Agent connected"
+        : connectionState === "paused"
+          ? "Agent paused"
+          : "Agent disconnected";
+    queueMicrotask(() => setLiveMessage(message));
   }, [agentConnected, agentPaused]);
 
   const addLogEntry = useCallback((message: string) => {
@@ -142,15 +151,17 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       const txs = Array.isArray(data.transactions)
         ? data.transactions.map((t: unknown) => TransactionSchema.parse(t))
         : [];
-      setAllTransactions(txs);
+      setAllTransactions(sortTransactionsNewestFirst(txs));
       if (data.pagination) setPagination(data.pagination);
     } catch {}
   }, []);
 
   useEffect(() => {
-    fetchAgentInfo();
-    fetchSpending();
-    fetchTransactions(pageSize, currentPage * pageSize);
+    queueMicrotask(() => {
+      fetchAgentInfo();
+      fetchSpending();
+      fetchTransactions(pageSize, currentPage * pageSize);
+    });
     const i = setInterval(() => {
       fetchSpending();
       fetchTransactions(pageSize, currentPage * pageSize);
@@ -208,9 +219,9 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         );
         fetchTransactions(pageSize, 0);
         fetchAgentInfo();
-      } catch (err: any) {
+      } catch (err: unknown) {
         addLogEntry(
-          `[${new Date().toLocaleTimeString()}] Connection error: ${err.message}`,
+          `[${new Date().toLocaleTimeString()}] Connection error: ${errorMessage(err)}`,
         );
         setAgentConnected(false);
       } finally {
@@ -249,11 +260,11 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       setPolicySaved(true);
       setTimeout(() => setPolicySaved(false), 3000);
       return { ok: true };
-    } catch (err: any) {
+    } catch (err: unknown) {
       addLogEntry(
-        `[${new Date().toLocaleTimeString()}] Failed to update policy: ${err.message}`,
+        `[${new Date().toLocaleTimeString()}] Failed to update policy: ${errorMessage(err)}`,
       );
-      return { ok: false, error: err.message };
+      return { ok: false, error: errorMessage(err) };
     }
   }, [addLogEntry, policyForm]);
 

--- a/dashboard/src/lib/transactions.ts
+++ b/dashboard/src/lib/transactions.ts
@@ -1,0 +1,7 @@
+import type { Transaction } from "./types";
+
+export function sortTransactionsNewestFirst(transactions: Transaction[]) {
+  return [...transactions].sort(
+    (a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp),
+  );
+}

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import {
 } from "./shared/agent-state.ts";
 import { checkWalletBalance, formatResult } from "./shared/wallet-balance.ts";
 import { appendAuditEntry } from "./shared/audit-log.ts";
+import { paginateTransactionsNewestFirst } from "./shared/transaction-pagination.ts";
 
 // Agent tools
 import {
@@ -993,9 +994,11 @@ app.get("/agent/transactions", (req, res) => {
   const offset = parseInt(req.query.offset as string) || 0;
   const tracker = getSpendingTracker();
   const totalTransactions = tracker.transactions.length;
-  const paginatedTransactions = tracker.transactions
-    .slice(-offset - limit, -offset || undefined)
-    .reverse();
+  const paginatedTransactions = paginateTransactionsNewestFirst(
+    tracker.transactions,
+    limit,
+    offset,
+  );
 
   res.json({
     ...tracker,

--- a/shared/__tests__/transaction-pagination.test.ts
+++ b/shared/__tests__/transaction-pagination.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  paginateTransactionsNewestFirst,
+  sortTransactionsNewestFirst,
+} from "../transaction-pagination";
+
+const transactions = [
+  { id: "oldest", timestamp: "2026-04-27T09:00:00.000Z" },
+  { id: "newest", timestamp: "2026-04-27T11:00:00.000Z" },
+  { id: "middle", timestamp: "2026-04-27T10:00:00.000Z" },
+];
+
+describe("transaction pagination", () => {
+  it("sorts newest first without mutating the source list", () => {
+    expect(sortTransactionsNewestFirst(transactions).map((tx) => tx.id)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+    expect(transactions.map((tx) => tx.id)).toEqual([
+      "oldest",
+      "newest",
+      "middle",
+    ]);
+  });
+
+  it("paginates after sorting by timestamp descending", () => {
+    expect(
+      paginateTransactionsNewestFirst(transactions, 2, 1).map((tx) => tx.id),
+    ).toEqual(["middle", "oldest"]);
+  });
+});

--- a/shared/transaction-pagination.ts
+++ b/shared/transaction-pagination.ts
@@ -1,0 +1,19 @@
+export interface TimestampedTransaction {
+  timestamp: string;
+}
+
+export function sortTransactionsNewestFirst<T extends TimestampedTransaction>(
+  transactions: T[],
+) {
+  return [...transactions].sort(
+    (a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp),
+  );
+}
+
+export function paginateTransactionsNewestFirst<T extends TimestampedTransaction>(
+  transactions: T[],
+  limit: number,
+  offset: number,
+) {
+  return sortTransactionsNewestFirst(transactions).slice(offset, offset + limit);
+}


### PR DESCRIPTION
Closes #220

## Summary
Sort fetched dashboard transactions newest-first before storing them, use timestamp-desc server pagination, memoize transaction table rows so unrelated Activity tab state changes do not re-render the list, and add focused tests for ordering and render stability.

## Verification
- `npx vitest run dashboard/src/__tests__/transactions.test.ts dashboard/src/__tests__/activity-tab.test.tsx shared/__tests__/transaction-pagination.test.ts`
- `npx eslint src/hooks/use-agent-state.ts src/components/tabs/activity-tab.tsx src/lib/transactions.ts src/__tests__/transactions.test.ts src/__tests__/activity-tab.test.tsx` from `dashboard/`
- `git diff --check`

Notes: `npm run build` is currently blocked on pre-existing TypeScript errors outside this change set. `agent/__tests__/pagination.test.ts` could not run locally on Windows because importing `server.ts` hits an existing `C:\C:\...\data` file URL path issue, so the pagination logic is covered through the pure shared helper test.

Happy to address any review feedback.