### PR TITLE
Handle PDF download generation failures

### DIFF
--- a/dashboard/src/__tests__/pdf-download-errors.test.tsx
+++ b/dashboard/src/__tests__/pdf-download-errors.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ActivityTab } from "../components/tabs/activity-tab";
+import { BillsTab } from "../components/tabs/bills-tab";
+import { MedicationsTab } from "../components/tabs/medications-tab";
+
+vi.mock("jspdf", () => ({
+  default: vi.fn(() => {
+    throw new Error("jsPDF load failed");
+  }),
+}));
+
+vi.mock("jspdf-autotable", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: vi.fn(() => ({
+    getVirtualItems: () => [{ index: 0, size: 80, start: 0 }],
+    getTotalSize: () => 80,
+  })),
+}));
+
+const recipient = { name: "Rosa Garcia", age: 78 };
+
+const spending = {
+  policy: {
+    dailyLimit: 100,
+    monthlyLimit: 500,
+    medicationMonthlyBudget: 300,
+    billMonthlyBudget: 500,
+    approvalThreshold: 75,
+  },
+  spending: {
+    medications: 10,
+    bills: 20,
+    serviceFees: 0.01,
+    total: 30.01,
+  },
+  budgetRemaining: {
+    medications: 290,
+    bills: 480,
+  },
+  transactionCount: 1,
+  recentTransactions: [],
+};
+
+function expectPdfFailureToast() {
+  const toast = screen.getByRole("status");
+  expect(toast).toHaveTextContent("Couldn't generate PDF — try again");
+  expect(toast).toHaveTextContent(/Request ID: pdf-/);
+}
+
+describe("PDF download error handling", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a request-id toast when medication PDF generation fails", () => {
+    render(
+      <MedicationsTab
+        recipient={recipient}
+        agentResult={{
+          response: "",
+          spending,
+          toolCalls: [
+            {
+              tool: "compare_pharmacy_prices",
+              input: {},
+              result: {
+                drug: "Lisinopril",
+                prices: [{ pharmacyName: "Pharmacy A", price: 12 }],
+                cheapest: { pharmacyName: "Pharmacy A", price: 12 },
+                mostExpensive: { pharmacyName: "Pharmacy B", price: 24 },
+                potentialSavings: 12,
+                savingsPercent: 50,
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+    expectPdfFailureToast();
+  });
+
+  it("shows a request-id toast when bill PDF generation fails", () => {
+    render(
+      <BillsTab
+        recipient={recipient}
+        agentResult={{
+          response: "",
+          spending,
+          toolCalls: [
+            {
+              tool: "audit_medical_bill",
+              input: {},
+              result: {
+                totalCharged: 200,
+                totalCorrect: 150,
+                totalOvercharge: 50,
+                errorCount: 1,
+                lineItems: [
+                  {
+                    description: "Duplicate line item",
+                    quantity: 1,
+                    chargedAmount: 200,
+                    status: "duplicate",
+                    suggestedAmount: 150,
+                    errorDescription: "Duplicate charge",
+                  },
+                ],
+                recommendation: "Ask billing to correct the duplicate charge.",
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download PDF" }));
+
+    expectPdfFailureToast();
+  });
+
+  it("shows a request-id toast when transaction PDF generation fails", () => {
+    render(
+      <ActivityTab
+        recipient={recipient}
+        agentLog={[]}
+        setAgentLog={vi.fn()}
+        allTransactions={[
+          {
+            id: "tx-1",
+            timestamp: "2026-05-22T06:00:00.000Z",
+            type: "bill",
+            description: "Hospital bill payment",
+            amount: 20,
+            recipient: "Rosa Garcia",
+            status: "completed",
+            category: "bills",
+          },
+        ]}
+        pagination={null}
+        currentPage={0}
+        setCurrentPage={vi.fn()}
+        pageSize={10}
+        setPageSize={vi.fn()}
+        spending={spending}
+        onResetAgent={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download Report" }));
+
+    expectPdfFailureToast();
+  });
+});

--- a/dashboard/src/components/tabs/activity-tab.tsx
+++ b/dashboard/src/components/tabs/activity-tab.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from "react";
 import { downloadTransactionPDF } from "../../app/pdf";
+import { reportPdfDownloadFailure } from "../../lib/pdf-download-error";
 import type { RecipientProfile } from "../../lib/types";
 import { ConfirmDialog } from "../primitives/confirm-dialog";
+import { Toast } from "../primitives/toast";
 import { TxLink } from "../primitives/tx-link";
 import type {
   AgentLogEntry,
@@ -41,6 +43,7 @@ export function ActivityTab({
 }: ActivityTabProps) {
   const [showAllLogEntries, setShowAllLogEntries] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [toastMsg, setToastMsg] = useState<string | null>(null);
 
   return (
     <div
@@ -50,6 +53,7 @@ export function ActivityTab({
       tabIndex={0}
       className="space-y-4"
     >
+      <Toast message={toastMsg} onDismiss={() => setToastMsg(null)} />
       <ConfirmDialog
         open={confirmOpen}
         title="Reset all agent data?"
@@ -70,9 +74,13 @@ export function ActivityTab({
         <div className="flex items-center gap-3">
           {allTransactions.length > 0 && (
             <button
-              onClick={() =>
-                downloadTransactionPDF(allTransactions, spending, { recipient })
-              }
+              onClick={() => {
+                try {
+                  downloadTransactionPDF(allTransactions, spending, { recipient });
+                } catch (error) {
+                  setToastMsg(reportPdfDownloadFailure(error));
+                }
+              }}
               className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
             >
               Download Report

--- a/dashboard/src/components/tabs/bills-tab.tsx
+++ b/dashboard/src/components/tabs/bills-tab.tsx
@@ -6,7 +6,9 @@ import {
   BillAuditResultSchema,
   type RecipientProfile,
 } from "../../lib/types";
+import { reportPdfDownloadFailure } from "../../lib/pdf-download-error";
 import { BillLineItemsVirtualized } from "../primitives/bill-line-items-virtualized";
+import { Toast } from "../primitives/toast";
 import type { AgentResult } from "../types";
 
 export interface BillsTabProps {
@@ -16,6 +18,7 @@ export interface BillsTabProps {
 
 export function BillsTab({ agentResult, recipient }: BillsTabProps) {
   const [showErrorsOnly, setShowErrorsOnly] = useState(false);
+  const [toastMsg, setToastMsg] = useState<string | null>(null);
 
   const auditCalls = agentResult?.toolCalls.filter(
     (t) =>
@@ -30,78 +33,89 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
       tabIndex={0}
       className="space-y-6"
     >
+      <Toast message={toastMsg} onDismiss={() => setToastMsg(null)} />
       {auditCalls && auditCalls.length > 0 ? (
-        auditCalls.map((t, i) => (
-          <div
-            key={i}
-            className="bg-white rounded-xl border border-slate-200 p-6"
-          >
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-sm font-semibold text-slate-700">
-                Bill Audit Results
-              </h2>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() =>
-                    downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), {
-                      errorsOnly: showErrorsOnly,
-                      recipient,
-                    })
-                  }
-                  className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
-                >
-                  Download PDF
-                </button>
-                <span
-                  className={`px-3 py-1 rounded-full text-xs font-medium ${
-                    t.result.errorCount > 0
-                      ? "bg-red-100 text-red-700"
-                      : "bg-green-100 text-green-700"
-                  }`}
-                >
-                  {t.result.errorCount} errors found
+        auditCalls.map((t, i) => {
+          const auditResult = BillAuditResultSchema.parse(t.result);
+
+          return (
+            <div
+              key={i}
+              className="bg-white rounded-xl border border-slate-200 p-6"
+            >
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-sm font-semibold text-slate-700">
+                  Bill Audit Results
+                </h2>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => {
+                      try {
+                        downloadBillAuditPDF(auditResult, {
+                          errorsOnly: showErrorsOnly,
+                          recipient,
+                        });
+                      } catch (error) {
+                        setToastMsg(reportPdfDownloadFailure(error));
+                      }
+                    }}
+                    className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
+                  >
+                    Download PDF
+                  </button>
+                  <span
+                    className={`px-3 py-1 rounded-full text-xs font-medium ${
+                      auditResult.errorCount > 0
+                        ? "bg-red-100 text-red-700"
+                        : "bg-green-100 text-green-700"
+                    }`}
+                  >
+                    {auditResult.errorCount} errors found
+                  </span>
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-4 mb-4">
+                <div className="bg-slate-50 rounded-lg p-3 text-center">
+                  <div className="text-lg font-bold">
+                    ${auditResult.totalCharged}
+                  </div>
+                  <div className="text-xs text-slate-500">Total Charged</div>
+                </div>
+                <div className="bg-red-50 rounded-lg p-3 text-center">
+                  <div className="text-lg font-bold text-red-600">
+                    ${auditResult.totalOvercharge}
+                  </div>
+                  <div className="text-xs text-slate-500">Overcharges</div>
+                </div>
+                <div className="bg-green-50 rounded-lg p-3 text-center">
+                  <div className="text-lg font-bold text-green-600">
+                    ${auditResult.totalCorrect}
+                  </div>
+                  <div className="text-xs text-slate-500">Correct Amount</div>
+                </div>
+              </div>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs text-slate-500">
+                  {auditResult.lineItems.length} line items
                 </span>
+                <button
+                  onClick={() => setShowErrorsOnly(!showErrorsOnly)}
+                  className="text-xs text-sky-600 hover:text-sky-800 cursor-pointer"
+                >
+                  {showErrorsOnly ? "Show all items" : "Show errors only"}
+                </button>
               </div>
+              <BillLineItemsVirtualized
+                lineItems={auditResult.lineItems.filter(
+                  (item) => !showErrorsOnly || item.status !== "valid",
+                )}
+              />
+              <p className="mt-4 text-sm font-medium text-slate-700">
+                {auditResult.recommendation}
+              </p>
             </div>
-            <div className="grid grid-cols-3 gap-4 mb-4">
-              <div className="bg-slate-50 rounded-lg p-3 text-center">
-                <div className="text-lg font-bold">${t.result.totalCharged}</div>
-                <div className="text-xs text-slate-500">Total Charged</div>
-              </div>
-              <div className="bg-red-50 rounded-lg p-3 text-center">
-                <div className="text-lg font-bold text-red-600">
-                  ${t.result.totalOvercharge}
-                </div>
-                <div className="text-xs text-slate-500">Overcharges</div>
-              </div>
-              <div className="bg-green-50 rounded-lg p-3 text-center">
-                <div className="text-lg font-bold text-green-600">
-                  ${t.result.totalCorrect}
-                </div>
-                <div className="text-xs text-slate-500">Correct Amount</div>
-              </div>
-            </div>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs text-slate-500">
-                {t.result.lineItems.length} line items
-              </span>
-              <button
-                onClick={() => setShowErrorsOnly(!showErrorsOnly)}
-                className="text-xs text-sky-600 hover:text-sky-800 cursor-pointer"
-              >
-                {showErrorsOnly ? "Show all items" : "Show errors only"}
-              </button>
-            </div>
-            <BillLineItemsVirtualized
-              lineItems={t.result.lineItems.filter(
-                (item: any) => !showErrorsOnly || item.status !== "valid",
-              )}
-            />
-            <p className="mt-4 text-sm font-medium text-slate-700">
-              {t.result.recommendation}
-            </p>
-          </div>
-        ))
+          );
+        })
       ) : (
         <div className="bg-white rounded-xl border border-slate-200 p-12 text-center text-sm text-slate-400">
           No bills audited yet. Run &quot;Audit Hospital Bill&quot; from Overview.

--- a/dashboard/src/components/tabs/medications-tab.tsx
+++ b/dashboard/src/components/tabs/medications-tab.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { downloadMedicationPDF } from "../../app/pdf";
 import {
   DrugInteractionResultSchema,
   PharmacyCompareResultSchema,
   type RecipientProfile,
 } from "../../lib/types";
+import { reportPdfDownloadFailure } from "../../lib/pdf-download-error";
+import { Toast } from "../primitives/toast";
 import type { AgentResult } from "../types";
 
 const MEDS = ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"] as const;
@@ -16,6 +19,7 @@ export interface MedicationsTabProps {
 }
 
 export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) {
+  const [toastMsg, setToastMsg] = useState<string | null>(null);
   const hasPriceResults = agentResult?.toolCalls.some(
     (t) => t.tool === "compare_pharmacy_prices",
   );
@@ -31,6 +35,7 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
       tabIndex={0}
       className="space-y-6"
     >
+      <Toast message={toastMsg} onDismiss={() => setToastMsg(null)} />
       <div className="bg-white rounded-xl border border-slate-200 p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-sm font-semibold text-slate-700">
@@ -39,21 +44,25 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
           {hasPriceResults && (
             <button
               onClick={() => {
-                const priceResults = agentResult!.toolCalls
-                  .filter((t) => t.tool === "compare_pharmacy_prices")
-                  .map((t) => PharmacyCompareResultSchema.parse(t.result));
-                const interactionResult = agentResult!.toolCalls.find(
-                  (t) => t.tool === "check_drug_interactions",
-                )?.result;
-                downloadMedicationPDF(
-                  {
-                    priceResults,
-                    interactionResult: interactionResult
-                      ? DrugInteractionResultSchema.parse(interactionResult)
-                      : undefined,
-                  },
-                  { recipient },
-                );
+                try {
+                  const priceResults = agentResult!.toolCalls
+                    .filter((t) => t.tool === "compare_pharmacy_prices")
+                    .map((t) => PharmacyCompareResultSchema.parse(t.result));
+                  const interactionResult = agentResult!.toolCalls.find(
+                    (t) => t.tool === "check_drug_interactions",
+                  )?.result;
+                  downloadMedicationPDF(
+                    {
+                      priceResults,
+                      interactionResult: interactionResult
+                        ? DrugInteractionResultSchema.parse(interactionResult)
+                        : undefined,
+                    },
+                    { recipient },
+                  );
+                } catch (error) {
+                  setToastMsg(reportPdfDownloadFailure(error));
+                }
               }}
               className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
             >
@@ -101,30 +110,36 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
           <h2 className="text-sm font-semibold text-slate-700 mb-4">
             Drug Interactions
           </h2>
-          {interactionCalls.map((t, i) => (
-            <div key={i} className="space-y-2">
-              <p className="text-sm text-slate-600">{t.result.summary}</p>
-              {t.result.interactions?.map((ix: any, j: number) => (
-                <div
-                  key={j}
-                  className={`p-3 rounded-lg text-sm ${
-                    ix.severity === "severe"
-                      ? "bg-red-50 border border-red-200"
-                      : ix.severity === "moderate"
-                        ? "bg-amber-50 border border-amber-200"
-                        : "bg-blue-50 border border-blue-200"
-                  }`}
-                >
-                  <div className="font-medium">
-                    {ix.drug1} + {ix.drug2} ({ix.severity})
+          {interactionCalls.map((t, i) => {
+            const interactionResult = DrugInteractionResultSchema.parse(t.result);
+
+            return (
+              <div key={i} className="space-y-2">
+                <p className="text-sm text-slate-600">
+                  {interactionResult.summary}
+                </p>
+                {interactionResult.interactions?.map((ix, j) => (
+                  <div
+                    key={j}
+                    className={`p-3 rounded-lg text-sm ${
+                      ix.severity === "severe"
+                        ? "bg-red-50 border border-red-200"
+                        : ix.severity === "moderate"
+                          ? "bg-amber-50 border border-amber-200"
+                          : "bg-blue-50 border border-blue-200"
+                    }`}
+                  >
+                    <div className="font-medium">
+                      {ix.drug1} + {ix.drug2} ({ix.severity})
+                    </div>
+                    <div className="text-xs mt-1 text-slate-600">
+                      {ix.recommendation}
+                    </div>
                   </div>
-                  <div className="text-xs mt-1 text-slate-600">
-                    {ix.recommendation}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ))}
+                ))}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/dashboard/src/lib/pdf-download-error.ts
+++ b/dashboard/src/lib/pdf-download-error.ts
@@ -1,0 +1,13 @@
+export function createPdfRequestId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `pdf-${crypto.randomUUID()}`;
+  }
+
+  return `pdf-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function reportPdfDownloadFailure(error: unknown) {
+  const requestId = createPdfRequestId();
+  console.error(`PDF generation failed (${requestId})`, error);
+  return `Couldn't generate PDF — try again. Request ID: ${requestId}`;
+}


### PR DESCRIPTION
Closes #219

## Summary
Wrap medication, bill audit, and transaction PDF downloads in UI try/catch handlers, show a toast with "Couldn't generate PDF - try again" plus a request id on failure, log the same request id with the thrown error, and add focused Vitest coverage that mocks `jspdf` failures for all three download buttons.

## Verification
- `npm.cmd test -- --run dashboard/src/__tests__/pdf-download-errors.test.tsx`
- `npm.cmd test -- --run dashboard/src/__tests__/pdf-download-errors.test.tsx dashboard/src/app/__tests__/pdf-pagination.test.ts`
- `npm.cmd exec -- eslint src/components/tabs/medications-tab.tsx src/components/tabs/bills-tab.tsx src/components/tabs/activity-tab.tsx src/lib/pdf-download-error.ts src/__tests__/pdf-download-errors.test.tsx` from `dashboard/`
- `git diff --check`

Note: `npm.cmd run build` in `dashboard/` is still blocked on current `main` by `dashboard/src/components/ui/skeleton.tsx` importing missing `../../lib/utils`; that upstream-main build issue is addressed separately in PR #351.

Happy to address any review feedback.