### PR TITLE
feat(security): body limits, sig verification, PHI scrubbing, secret …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,3 +116,13 @@ WALLET_BALANCE_CHECK_ENABLED=0
 WALLET_BALANCE_CHECK_CRON=*/15 * * * *
 # Optional Slack webhook for low-balance alert notifications.
 SLACK_WEBHOOK_URL=
+
+# --- Request body-size limits (issue #92) ---
+# Default JSON body limit for all endpoints except bill audit.
+JSON_BODY_LIMIT=20kb
+# Bill-audit routes handle up to 500 line items; allow larger payloads.
+BILL_AUDIT_BODY_LIMIT=256kb
+
+# --- LLM PHI scrubbing (issue #97) ---
+# Set to false ONLY for LLM providers with a signed BAA (e.g., enterprise OpenAI).
+LLM_PII_SCRUB=true

--- a/agent/__tests__/body-limit.test.ts
+++ b/agent/__tests__/body-limit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for issue #92 — explicit Express body-size limits.
+ *
+ * Tests the middleware configuration directly (no LLM/Stellar mocks needed).
+ */
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+
+function buildApp(defaultLimit: string, billAuditLimit?: string) {
+  const app = express();
+  if (billAuditLimit) {
+    const smallJson = express.json({ limit: defaultLimit });
+    const largeJson = express.json({ limit: billAuditLimit });
+    app.use((req: any, res: any, next: any) =>
+      (req.path.startsWith("/bill/audit") ? largeJson : smallJson)(req, res, next)
+    );
+  } else {
+    app.use(express.json({ limit: defaultLimit }));
+  }
+  app.post("/agent/run", (req, res) => res.json({ ok: true }));
+  app.post("/bill/audit", (req, res) => res.json({ ok: true }));
+  // 413 error handler
+  app.use((err: any, _req: any, res: any, next: any) => {
+    if (err.type === "entity.too.large") {
+      return res.status(413).json({ error: "Request body too large", limit: err.limit });
+    }
+    next(err);
+  });
+  return app;
+}
+
+const oversized = JSON.stringify({ data: "x".repeat(25_000) });    // ~25kb
+const medium    = JSON.stringify({ data: "x".repeat(200_000) });   // ~200kb
+const small     = JSON.stringify({ task: "Check drug prices" });
+
+describe("#92 body-size limit — 20kb default", () => {
+  const app = buildApp("20kb");
+
+  it("returns 413 when POST body exceeds 20kb", async () => {
+    const res = await request(app)
+      .post("/agent/run")
+      .set("Content-Type", "application/json")
+      .send(oversized);
+
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/too large/i);
+  });
+
+  it("does not 413 when body is within 20kb", async () => {
+    const res = await request(app)
+      .post("/agent/run")
+      .set("Content-Type", "application/json")
+      .send(small);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});
+
+describe("#92 body-size limit — bill-audit route gets 256kb", () => {
+  const app = buildApp("20kb", "256kb");
+
+  it("allows ~200kb on /bill/audit", async () => {
+    const res = await request(app)
+      .post("/bill/audit")
+      .set("Content-Type", "application/json")
+      .send(medium);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("still 413 on non-bill route with oversized body", async () => {
+    const res = await request(app)
+      .post("/agent/run")
+      .set("Content-Type", "application/json")
+      .send(oversized);
+
+    expect(res.status).toBe(413);
+  });
+
+  it("413 on /bill/audit above 256kb", async () => {
+    const huge = JSON.stringify({ data: "x".repeat(300_000) }); // ~300kb
+    const res = await request(app)
+      .post("/bill/audit")
+      .set("Content-Type", "application/json")
+      .send(huge);
+
+    expect(res.status).toBe(413);
+  });
+});

--- a/agent/__tests__/stellar-signature.test.ts
+++ b/agent/__tests__/stellar-signature.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for issue #93 — verify Stellar tx signer hint before submit in payBill.
+ */
+
+// vi.hoisted runs before vi.mock factories — constants and mutable refs must live here
+const { MATCHING_HINT, WRONG_HINT, mockKeypairHint, mockTxHint, mockSubmit, mockOnProgress } = vi.hoisted(() => {
+  process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+  process.env.BILL_PROVIDER_PUBLIC_KEY = "GBILLPROVIDER";
+  const MATCHING_HINT = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+  const WRONG_HINT    = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+  return {
+    MATCHING_HINT,
+    WRONG_HINT,
+    mockKeypairHint: vi.fn().mockReturnValue(MATCHING_HINT),
+    mockTxHint:      vi.fn().mockReturnValue(MATCHING_HINT),
+    mockSubmit:      vi.fn().mockResolvedValue({ hash: "TESTHASH" }),
+    mockOnProgress:  { fn: undefined as ((e: any) => void) | undefined },
+  };
+});
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("fs", () => ({
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("@stellar/stellar-sdk", () => ({
+  Keypair: {
+    fromSecret: vi.fn().mockReturnValue({
+      publicKey: () => "GPUB123",
+      sign: vi.fn(),
+      signatureHint: mockKeypairHint,
+    }),
+  },
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  TransactionBuilder: vi.fn().mockReturnValue({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockReturnValue({
+      sign: vi.fn(),
+      signatures: [{ hint: mockTxHint }],
+    }),
+  }),
+  Operation: { payment: vi.fn() },
+  Asset: vi.fn(),
+  Horizon: {
+    Server: vi.fn().mockReturnValue({
+      loadAccount: vi.fn().mockResolvedValue({ id: "GPUB123", sequence: "1", balances: [] }),
+      submitTransaction: mockSubmit,
+    }),
+  },
+}));
+vi.mock("@x402/stellar", () => ({
+  createEd25519Signer: vi.fn().mockReturnValue({}),
+  ExactStellarScheme: vi.fn(),
+}));
+vi.mock("@x402/fetch", () => ({
+  wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
+  x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }),
+  decodePaymentResponseHeader: vi.fn(),
+}));
+vi.mock("@stellar/mpp/charge/client", () => ({
+  stellar: vi.fn().mockImplementation((opts: any) => {
+    if (opts?.onProgress) mockOnProgress.fn = opts.onProgress;
+    return {};
+  }),
+}));
+vi.mock("mppx/client", () => ({
+  Mppx: { create: vi.fn().mockReturnValue({ fetch: vi.fn() }) },
+}));
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { payBill } from "../tools.ts";
+
+describe("#93 Stellar signature hint verification in payBill", () => {
+  beforeEach(() => {
+    mockSubmit.mockClear();
+    // Reset hints to matching (happy path default)
+    mockKeypairHint.mockReturnValue(MATCHING_HINT);
+    mockTxHint.mockReturnValue(MATCHING_HINT);
+  });
+
+  it("submits when signer hint matches agentKeypair", async () => {
+    const result = await payBill("provider-1", "Hospital", "ER Visit", 5, true);
+
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it("refuses to submit when tx signer hint does not match agentKeypair", async () => {
+    mockTxHint.mockReturnValue(WRONG_HINT); // tx has wrong hint
+
+    const result = await payBill("provider-1", "Hospital", "ER Visit", 5, true);
+
+    expect(mockSubmit).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Signer mismatch/);
+  });
+
+  it("refuses to submit when signatures array is empty", async () => {
+    // Simulate no signatures (edge: sign() failed silently)
+    const { TransactionBuilder } = await import("@stellar/stellar-sdk");
+    vi.mocked(TransactionBuilder).mockReturnValueOnce({
+      addOperation: vi.fn().mockReturnThis(),
+      setTimeout: vi.fn().mockReturnThis(),
+      build: vi.fn().mockReturnValue({
+        sign: vi.fn(),
+        signatures: [], // empty
+      }),
+    } as any);
+
+    const result = await payBill("provider-1", "Hospital", "ER Visit", 5, true);
+
+    expect(mockSubmit).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Signer mismatch/);
+  });
+});

--- a/agent/__tests__/tools.test.ts
+++ b/agent/__tests__/tools.test.ts
@@ -1,8 +1,12 @@
 // vi.hoisted runs before any vi.mock factory — sets env vars + captures mutable refs
-const { mockMppFetch, onProgressHolder } = vi.hoisted(() => {
+const { mockMppFetch, onProgressHolder, MOCK_HINT } = vi.hoisted(() => {
   process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
   const onProgressHolder: { fn?: (event: any) => void } = {};
-  return { mockMppFetch: vi.fn(), onProgressHolder };
+  return {
+    mockMppFetch: vi.fn(),
+    onProgressHolder,
+    MOCK_HINT: Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
+  };
 });
 
 vi.mock("dotenv/config", () => ({}));
@@ -13,12 +17,21 @@ vi.mock("fs", () => ({
   mkdirSync: vi.fn(),
 }));
 vi.mock("@stellar/stellar-sdk", () => ({
-  Keypair: { fromSecret: vi.fn().mockReturnValue({ publicKey: () => "GPUB123", sign: vi.fn() }) },
+  Keypair: {
+    fromSecret: vi.fn().mockReturnValue({
+      publicKey: () => "GPUB123",
+      sign: vi.fn(),
+      signatureHint: vi.fn().mockReturnValue(MOCK_HINT),
+    }),
+  },
   Networks: { TESTNET: "Test SDF Network ; September 2015" },
   TransactionBuilder: vi.fn().mockReturnValue({
     addOperation: vi.fn().mockReturnThis(),
     setTimeout: vi.fn().mockReturnThis(),
-    build: vi.fn().mockReturnValue({ sign: vi.fn() }),
+    build: vi.fn().mockReturnValue({
+      sign: vi.fn(),
+      signatures: [{ hint: vi.fn().mockReturnValue(MOCK_HINT) }],
+    }),
   }),
   Operation: { payment: vi.fn() },
   Asset: vi.fn(),

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -17,6 +17,7 @@ import { applySecurityMiddleware } from "../shared/security-middleware.ts";
 import { logger } from "../shared/logger.ts";
 import { validateTask, getSuspiciousTaskCount } from "../shared/task-validation.ts";
 import { appendAuditEntry } from "../shared/audit-log.ts";
+import { buildScrubSession, scrubText } from "../shared/prompt-scrub.ts";
 import {
   comparePharmacyPrices,
   auditBill,
@@ -74,6 +75,15 @@ PAYMENT PROTOCOLS:
 Current care recipient: Rosa Garcia (age 78)
 Caregiver: Maria Garcia (daughter)`;
 
+// PHI scrubbing — active unless LLM_PII_SCRUB=false (e.g. provider has a BAA)
+const _piiScrub = process.env.LLM_PII_SCRUB !== "false";
+const _scrubSession = _piiScrub
+  ? buildScrubSession(["Rosa Garcia"], ["Maria Garcia"])
+  : null;
+const SCRUBBED_SYSTEM_PROMPT = _scrubSession
+  ? scrubText(SYSTEM_PROMPT, _scrubSession)
+  : SYSTEM_PROMPT;
+
 // Convert tool definitions to OpenAI-compatible function format
 const LLM_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = TOOL_DEFINITIONS.map((t) => ({
   type: "function" as const,
@@ -130,9 +140,10 @@ let totalCompletionTokens = 0;
 
 // Run the agent with a task — full agentic loop
 async function runAgent(task: string) {
+  const userTask = _scrubSession ? scrubText(task, _scrubSession) : task;
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
-    { role: "system", content: SYSTEM_PROMPT },
-    { role: "user", content: task },
+    { role: "system", content: SCRUBBED_SYSTEM_PROMPT },
+    { role: "user", content: userTask },
   ];
   const toolCalls: Array<{ tool: string; input: any; result: any }> = [];
   let finalResponse = "";
@@ -304,7 +315,7 @@ let toolCallCapHitsTotal = 0;
 const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json());
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
 
 let agentPaused = false;
 
@@ -498,6 +509,15 @@ async function verifyWallet() {
     process.exit(1);
   }
 }
+
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+  }
+  next(err);
+});
+
+export { app };
 
 app.listen(PORT, async () => {
   logger.info({ port: PORT, network: "stellar:testnet", llm: LLM_MODEL, llmBaseUrl: LLM_BASE_URL, wallet: agentKeypair.publicKey() }, "CareGuard Agent started");

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -16,7 +16,8 @@ import { createEd25519Signer, ExactStellarScheme } from "@x402/stellar";
 import { Mppx } from "mppx/client";
 import { stellar as stellarCharge } from "@stellar/mpp/charge/client";
 import type { SpendingPolicy, Transaction } from "../shared/types.ts";
-export { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
+import { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
+export { SPENDING_TIMEZONE, getLocalDateStr };
 
 // Environment
 const AGENT_SECRET_KEY = process.env.AGENT_SECRET_KEY;
@@ -456,6 +457,17 @@ export async function payBill(providerId: string, providerName: string, descript
       .build();
 
     stellarTx.sign(agentKeypair);
+
+    // Belt-and-braces: verify the signed envelope's signer hint matches the agent keypair
+    // before broadcast — cheap guard against future wallet mix-ups.
+    const sigHint = stellarTx.signatures[0]?.hint();
+    if (!sigHint || !sigHint.equals(agentKeypair.signatureHint())) {
+      throw new Error(
+        `Signer mismatch: expected ${agentKeypair.publicKey()} — refusing to submit`
+      );
+    }
+    console.log(`  [Stellar] Signer verified: ${agentKeypair.publicKey().slice(0, 8)}...`);
+
     const result = await horizonServer.submitTransaction(stellarTx);
     stellarTxHash = (result as any).hash;
     logger.info({ txHash: stellarTxHash }, "[Stellar] TX confirmed");

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -64,6 +64,54 @@ Log format: JSON in `NODE_ENV=production`, pino-pretty in development.
 
 ---
 
+## #97 — PHI Scrubbing for LLM Providers
+
+### Data flow to LLM providers
+
+CareGuard sends two types of text to the configured LLM provider (Groq, OpenAI, OpenRouter, etc.):
+
+| What | When | Contains PHI? |
+|------|------|---------------|
+| `SYSTEM_PROMPT` | Once per agent run | Patient/caregiver **names** (scrubbed — see below) |
+| User task string | Once per run | May contain names typed by the caregiver (scrubbed) |
+| Tool call results | Each tool invocation | Medication names, prices, CPT codes — **not scrubbed** (not identifying by themselves) |
+
+### PHI scrubbing
+
+Before any text reaches the LLM, `shared/prompt-scrub.ts` replaces real patient and caregiver names with stable pseudonyms for the duration of a run:
+
+| Real value | Pseudonym sent to LLM |
+|------------|-----------------------|
+| Rosa Garcia | Patient A |
+| Maria Garcia | Caregiver A |
+
+The mapping table is kept **server-side only** and never forwarded to the provider. Agent tool calls continue to use real wallet IDs and API identifiers — only the free-form text visible to the model is pseudonymised.
+
+### Disabling scrubbing (BAA providers)
+
+Set `LLM_PII_SCRUB=false` in your environment to send real names to the LLM. Do this **only** when your LLM provider has a signed HIPAA BAA covering patient name use in prompts (e.g. enterprise OpenAI).
+
+---
+
+## #92 — Body-Size Limits
+
+All Express endpoints enforce explicit JSON body limits to reduce DoS surface:
+
+| Endpoint | Limit | Configured via |
+|----------|-------|----------------|
+| `/bill/audit` | 256 kb | `BILL_AUDIT_BODY_LIMIT` |
+| All others | 20 kb | `JSON_BODY_LIMIT` |
+
+Requests exceeding the limit receive HTTP 413 with a JSON error body.
+
+---
+
+## Secret Rotation
+
+See `docs/runbooks/rotate-secrets.md` for step-by-step rotation procedures for every secret (agent wallet, OZ API key, LLM key, MPP key, JWT).
+
+---
+
 ## Reporting Vulnerabilities
 
 Open a private issue on the repository or contact the maintainers directly. Do not disclose vulnerabilities publicly before a fix is available.

--- a/docs/runbooks/rotate-secrets.md
+++ b/docs/runbooks/rotate-secrets.md
@@ -1,0 +1,119 @@
+# Runbook: Rotate every secret
+
+Rotate secrets **at least quarterly**, and immediately whenever a key is suspected or confirmed to be compromised.
+
+---
+
+## 1. Agent wallet (`AGENT_SECRET_KEY` / `AGENT_PUBLIC_KEY`)
+
+The agent wallet signs every Stellar transaction. If this key leaks, an attacker can drain all USDC and XLM from the wallet.
+
+**Automated rotation script:**
+
+```sh
+# Dry run — shows what would happen (no transactions broadcast)
+npx tsx scripts/rotate-agent-wallet.ts
+
+# Execute rotation on the configured network (STELLAR_NETWORK env)
+npx tsx scripts/rotate-agent-wallet.ts --execute
+```
+
+**What the script does:**
+1. Reads current `AGENT_SECRET_KEY` from env and derives the old public key.
+2. Generates a new Stellar keypair (`Keypair.random()`).
+3. Funds the new wallet: sends XLM (base reserve + fee buffer) from old → new.
+4. Sweeps USDC: moves all USDC from old → new.
+5. Prints the new key pair and the exact `.env` / Render env-var lines to update.
+
+**After the script completes:**
+1. Update `AGENT_SECRET_KEY` and `AGENT_PUBLIC_KEY` in your `.env` file or Render dashboard.
+2. Restart the server.
+3. Verify the dashboard shows the new wallet address and correct balance.
+
+---
+
+## 2. OZ Facilitator API key (`OZ_FACILITATOR_API_KEY`)
+
+The OZ API key authorises x402 payment facilitation (one key per environment).
+
+**Steps:**
+1. Go to [https://channels.openzeppelin.com/testnet/gen](https://channels.openzeppelin.com/testnet/gen) (testnet) or the production console (mainnet).
+2. Generate a new API key.
+3. Update `OZ_FACILITATOR_API_KEY` in `.env` / Render.
+4. Restart the server — x402 payments require the new key immediately on the next request.
+5. Revoke the old key in the OZ console.
+
+---
+
+## 3. LLM API key (`LLM_API_KEY`)
+
+Used to authenticate every call to the LLM provider (Groq, OpenRouter, OpenAI, etc.).
+
+**Steps:**
+1. Log in to your LLM provider's console.
+   - Groq: [https://console.groq.com/keys](https://console.groq.com/keys)
+   - OpenAI: [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+   - OpenRouter: [https://openrouter.ai/settings/keys](https://openrouter.ai/settings/keys)
+2. Create a new API key with the same permissions as the old one.
+3. Update `LLM_API_KEY` in `.env` / Render.
+4. Restart the server.
+5. Revoke the old key in the provider's console.
+
+---
+
+## 4. MPP secret key (`MPP_SECRET_KEY`)
+
+Signs MPP credential tokens used for pharmacy payment authorisation. A leaked key lets attackers forge payment credentials.
+
+**Steps:**
+1. Generate a new 256-bit secret:
+   ```sh
+   openssl rand -hex 32
+   ```
+2. Update `MPP_SECRET_KEY` in `.env` / Render.
+3. Restart the server — the new key takes effect immediately for new payment sessions.
+
+> Note: in-flight MPP sessions signed with the old key will fail. Ensure no orders are mid-flight before rotating (check `/pharmacy/orders`).
+
+---
+
+## 5. JWT refresh secret (when auth lands in #10)
+
+Once user authentication is implemented, JWT signing keys must be rotated with a **dual-verify window** to avoid rejecting valid sessions mid-flight.
+
+**Rotation procedure:**
+1. Generate a new JWT secret: `openssl rand -hex 64`
+2. Update your config to **accept both old and new** secrets for verification (dual-verify window).
+3. Deploy and wait for one access-token TTL (default: 15 minutes) — all previously issued tokens will have expired.
+4. Remove the old secret from the config.
+5. Deploy again.
+
+This ensures users are not logged out mid-session.
+
+---
+
+## Quarterly rotation calendar
+
+Schedule the following in your team's calendar every 3 months:
+
+| Secret | Action |
+|--------|--------|
+| Agent wallet | Run `scripts/rotate-agent-wallet.ts --execute` |
+| OZ API key | Regenerate in OZ console |
+| LLM API key | Regenerate in provider console |
+| MPP_SECRET_KEY | `openssl rand -hex 32` and update env |
+| JWT secret (once #10 lands) | Dual-verify rotation |
+
+**Suggested calendar entry:** `CareGuard secret rotation — Q[1/2/3/4]`
+
+Set a recurring reminder every 90 days. After each rotation, append a dated entry to `data/audit.log.jsonl` manually or via the admin API for compliance tracking.
+
+---
+
+## Related
+
+- Issue [#95](https://github.com/harystyleseze/careguard/issues/95) — original spec
+- Issue [#10](https://github.com/harystyleseze/careguard/issues/10) — auth (JWT)
+- `scripts/rotate-agent-wallet.ts` — automation for agent wallet rotation
+- `docs/runbooks/wallet-low.md` — what to do when the wallet balance is low
+- `docs/SECURITY.md` — full security overview

--- a/scripts/rotate-agent-wallet.ts
+++ b/scripts/rotate-agent-wallet.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Agent wallet rotation script (issue #95).
+ *
+ * Generates a new Stellar keypair, sweeps USDC + XLM from the old wallet to
+ * the new one, and prints the updated env-var lines to paste into .env or the
+ * Render dashboard.
+ *
+ * Usage:
+ *   npx tsx scripts/rotate-agent-wallet.ts           # dry run (safe, no txs)
+ *   npx tsx scripts/rotate-agent-wallet.ts --execute  # broadcast on STELLAR_NETWORK
+ *
+ * After --execute: update AGENT_SECRET_KEY + AGENT_PUBLIC_KEY in your env, then restart.
+ */
+
+import "dotenv/config";
+import {
+  Keypair,
+  Horizon,
+  Networks,
+  TransactionBuilder,
+  Operation,
+  Asset,
+} from "@stellar/stellar-sdk";
+
+const EXECUTE = process.argv.includes("--execute");
+const NETWORK = process.env.STELLAR_NETWORK === "public" ? "public" : "testnet";
+const HORIZON_URL =
+  NETWORK === "public"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+const NETWORK_PASSPHRASE =
+  NETWORK === "public" ? Networks.PUBLIC : Networks.TESTNET;
+const USDC_ISSUER =
+  process.env.USDC_ISSUER ||
+  "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+const OLD_SECRET = process.env.AGENT_SECRET_KEY;
+if (!OLD_SECRET) {
+  console.error("AGENT_SECRET_KEY not set in environment. Aborting.");
+  process.exit(1);
+}
+
+const horizon = new Horizon.Server(HORIZON_URL);
+
+async function main() {
+  const oldKeypair = Keypair.fromSecret(OLD_SECRET!);
+  const newKeypair = Keypair.random();
+
+  console.log("\n=== CareGuard Agent Wallet Rotation ===");
+  console.log(`Network:     ${NETWORK}`);
+  console.log(`Old wallet:  ${oldKeypair.publicKey()}`);
+  console.log(`New wallet:  ${newKeypair.publicKey()}`);
+  console.log(`Mode:        ${EXECUTE ? "EXECUTE (broadcasting)" : "DRY RUN (no transactions)"}`);
+  console.log("");
+
+  // Load old account state
+  let oldAccount: Horizon.AccountResponse;
+  try {
+    oldAccount = await horizon.loadAccount(oldKeypair.publicKey());
+  } catch {
+    console.error("Could not load old agent wallet from Horizon. Is STELLAR_NETWORK correct?");
+    process.exit(1);
+  }
+
+  const usdcBalance = oldAccount.balances.find(
+    (b: any) => b.asset_code === "USDC" && b.asset_issuer === USDC_ISSUER
+  );
+  const xlmBalance = oldAccount.balances.find((b: any) => b.asset_type === "native");
+
+  const xlmAvailable = parseFloat(xlmBalance?.balance ?? "0");
+  const usdcAvailable = parseFloat(usdcBalance?.balance ?? "0");
+  const xlmForBaseReserve = 2.5;  // base reserve (2×0.5) + 1 trustline + buffer
+  const xlmForFees = 0.01;
+  const xlmToSend = Math.max(0, xlmAvailable - xlmForBaseReserve - xlmForFees);
+
+  console.log(`Old USDC balance: ${usdcAvailable}`);
+  console.log(`Old XLM balance:  ${xlmAvailable}`);
+  console.log(`XLM to transfer:  ${xlmToSend.toFixed(7)} (keeping ${xlmForBaseReserve} for reserves + fees)`);
+  console.log(`USDC to sweep:    ${usdcAvailable}`);
+  console.log("");
+
+  if (xlmToSend < 1) {
+    console.error("Insufficient XLM to fund the new wallet (need at least 1 XLM to transfer).");
+    console.error("Fund the old wallet first, then re-run.");
+    process.exit(1);
+  }
+
+  if (!EXECUTE) {
+    console.log("DRY RUN — no transactions broadcast. Re-run with --execute to proceed.");
+    printUpdateInstructions(newKeypair);
+    return;
+  }
+
+  // Step 1: Create new account and fund with XLM
+  console.log("Step 1: Creating new account + sending XLM...");
+  const oldAccountFresh = await horizon.loadAccount(oldKeypair.publicKey());
+  const createTx = new TransactionBuilder(oldAccountFresh, {
+    fee: "100",
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      Operation.createAccount({
+        destination: newKeypair.publicKey(),
+        startingBalance: xlmToSend.toFixed(7),
+      })
+    )
+    .setTimeout(30)
+    .build();
+
+  createTx.sign(oldKeypair);
+  const createResult = await horizon.submitTransaction(createTx);
+  console.log(`  ✓ New account created. TX: ${(createResult as any).hash}`);
+
+  // Step 2: Establish USDC trustline on new account
+  if (usdcAvailable > 0) {
+    console.log("Step 2: Establishing USDC trustline on new account...");
+    const newAccountFresh = await horizon.loadAccount(newKeypair.publicKey());
+    const trustTx = new TransactionBuilder(newAccountFresh, {
+      fee: "100",
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        Operation.changeTrust({
+          asset: new Asset("USDC", USDC_ISSUER),
+        })
+      )
+      .setTimeout(30)
+      .build();
+
+    trustTx.sign(newKeypair);
+    const trustResult = await horizon.submitTransaction(trustTx);
+    console.log(`  ✓ USDC trustline established. TX: ${(trustResult as any).hash}`);
+
+    // Step 3: Sweep USDC
+    console.log(`Step 3: Sweeping ${usdcAvailable} USDC to new wallet...`);
+    const oldAccountForUsdc = await horizon.loadAccount(oldKeypair.publicKey());
+    const usdcTx = new TransactionBuilder(oldAccountForUsdc, {
+      fee: "100",
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: newKeypair.publicKey(),
+          asset: new Asset("USDC", USDC_ISSUER),
+          amount: usdcAvailable.toFixed(7),
+        })
+      )
+      .setTimeout(30)
+      .build();
+
+    usdcTx.sign(oldKeypair);
+    const usdcResult = await horizon.submitTransaction(usdcTx);
+    console.log(`  ✓ USDC swept. TX: ${(usdcResult as any).hash}`);
+  } else {
+    console.log("Step 2-3: No USDC to sweep — skipping trustline and USDC transfer.");
+  }
+
+  console.log("\n=== Rotation complete ===");
+  printUpdateInstructions(newKeypair);
+}
+
+function printUpdateInstructions(newKeypair: Keypair) {
+  console.log("\n--- Update your .env or Render environment with: ---");
+  console.log(`AGENT_SECRET_KEY=${newKeypair.secret()}`);
+  console.log(`AGENT_PUBLIC_KEY=${newKeypair.publicKey()}`);
+  console.log("-----------------------------------------------------");
+  console.log("\nNext steps:");
+  console.log("  1. Update the env vars above in .env or your hosting dashboard.");
+  console.log("  2. Restart the server.");
+  console.log("  3. Verify the dashboard shows the new wallet address.");
+  console.log("  4. Fund the new wallet with USDC if needed (https://faucet.circle.com for testnet).");
+}
+
+main().catch((err) => {
+  console.error(`Rotation failed: ${err?.message ?? err}`);
+  process.exit(1);
+});

--- a/server.ts
+++ b/server.ts
@@ -24,6 +24,7 @@ import { createCorsMiddleware } from "./shared/cors.ts";
 import { applySecurityMiddleware } from "./shared/security-middleware.ts";
 import { logger } from "./shared/logger.ts";
 import { validateTask, getSuspiciousTaskCount } from "./shared/task-validation.ts";
+import { buildScrubSession, scrubText } from "./shared/prompt-scrub.ts";
 
 // Sentry (gated by SENTRY_DSN)
 import { initSentry } from "./shared/sentry.ts";
@@ -114,7 +115,11 @@ const sentry = await initSentry({ service: "careguard-server" });
 app.use(sentry.requestHandler());
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json());
+const _smallJson = express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" });
+const _largeJson = express.json({ limit: process.env.BILL_AUDIT_BODY_LIMIT ?? "256kb" });
+app.use((req, res, next) =>
+  (req.path.startsWith("/bill/audit") ? _largeJson : _smallJson)(req, res, next)
+);
 
 // --- Root info ---
 app.get("/", (_req, res) => {
@@ -843,6 +848,15 @@ IMPORTANT RULES:
 Current care recipient: Rosa Garcia (age 78)
 Caregiver: Maria Garcia (daughter)`;
 
+// PHI scrubbing — active unless LLM_PII_SCRUB=false (e.g. provider has a BAA)
+const _piiScrub = process.env.LLM_PII_SCRUB !== "false";
+const _scrubSession = _piiScrub
+  ? buildScrubSession(["Rosa Garcia"], ["Maria Garcia"])
+  : null;
+const SCRUBBED_SYSTEM_PROMPT = _scrubSession
+  ? scrubText(SYSTEM_PROMPT, _scrubSession)
+  : SYSTEM_PROMPT;
+
 const LLM_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] =
   TOOL_DEFINITIONS.map((t) => ({
     type: "function" as const,
@@ -894,9 +908,10 @@ async function executeTool(name: string, input: any): Promise<any> {
 }
 
 async function runAgent(task: string) {
+  const userTask = _scrubSession ? scrubText(task, _scrubSession) : task;
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
-    { role: "system", content: SYSTEM_PROMPT },
-    { role: "user", content: task },
+    { role: "system", content: SCRUBBED_SYSTEM_PROMPT },
+    { role: "user", content: userTask },
   ];
   const toolCalls: Array<{ tool: string; input: any; result: any }> = [];
   let finalResponse = "";
@@ -1064,6 +1079,14 @@ app.post("/agent/run", async (req, res) => {
 // ============================================================
 
 const horizonServer = new Horizon.Server("https://horizon-testnet.stellar.org");
+
+// 413 handler — must be before Sentry so Sentry also captures it
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+  }
+  next(err);
+});
 
 // Sentry error handler must be registered AFTER all routes
 app.use(sentry.errorHandler());

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -103,7 +103,7 @@ function auditBill(lineItems: BillItem[]) {
 const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json());
+app.use(express.json({ limit: process.env.BILL_AUDIT_BODY_LIMIT ?? "256kb" }));
 
 app.get("/", (_req, res) => {
   res.json({
@@ -156,6 +156,13 @@ app.post("/bill/audit", (req, res) => {
       res.status(400).json({ error: "Invalid request body" });
     }
   }
+});
+
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+  }
+  next(err);
 });
 
 app.listen(PORT, () => {

--- a/services/drug-interaction-api/server.ts
+++ b/services/drug-interaction-api/server.ts
@@ -69,7 +69,7 @@ function checkInteractions(medications: string[]) {
 const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json());
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
 
 app.get("/", (_req, res) => {
   res.json({ service: "CareGuard Drug Interaction Check API", version: "1.0.0", protocol: "x402 on Stellar", network: NETWORK, payTo: PAY_TO, price: "$0.001 per check" });
@@ -89,6 +89,13 @@ app.get("/drug/interactions", (req, res) => {
   const medications = medsParam.split(",").map(m => m.trim()).filter(Boolean);
   if (medications.length < 2) { res.status(400).json({ error: "Need at least 2 medications" }); return; }
   res.json(checkInteractions(medications));
+});
+
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+  }
+  next(err);
 });
 
 app.listen(PORT, () => {

--- a/services/pharmacy-api/server.ts
+++ b/services/pharmacy-api/server.ts
@@ -31,7 +31,7 @@ const pricingProvider = createPricingProvider();
 const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json());
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
 
 // Unprotected endpoints
 app.get("/", async (_req, res) => {
@@ -102,6 +102,13 @@ app.get("/pharmacy/compare", async (req, res) => {
       drugCount: await pricingProvider.getDrugCount()
     });
   }
+});
+
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+  }
+  next(err);
 });
 
 app.listen(PORT, async () => {

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -51,7 +51,7 @@ function saveOrder(order: any) {
 const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json());
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
 
 app.get("/", (_req, res) => {
   res.json({
@@ -146,6 +146,13 @@ app.post("/pharmacy/order", async (req, res) => {
   response.headers.forEach((value: string, key: string) => res.setHeader(key, value));
   const responseBody = await response.json();
   res.status(response.status).json(responseBody);
+});
+
+app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+  }
+  next(err);
 });
 
 app.listen(PORT, () => {

--- a/shared/__tests__/prompt-scrub.test.ts
+++ b/shared/__tests__/prompt-scrub.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { buildScrubSession, scrubText } from "../prompt-scrub.ts";
+
+const SESSION = buildScrubSession(["Rosa Garcia"], ["Maria Garcia"]);
+
+describe("buildScrubSession", () => {
+  it("maps patient name to Patient A", () => {
+    expect(SESSION.realToAlias.get("Rosa Garcia")).toBe("Patient A");
+  });
+
+  it("maps caregiver name to Caregiver A", () => {
+    expect(SESSION.realToAlias.get("Maria Garcia")).toBe("Caregiver A");
+  });
+
+  it("builds inverse table for server-side cross-reference", () => {
+    expect(SESSION.aliasToReal.get("Patient A")).toBe("Rosa Garcia");
+    expect(SESSION.aliasToReal.get("Caregiver A")).toBe("Maria Garcia");
+  });
+
+  it("assigns sequential labels for multiple patients", () => {
+    const s = buildScrubSession(["Alice", "Bob"], []);
+    expect(s.realToAlias.get("Alice")).toBe("Patient A");
+    expect(s.realToAlias.get("Bob")).toBe("Patient B");
+  });
+});
+
+describe("scrubText", () => {
+  it("replaces Rosa Garcia with Patient A consistently across a run", () => {
+    const prompt = "Current care recipient: Rosa Garcia (age 78)";
+    const scrubbed = scrubText(prompt, SESSION);
+    expect(scrubbed).not.toContain("Rosa Garcia");
+    expect(scrubbed).toContain("Patient A");
+    // Second call with same session produces same result
+    expect(scrubText(prompt, SESSION)).toBe(scrubbed);
+  });
+
+  it("replaces Maria Garcia with Caregiver A", () => {
+    const prompt = "Caregiver: Maria Garcia (daughter)";
+    const scrubbed = scrubText(prompt, SESSION);
+    expect(scrubbed).not.toContain("Maria Garcia");
+    expect(scrubbed).toContain("Caregiver A");
+  });
+
+  it("preserves medication names — they are not PII", () => {
+    const prompt = "Patient A takes Lisinopril, Metformin, Atorvastatin";
+    const scrubbed = scrubText(prompt, SESSION);
+    expect(scrubbed).toContain("Lisinopril");
+    expect(scrubbed).toContain("Metformin");
+    expect(scrubbed).toContain("Atorvastatin");
+  });
+
+  it("leaves text unchanged when the session has no mappings", () => {
+    const empty = buildScrubSession([], []);
+    const text = "Rosa Garcia (age 78)";
+    expect(scrubText(text, empty)).toBe(text);
+  });
+
+  it("replaces all occurrences in a long prompt", () => {
+    const prompt = "Rosa Garcia visited. Rosa Garcia's doctor saw Rosa Garcia.";
+    const scrubbed = scrubText(prompt, SESSION);
+    expect(scrubbed).not.toContain("Rosa Garcia");
+    expect(scrubbed.match(/Patient A/g)?.length).toBe(3);
+  });
+});

--- a/shared/prompt-scrub.ts
+++ b/shared/prompt-scrub.ts
@@ -1,0 +1,50 @@
+/**
+ * PHI scrubbing for LLM prompts (issue #97).
+ *
+ * Replaces real patient/caregiver names with consistent pseudonyms before
+ * sending prompts to external LLM providers. A server-side mapping table
+ * lets agent tool calls still reference real wallet IDs and data — only the
+ * text sent to the LLM is pseudonymised.
+ *
+ * Disable via LLM_PII_SCRUB=false for providers with a signed BAA
+ * (e.g. enterprise OpenAI).
+ */
+
+const LABELS = ["A", "B", "C", "D", "E", "F", "G", "H"];
+
+export interface ScrubSession {
+  /** Maps a real name to its pseudonym (e.g. "Rosa Garcia" → "Patient A"). */
+  realToAlias: Map<string, string>;
+  /** Inverse map — kept server-side for cross-referencing tool results. */
+  aliasToReal: Map<string, string>;
+}
+
+export function buildScrubSession(
+  patients: string[],
+  caregivers: string[]
+): ScrubSession {
+  const realToAlias = new Map<string, string>();
+  const aliasToReal = new Map<string, string>();
+
+  patients.forEach((name, i) => {
+    const alias = `Patient ${LABELS[i] ?? String(i + 1)}`;
+    realToAlias.set(name, alias);
+    aliasToReal.set(alias, name);
+  });
+
+  caregivers.forEach((name, i) => {
+    const alias = `Caregiver ${LABELS[i] ?? String(i + 1)}`;
+    realToAlias.set(name, alias);
+    aliasToReal.set(alias, name);
+  });
+
+  return { realToAlias, aliasToReal };
+}
+
+export function scrubText(text: string, session: ScrubSession): string {
+  let out = text;
+  for (const [real, alias] of session.realToAlias) {
+    out = out.replaceAll(real, alias);
+  }
+  return out;
+}


### PR DESCRIPTION
  ## Summary

  - **#92** — Added explicit JSON body limits to all 6 Express servers (20 kb default via `JSON_BODY_LIMIT`, 256 kb for
  `/bill/audit` via `BILL_AUDIT_BODY_LIMIT`). Route-aware middleware in the unified server; per-server limits on
  microservices. 413 handlers return `{ error, limit }` JSON.
  - **#93** — Added Stellar signature hint verification in `payBill` (`agent/tools.ts`): after `stellarTx.sign()`,
  asserts `signatures[0].hint()` equals `agentKeypair.signatureHint()` before calling `submitTransaction`, preventing
  silent wallet mismatch.
  - **#95** — Added `docs/runbooks/rotate-secrets.md` covering all secrets (agent wallet, OZ API key, LLM key, MPP key,
  JWT dual-verify window, quarterly calendar) and `scripts/rotate-agent-wallet.ts` (dry-run by default, `--execute` to
  broadcast).
  - **#97** — Added `shared/prompt-scrub.ts` that replaces real patient/caregiver names with stable pseudonyms (`Patient
  A`, `Caregiver A`) before any text reaches the LLM. Applied in both `server.ts` and `agent/server.ts`. Bypass with
  `LLM_PII_SCRUB=false` for BAA-covered providers. Documented in `docs/SECURITY.md`.

  Also fixed a pre-existing bug in `agent/tools.ts`: `getLocalDateStr` was re-exported but not imported into module scope
   (ESM re-export limitation), causing 2 Spending Policy tests to fail. Fixed by adding an explicit `import` alongside
  the `export`.

  ## Test plan

  - [x] `npx vitest run agent/__tests__/body-limit.test.ts` — 5 tests (oversized → 413, small → 200, bill-audit 200 kb →
  200)
  - [x] `npx vitest run agent/__tests__/stellar-signature.test.ts` — 3 tests (matching hint → submit, wrong hint →
  refused, empty signatures → refused)
  - [x] `npx vitest run shared/__tests__/prompt-scrub.test.ts` — 9 tests (name replacement, medication names preserved,
  empty session passthrough)
  - [x] `npx vitest run agent/__tests__/tools.test.ts` — 11 tests all passing (including 2 Spending Policy tests that
  were previously failing)
  - [x] `npx tsx scripts/rotate-agent-wallet.ts` — dry-run prints new keypair and transfer plan without broadcasting

  Closes #92
  Closes #93
  Closes #95
  Closes #97