### PR TITLE
fix: validate unified server port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,8 @@ ALLOWED_ORIGINS=http://localhost:3000
 SPENDING_TIMEZONE=America/Phoenix
 
 # --- Server Port ---
-# Unified server runs all services on one port
+# Unified server runs all services on one port.
+# Must be an integer from 1 to 65535. Most hosts inject this automatically.
 PORT=3004
 
 # --- Service URLs (agent tools connect to these — same server in unified mode) ---

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import {
 } from "./shared/agent-state.ts";
 import { checkWalletBalance, formatResult } from "./shared/wallet-balance.ts";
 import { appendAuditEntry } from "./shared/audit-log.ts";
+import { portSchema } from "./shared/server-env.ts";
 
 // Agent tools
 import {
@@ -55,7 +56,7 @@ import {
 
 // --- Environment ---
 const envSchema = z.object({
-  PORT: z.coerce.number().int().positive().default(3004),
+  PORT: portSchema.default(3004),
   STELLAR_NETWORK: z.enum(["testnet", "public"]).default("testnet"),
   LLM_API_KEY: z.string().min(1, "LLM_API_KEY required"),
   AGENT_SECRET_KEY: z.string().min(1, "AGENT_SECRET_KEY required"),

--- a/shared/__tests__/server-env.test.ts
+++ b/shared/__tests__/server-env.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { portSchema } from "../server-env.ts";
+
+describe("portSchema", () => {
+  it.each(["0", 0, "65536", 65536])(
+    "rejects invalid PORT value %s",
+    (value) => {
+      const result = portSchema.safeParse(value);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          "PORT must be between 1 and 65535",
+        );
+      }
+    },
+  );
+
+  it("rejects non-numeric PORT values with a clear message", () => {
+    const result = portSchema.safeParse("abc");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("PORT must be a number");
+    }
+  });
+
+  it("rejects fractional PORT values with a clear message", () => {
+    const result = portSchema.safeParse("3004.5");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("PORT must be an integer");
+    }
+  });
+
+  it.each(["1", 1, "80", 80, "3004", 3004, "65535", 65535])(
+    "accepts valid PORT value %s",
+    (value) => {
+      const result = portSchema.safeParse(value);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBe(Number(value));
+      }
+    },
+  );
+});

--- a/shared/server-env.ts
+++ b/shared/server-env.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const portSchema = z.coerce
+  .number({
+    invalid_type_error: "PORT must be a number",
+  })
+  .int("PORT must be an integer")
+  .min(1, "PORT must be between 1 and 65535")
+  .max(65535, "PORT must be between 1 and 65535");


### PR DESCRIPTION
## Summary
- add a shared Zod schema for the unified server PORT value
- reject non-numeric, fractional, zero, and out-of-range ports before startup
- document the accepted PORT range in `.env.example`

## Checks
- npm test -- shared/__tests__/server-env.test.ts
- git diff --check

Closes #234