### PR TITLE
feat: resolve issues #79, #65, #42, #49

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feat'
+      - 'feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '📦 Maintenance'
+    labels:
+      - 'chore'
+      - 'deps'
+      - 'dependencies'
+  - title: '📚 Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'feat'
+      - 'feature'
+  patch:
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'chore'
+      - 'docs'
+      - 'security'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ---
+
+  **Docker image:** `ghcr.io/$GITHUB_REPOSITORY:$RESOLVED_VERSION`
+  **Deployment:** $RENDER_DEPLOY_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  draft-release:
+    name: Draft GitHub Release
+    runs-on: ubuntu-latest
+    outputs:
+      release-body: ${{ steps.release-drafter.outputs.body }}
+      tag-name: ${{ github.ref_name }}
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        id: release-drafter
+        with:
+          config-name: release-drafter.yml
+          publish: true
+          tag: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RENDER_DEPLOY_URL: ${{ vars.RENDER_DEPLOY_URL || 'https://careguard.onrender.com' }}
+
+  update-changelog:
+    name: Update CHANGELOG.md
+    runs-on: ubuntu-latest
+    needs: draft-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-changelog: ${{ needs.draft-release.outputs.release-body }}
+          release-notes-heading: ${{ needs.draft-release.outputs.tag-name }}
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update CHANGELOG.md for ${{ needs.draft-release.outputs.tag-name }}"
+          file_pattern: CHANGELOG.md
+          branch: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to CareGuard will be documented here.
+
+This file is auto-updated by the release workflow on each `v*` tag push.

--- a/agent/__tests__/agent-endpoints.test.ts
+++ b/agent/__tests__/agent-endpoints.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration tests for /agent/* endpoints (Issue #42).
+ *
+ * Tests the unified server (server.ts) via supertest.
+ * LLM is mocked via vi.hoisted so individual tests can chain mockResolvedValueOnce
+ * for deterministic multi-turn exchanges.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+
+// Capture LLM create mock reference before any module is imported
+const { createMock } = vi.hoisted(() => {
+  const createMock = vi.fn();
+  return { createMock };
+});
+
+vi.mock("dotenv/config", () => ({}));
+
+vi.mock("openai", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    chat: { completions: { create: createMock } },
+  })),
+}));
+
+vi.mock("../tools.ts", () => ({
+  comparePharmacyPrices: vi.fn(),
+  auditBill: vi.fn(),
+  fetchRosaBill: vi.fn(),
+  fetchAndAuditBill: vi.fn(),
+  checkDrugInteractions: vi.fn(),
+  payForMedication: vi.fn(),
+  payBill: vi.fn(),
+  checkSpendingPolicy: vi.fn(),
+  getSpendingSummary: vi.fn(() => ({
+    policy: {
+      dailyLimit: 100,
+      monthlyLimit: 500,
+      medicationMonthlyBudget: 300,
+      billMonthlyBudget: 500,
+      approvalThreshold: 75,
+    },
+    spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+    budgetRemaining: { medications: 300, bills: 500 },
+    transactionCount: 0,
+    recentTransactions: [],
+  })),
+  setSpendingPolicy: vi.fn(),
+  getSpendingTracker: vi.fn(() => ({ transactions: [], policy: {}, spending: {} })),
+  resetSpendingTracker: vi.fn(),
+  TOOL_DEFINITIONS: [],
+}));
+
+vi.mock("../../shared/x402-middleware.ts", () => ({
+  applyX402Middleware: vi.fn(),
+  OZ_FACILITATOR_URL: "https://channels.openzeppelin.com/x402/testnet",
+  DEFAULT_FACILITATOR_URL: "https://channels.openzeppelin.com/x402/testnet",
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Keypair: { fromSecret: vi.fn(() => ({ publicKey: () => "GMOCKAGENTWALLETPUBKEY123456" })) },
+  Horizon: { Server: vi.fn(() => ({ loadAccount: vi.fn() })) },
+}));
+
+vi.mock("mppx/server", () => ({
+  Mppx: { create: vi.fn(() => ({ charge: vi.fn(() => vi.fn()) })) },
+  Store: { memory: vi.fn() },
+}));
+vi.mock("@stellar/mpp/charge/server", () => ({ stellar: { charge: vi.fn() } }));
+vi.mock("@stellar/mpp", () => ({ USDC_SAC_TESTNET: "mock-sac-testnet" }));
+
+// Required env vars — set before server import to pass envSchema validation
+process.env.LLM_API_KEY = "test-llm-key";
+process.env.AGENT_SECRET_KEY = "SCZANGBA5YHTNYVS23C4QSOT45PZCBL2D4ZO5TSRE73UFYS3FMAJNMX";
+process.env.PHARMACY_1_PUBLIC_KEY = "GBQTESTPHARMACY1PUBKEY";
+process.env.BILL_PROVIDER_PUBLIC_KEY = "GBQTESTBILLPROVIDERPUBKEY";
+process.env.MPP_SECRET_KEY = "test-mpp-secret-key";
+
+const { app } = await import("../../server.ts");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pause / status / run-while-paused
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /agent/pause → GET /agent/status → POST /agent/run (Issue #42)", () => {
+  beforeEach(async () => {
+    await request(app).post("/agent/resume");
+  });
+
+  it("POST /agent/pause sets paused=true", async () => {
+    const res = await request(app).post("/agent/pause");
+    expect(res.status).toBe(200);
+    expect(res.body.paused).toBe(true);
+  });
+
+  it("GET /agent/status reflects paused state", async () => {
+    await request(app).post("/agent/pause");
+    const res = await request(app).get("/agent/status");
+    expect(res.status).toBe(200);
+    expect(res.body.paused).toBe(true);
+  });
+
+  it("POST /agent/run returns 409 when agent is paused", async () => {
+    await request(app).post("/agent/pause");
+    const res = await request(app)
+      .post("/agent/run")
+      .send({ task: "Compare medication prices" });
+    expect(res.status).toBe(409);
+    expect(res.body.paused).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resume
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /agent/resume (Issue #42)", () => {
+  it("clears paused state", async () => {
+    await request(app).post("/agent/pause");
+    const res = await request(app).post("/agent/resume");
+    expect(res.status).toBe(200);
+    expect(res.body.paused).toBe(false);
+  });
+
+  it("GET /agent/status shows paused=false after resume", async () => {
+    await request(app).post("/agent/pause");
+    await request(app).post("/agent/resume");
+    const res = await request(app).get("/agent/status");
+    expect(res.body.paused).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// run validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /agent/run — validation (Issue #42)", () => {
+  beforeEach(async () => {
+    await request(app).post("/agent/resume");
+  });
+
+  it("missing task → 400", async () => {
+    const res = await request(app).post("/agent/run").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it("empty string task → 400", async () => {
+    const res = await request(app).post("/agent/run").send({ task: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it("valid task + mocked LLM with 1 tool call → 200 with expected toolCalls array", async () => {
+    // First call: LLM returns a single tool call (get_spending_summary — no side effects)
+    createMock.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call-abc123",
+                type: "function",
+                function: { name: "get_spending_summary", arguments: "{}" },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    });
+    // Second call: LLM returns final response
+    createMock.mockResolvedValueOnce({
+      choices: [
+        {
+          message: { role: "assistant", content: "Task complete.", tool_calls: undefined },
+          finish_reason: "stop",
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post("/agent/run")
+      .send({ task: "What is the current spending summary?" });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.toolCalls)).toBe(true);
+    expect(res.body.toolCalls).toHaveLength(1);
+    expect(res.body.toolCalls[0].tool).toBe("get_spending_summary");
+    expect(res.body.response).toBe("Task complete.");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// policy
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /agent/policy (Issue #42)", () => {
+  const VALID_POLICY = {
+    dailyLimit: 150,
+    monthlyLimit: 600,
+    medicationMonthlyBudget: 350,
+    billMonthlyBudget: 550,
+    approvalThreshold: 80,
+  };
+
+  it("valid body → 200 with success: true", async () => {
+    const res = await request(app).post("/agent/policy").send(VALID_POLICY);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("invalid body (missing fields) → 400", async () => {
+    const res = await request(app).post("/agent/policy").send({ dailyLimit: 100 });
+    expect(res.status).toBe(400);
+  });
+
+  it("negative value → 400", async () => {
+    const res = await request(app)
+      .post("/agent/policy")
+      .send({ ...VALID_POLICY, dailyLimit: -10 });
+    expect(res.status).toBe(400);
+  });
+
+  it("zero value → 400", async () => {
+    const res = await request(app)
+      .post("/agent/policy")
+      .send({ ...VALID_POLICY, monthlyLimit: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it("non-object body → 400", async () => {
+    const res = await request(app)
+      .post("/agent/policy")
+      .set("Content-Type", "application/json")
+      .send('"just a string"');
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// reset
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("POST /agent/reset (Issue #42)", () => {
+  it("returns { success: true }", async () => {
+    const res = await request(app).post("/agent/reset");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("GET /agent/transactions returns empty transactions after reset", async () => {
+    await request(app).post("/agent/reset");
+    const res = await request(app).get("/agent/transactions");
+    expect(res.status).toBe(200);
+    expect(res.body.transactions).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API key header — with and without (Issue #42 + #10)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Agent endpoints — with and without X-API-Key header (Issue #42, #10)", () => {
+  it("GET /agent/status works without X-API-Key header", async () => {
+    const res = await request(app).get("/agent/status");
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /agent/status works with X-API-Key header (no auth required on agent routes)", async () => {
+    const res = await request(app)
+      .get("/agent/status")
+      .set("X-API-Key", "some-arbitrary-key");
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /agent/pause works without X-API-Key header", async () => {
+    const res = await request(app).post("/agent/resume");
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /agent/run returns 400 (validation) without X-API-Key header", async () => {
+    const res = await request(app).post("/agent/run").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /agent/run returns same status with X-API-Key header as without", async () => {
+    const withoutKey = await request(app).post("/agent/run").send({});
+    const withKey = await request(app)
+      .post("/agent/run")
+      .set("X-API-Key", "some-key")
+      .send({});
+    expect(withKey.status).toBe(withoutKey.status);
+  });
+});

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -445,7 +445,26 @@ const DEFAULT_PROFILE = {
   },
 };
 
-app.get("/agent/profile", (_req, res) => { res.json(DEFAULT_PROFILE); });
+let profileData = {
+  recipient: { ...DEFAULT_PROFILE.recipient, medications: [...DEFAULT_PROFILE.recipient.medications] },
+  caregiver: { ...DEFAULT_PROFILE.caregiver },
+};
+
+app.get("/agent/profile", (_req, res) => { res.json(profileData); });
+
+app.patch("/agent/profile", (req, res) => {
+  const { recipient, caregiver } = req.body ?? {};
+  if (recipient && typeof recipient === "object") {
+    profileData.recipient = { ...profileData.recipient, ...recipient };
+    if (Array.isArray(recipient.medications)) {
+      profileData.recipient.medications = recipient.medications;
+    }
+  }
+  if (caregiver && typeof caregiver === "object") {
+    profileData.caregiver = { ...profileData.caregiver, ...caregiver };
+  }
+  res.json(profileData);
+});
 
 // Startup: verify agent wallet has USDC balance
 async function verifyWallet() {

--- a/dashboard/src/__tests__/settings-tab.test.tsx
+++ b/dashboard/src/__tests__/settings-tab.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Component tests for SettingsTab (Issue #79).
+ * Runs in jsdom via environmentMatchGlobs in vitest.config.ts.
+ * Covers: load from props, edit mode, save, cancel, agent status display.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SettingsTab } from "../components/tabs/settings-tab";
+import type { SettingsTabProps } from "../components/tabs/settings-tab";
+
+const RECIPIENT = {
+  name: "Rosa Garcia",
+  age: 78,
+  medications: ["Lisinopril", "Metformin"],
+  doctor: "Dr. Chen, General Hospital",
+  insurance: "Medicare Part D",
+};
+
+const CAREGIVER = {
+  name: "Maria Garcia",
+  relationship: "Daughter",
+  location: "Phoenix, AZ",
+  notifications: "Email + SMS",
+};
+
+function buildProps(overrides: Partial<SettingsTabProps> = {}): SettingsTabProps {
+  return {
+    recipient: RECIPIENT,
+    caregiver: CAREGIVER,
+    agentInfo: null,
+    agentPaused: false,
+    onTogglePause: vi.fn(),
+    onUpdateProfile: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("SettingsTab — load from props (Issue #79)", () => {
+  it("renders recipient name from props (not hardcoded)", () => {
+    render(<SettingsTab {...buildProps()} />);
+    expect(screen.getByText("Rosa Garcia")).toBeTruthy();
+  });
+
+  it("renders caregiver name from props (not hardcoded)", () => {
+    render(<SettingsTab {...buildProps()} />);
+    expect(screen.getByText("Maria Garcia")).toBeTruthy();
+  });
+
+  it("renders medications from props", () => {
+    render(<SettingsTab {...buildProps()} />);
+    expect(screen.getByText(/Lisinopril/)).toBeTruthy();
+  });
+
+  it("renders doctor from props", () => {
+    render(<SettingsTab {...buildProps()} />);
+    expect(screen.getByText("Dr. Chen, General Hospital")).toBeTruthy();
+  });
+
+  it("renders insurance from props", () => {
+    render(<SettingsTab {...buildProps()} />);
+    expect(screen.getByText("Medicare Part D")).toBeTruthy();
+  });
+
+  it("shows Edit button in display mode", () => {
+    render(<SettingsTab {...buildProps()} />);
+    expect(screen.getByRole("button", { name: /Edit/i })).toBeTruthy();
+  });
+});
+
+describe("SettingsTab — edit mode (Issue #79)", () => {
+  it("shows inputs when Edit is clicked", () => {
+    render(<SettingsTab {...buildProps()} />);
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    expect(screen.getByLabelText(/Recipient Name/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Caregiver Name/i)).toBeTruthy();
+  });
+
+  it("pre-populates inputs with current prop values", () => {
+    render(<SettingsTab {...buildProps()} />);
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    const nameInput = screen.getByLabelText(/Recipient Name/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("Rosa Garcia");
+  });
+
+  it("pre-populates medications as comma-joined string", () => {
+    render(<SettingsTab {...buildProps()} />);
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    const medInput = screen.getByLabelText(/Medications/i) as HTMLInputElement;
+    expect(medInput.value).toBe("Lisinopril, Metformin");
+  });
+
+  it("Cancel reverts to display mode without calling onUpdateProfile", () => {
+    const onUpdateProfile = vi.fn();
+    render(<SettingsTab {...buildProps({ onUpdateProfile })} />);
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(onUpdateProfile).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /Edit/i })).toBeTruthy();
+  });
+});
+
+describe("SettingsTab — save (Issue #79)", () => {
+  it("calls onUpdateProfile with updated values on Save", async () => {
+    const onUpdateProfile = vi.fn().mockResolvedValue(undefined);
+    render(<SettingsTab {...buildProps({ onUpdateProfile })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    const nameInput = screen.getByLabelText(/Recipient Name/i);
+    fireEvent.change(nameInput, { target: { value: "Rosa M. Garcia" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipient: expect.objectContaining({ name: "Rosa M. Garcia" }),
+        }),
+      );
+    });
+  });
+
+  it("returns to display mode after successful save", async () => {
+    const onUpdateProfile = vi.fn().mockResolvedValue(undefined);
+    render(<SettingsTab {...buildProps({ onUpdateProfile })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Edit/i })).toBeTruthy();
+    });
+  });
+
+  it("passes caregiver fields to onUpdateProfile", async () => {
+    const onUpdateProfile = vi.fn().mockResolvedValue(undefined);
+    render(<SettingsTab {...buildProps({ onUpdateProfile })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    const relInput = screen.getByLabelText(/Relationship/i);
+    fireEvent.change(relInput, { target: { value: "Son" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          caregiver: expect.objectContaining({ relationship: "Son" }),
+        }),
+      );
+    });
+  });
+});
+
+describe("SettingsTab — agent status (Issue #79)", () => {
+  it("reads /agent/status via agentPaused prop — shows Paused + Resume button", () => {
+    render(<SettingsTab {...buildProps({ agentPaused: true })} />);
+    expect(screen.getByText("Paused")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Resume Agent/i })).toBeTruthy();
+  });
+
+  it("shows Active when agentPaused is false", () => {
+    render(<SettingsTab {...buildProps({ agentPaused: false })} />);
+    expect(screen.getByText("Active")).toBeTruthy();
+  });
+
+  it("calls onTogglePause when pause/resume button clicked", () => {
+    const onTogglePause = vi.fn();
+    render(<SettingsTab {...buildProps({ onTogglePause })} />);
+    fireEvent.click(screen.getByRole("button", { name: /Pause Agent/i }));
+    expect(onTogglePause).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/__tests__/wallet-tab.test.tsx
+++ b/dashboard/src/__tests__/wallet-tab.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * React tests for WalletTab (Issue #49).
+ * Runs in jsdom via environmentMatchGlobs in vitest.config.ts.
+ * Balances arrive as props from useAgentState — tested here via direct prop injection.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WalletTab } from "../components/tabs/wallet-tab";
+import type { WalletTabProps } from "../components/tabs/wallet-tab";
+
+const WALLET_ADDRESS = "GDTEST123WALLETADDRESS456ABCDEF";
+
+function buildProps(overrides: Partial<WalletTabProps> = {}): WalletTabProps {
+  return {
+    agentInfo: {
+      agentWallet: WALLET_ADDRESS,
+      llm: "groq/llama-3.3",
+      network: "stellar:testnet",
+    } as any,
+    walletBalance: "42.50",
+    walletXlm: "10.20",
+    ...overrides,
+  };
+}
+
+describe("WalletTab — balance display (Issue #49)", () => {
+  it("renders USDC balance at 2-decimal precision", () => {
+    render(<WalletTab {...buildProps({ walletBalance: "42.50" })} />);
+    expect(screen.getByText("$42.50")).toBeTruthy();
+  });
+
+  it("renders XLM balance at 2-decimal precision", () => {
+    render(<WalletTab {...buildProps({ walletXlm: "10.20" })} />);
+    expect(screen.getByText("10.20")).toBeTruthy();
+  });
+
+  it("missing USDC trustline (walletBalance=null) shows $0.00", () => {
+    render(<WalletTab {...buildProps({ walletBalance: null })} />);
+    expect(screen.getByText("$0.00")).toBeTruthy();
+  });
+
+  it("missing XLM (walletXlm=null) shows 0.00", () => {
+    render(<WalletTab {...buildProps({ walletXlm: null })} />);
+    // The XLM div shows just the value without $ prefix
+    expect(screen.getByText("0.00")).toBeTruthy();
+  });
+
+  it("walletBalance='0' renders as '$0' — nullish coalescing does not replace real zero", () => {
+    render(<WalletTab {...buildProps({ walletBalance: "0" })} />);
+    // With ?? the real value "0" is preserved; || would silently replace it with "0.00"
+    expect(screen.getByText("$0")).toBeTruthy();
+  });
+
+  it("Horizon error (both null) shows $0.00 placeholder for USDC", () => {
+    render(<WalletTab {...buildProps({ walletBalance: null, walletXlm: null })} />);
+    expect(screen.getByText("$0.00")).toBeTruthy();
+  });
+});
+
+describe("WalletTab — wallet address display (Issue #49)", () => {
+  it("renders wallet address", () => {
+    render(<WalletTab {...buildProps()} />);
+    expect(screen.getByText(WALLET_ADDRESS)).toBeTruthy();
+  });
+
+  it("shows 'Not connected' when agentInfo is null", () => {
+    render(<WalletTab {...buildProps({ agentInfo: null })} />);
+    expect(screen.getAllByText("Not connected").length).toBeGreaterThan(0);
+  });
+});
+
+// Mock copyText so we don't depend on jsdom's clipboard/isSecureContext quirks.
+// The copyText implementation is tested separately in clipboard.test.ts.
+const { copyTextMock } = vi.hoisted(() => ({
+  copyTextMock: vi.fn().mockResolvedValue("ok" as const),
+}));
+vi.mock("../lib/clipboard", () => ({
+  copyText: copyTextMock,
+}));
+
+describe("WalletTab — copy button (Issue #49)", () => {
+  beforeEach(() => {
+    copyTextMock.mockClear();
+    copyTextMock.mockResolvedValue("ok");
+  });
+
+  it("Copy button writes wallet address to clipboard (mocked)", async () => {
+    const user = userEvent.setup();
+    render(<WalletTab {...buildProps()} />);
+    await user.click(screen.getByRole("button", { name: /Copy/i }));
+    expect(copyTextMock).toHaveBeenCalledWith(WALLET_ADDRESS);
+  });
+
+  it("Copy button shows 'Copied' text after click", async () => {
+    const user = userEvent.setup();
+    render(<WalletTab {...buildProps()} />);
+    await user.click(screen.getByRole("button", { name: /Copy/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Copied")).toBeTruthy();
+    });
+  });
+});
+
+describe("WalletTab — Stellar Explorer link (Issue #49)", () => {
+  it("View on Stellar Explorer link points at correct URL", () => {
+    render(<WalletTab {...buildProps()} />);
+    const link = screen.getByRole("link", { name: /View on Stellar Explorer/i }) as HTMLAnchorElement;
+    expect(link.href).toBe(
+      `https://stellar.expert/explorer/testnet/account/${WALLET_ADDRESS}`,
+    );
+  });
+
+  it("Explorer link is not rendered when agentInfo is null", () => {
+    render(<WalletTab {...buildProps({ agentInfo: null })} />);
+    expect(screen.queryByRole("link", { name: /View on Stellar Explorer/i })).toBeNull();
+  });
+
+  it("Explorer link opens in new tab", () => {
+    render(<WalletTab {...buildProps()} />);
+    const link = screen.getByRole("link", { name: /View on Stellar Explorer/i }) as HTMLAnchorElement;
+    expect(link.target).toBe("_blank");
+    expect(link.rel).toContain("noopener");
+  });
+});

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -20,7 +20,7 @@ import { useAgentState } from "../hooks/use-agent-state";
 import { useProfile } from "../lib/useProfile";
 
 export default function Dashboard() {
-  const { recipient } = useProfile();
+  const { recipient, caregiver, updateProfile } = useProfile();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -128,9 +128,11 @@ export default function Dashboard() {
         {activeTab === "settings" && (
           <SettingsTab
             recipient={recipient}
+            caregiver={caregiver}
             agentInfo={state.agentInfo}
             agentPaused={state.agentPaused}
             onTogglePause={state.togglePause}
+            onUpdateProfile={updateProfile}
           />
         )}
       </div>

--- a/dashboard/src/components/tabs/settings-tab.tsx
+++ b/dashboard/src/components/tabs/settings-tab.tsx
@@ -2,26 +2,84 @@
 
 import { useState } from "react";
 import { copyText } from "../../lib/clipboard";
-import type { RecipientProfile } from "../../lib/types";
+import type { CaregiverProfile, RecipientProfile } from "../../lib/types";
 import { Toast } from "../primitives/toast";
 import type { AgentInfo } from "../types";
 
 export interface SettingsTabProps {
   recipient: RecipientProfile;
+  caregiver: CaregiverProfile;
   agentInfo: AgentInfo | null;
   agentPaused: boolean;
   onTogglePause: () => void;
+  onUpdateProfile: (patch: {
+    recipient?: Partial<RecipientProfile>;
+    caregiver?: Partial<CaregiverProfile>;
+  }) => Promise<void>;
 }
 
 export function SettingsTab({
   recipient,
+  caregiver,
   agentInfo,
   agentPaused,
   onTogglePause,
+  onUpdateProfile,
 }: SettingsTabProps) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [toastFallback, setToastFallback] = useState<string | undefined>(undefined);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    recipientName: "",
+    recipientAge: "",
+    medications: "",
+    doctor: "",
+    insurance: "",
+    caregiverName: "",
+    relationship: "",
+    location: "",
+    notifications: "",
+  });
+
+  const startEditing = () => {
+    setForm({
+      recipientName: recipient.name,
+      recipientAge: String(recipient.age ?? ""),
+      medications: (recipient.medications ?? []).join(", "),
+      doctor: recipient.doctor ?? "",
+      insurance: recipient.insurance ?? "",
+      caregiverName: caregiver.name,
+      relationship: caregiver.relationship ?? "",
+      location: caregiver.location ?? "",
+      notifications: caregiver.notifications ?? "",
+    });
+    setEditing(true);
+  };
+
+  const cancelEditing = () => setEditing(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    await onUpdateProfile({
+      recipient: {
+        name: form.recipientName.trim() || recipient.name,
+        age: form.recipientAge ? Number(form.recipientAge) : recipient.age,
+        medications: form.medications.split(",").map((m) => m.trim()).filter(Boolean),
+        doctor: form.doctor.trim() || recipient.doctor,
+        insurance: form.insurance.trim() || recipient.insurance,
+      },
+      caregiver: {
+        name: form.caregiverName.trim() || caregiver.name,
+        relationship: form.relationship.trim() || caregiver.relationship,
+        location: form.location.trim() || caregiver.location,
+        notifications: form.notifications.trim() || caregiver.notifications,
+      },
+    });
+    setSaving(false);
+    setEditing(false);
+  };
 
   const handleCopy = async (text: string, id: string) => {
     const result = await copyText(text);
@@ -33,6 +91,9 @@ export function SettingsTab({
     setToastMsg("Couldn't copy. Press Ctrl+C.");
     setToastFallback(text);
   };
+
+  const readClass = "px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm";
+  const editClass = "px-3 py-2 bg-white border border-sky-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-sky-500";
 
   return (
     <div
@@ -51,49 +112,85 @@ export function SettingsTab({
         }}
       />
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">
-          Care Recipient
-        </h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-slate-700">Care Recipient</h2>
+          {!editing && (
+            <button
+              onClick={startEditing}
+              className="px-3 py-1.5 text-xs font-medium bg-sky-50 text-sky-700 border border-sky-200 rounded-lg hover:bg-sky-100 cursor-pointer transition-all"
+            >
+              Edit
+            </button>
+          )}
+        </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Name
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              {recipient.name}
-            </div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Name</label>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.recipientName}
+                onChange={(e) => setForm((f) => ({ ...f, recipientName: e.target.value }))}
+                aria-label="Recipient Name"
+              />
+            ) : (
+              <div className={readClass}>{recipient.name}</div>
+            )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Age
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              {recipient.age ?? "N/A"}
-            </div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Age</label>
+            {editing ? (
+              <input
+                type="number"
+                className={editClass}
+                value={form.recipientAge}
+                onChange={(e) => setForm((f) => ({ ...f, recipientAge: e.target.value }))}
+                aria-label="Recipient Age"
+              />
+            ) : (
+              <div className={readClass}>{recipient.age ?? "N/A"}</div>
+            )}
           </div>
           <div className="col-span-2">
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              Medications
+              Medications (comma-separated)
             </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Lisinopril, Metformin, Atorvastatin, Amlodipine
-            </div>
+            {editing ? (
+              <input
+                className={editClass + " w-full"}
+                value={form.medications}
+                onChange={(e) => setForm((f) => ({ ...f, medications: e.target.value }))}
+                aria-label="Medications"
+              />
+            ) : (
+              <div className={readClass}>{(recipient.medications ?? []).join(", ")}</div>
+            )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Primary Doctor
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Dr. Chen, {recipient.facility || "General Hospital"}
-            </div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Primary Doctor</label>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.doctor}
+                onChange={(e) => setForm((f) => ({ ...f, doctor: e.target.value }))}
+                aria-label="Primary Doctor"
+              />
+            ) : (
+              <div className={readClass}>{recipient.doctor ?? "N/A"}</div>
+            )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Insurance
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Medicare Part D
-            </div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Insurance</label>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.insurance}
+                onChange={(e) => setForm((f) => ({ ...f, insurance: e.target.value }))}
+                aria-label="Insurance"
+              />
+            ) : (
+              <div className={readClass}>{recipient.insurance ?? "N/A"}</div>
+            )}
           </div>
         </div>
       </div>
@@ -102,49 +199,84 @@ export function SettingsTab({
         <h2 className="text-sm font-semibold text-slate-700 mb-4">Caregiver</h2>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Name
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Maria Garcia
-            </div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Name</label>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.caregiverName}
+                onChange={(e) => setForm((f) => ({ ...f, caregiverName: e.target.value }))}
+                aria-label="Caregiver Name"
+              />
+            ) : (
+              <div className={readClass}>{caregiver.name}</div>
+            )}
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Relationship</label>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.relationship}
+                onChange={(e) => setForm((f) => ({ ...f, relationship: e.target.value }))}
+                aria-label="Relationship"
+              />
+            ) : (
+              <div className={readClass}>{caregiver.relationship ?? "N/A"}</div>
+            )}
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Location</label>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.location}
+                onChange={(e) => setForm((f) => ({ ...f, location: e.target.value }))}
+                aria-label="Location"
+              />
+            ) : (
+              <div className={readClass}>{caregiver.location ?? "N/A"}</div>
+            )}
           </div>
           <div>
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              Relationship
+              Notification Channel
             </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Daughter
-            </div>
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Location
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Phoenix, AZ (800 miles from Rosa)
-            </div>
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Notifications
-            </label>
-            <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
-              Email + SMS
-            </div>
+            {editing ? (
+              <input
+                className={editClass}
+                value={form.notifications}
+                onChange={(e) => setForm((f) => ({ ...f, notifications: e.target.value }))}
+                aria-label="Notification Channel"
+              />
+            ) : (
+              <div className={readClass}>{caregiver.notifications ?? "N/A"}</div>
+            )}
           </div>
         </div>
+        {editing && (
+          <div className="flex justify-end gap-3 mt-4">
+            <button
+              onClick={cancelEditing}
+              className="px-4 py-2 rounded-lg text-sm font-medium cursor-pointer bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 rounded-lg text-sm font-medium cursor-pointer bg-sky-500 text-white hover:bg-sky-600 disabled:opacity-50 transition-all"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">
-          Agent Configuration
-        </h2>
+        <h2 className="text-sm font-semibold text-slate-700 mb-4">Agent Configuration</h2>
         <div className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Agent Status
-            </label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Agent Status</label>
             <div className="flex items-center gap-2">
               <div
                 className={`px-3 py-2 flex-1 bg-slate-50 border border-slate-200 rounded-lg text-sm ${agentPaused ? "text-amber-600" : "text-green-600"}`}
@@ -160,34 +292,26 @@ export function SettingsTab({
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              LLM Provider
-            </label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">LLM Provider</label>
             <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-mono">
               {agentInfo?.llm || "Not connected"}
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Network
-            </label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Network</label>
             <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
               {agentInfo?.network || "stellar:testnet"}
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">
-              Agent Wallet
-            </label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">Agent Wallet</label>
             <div className="flex items-center gap-2">
               <code className="flex-1 px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-mono break-all">
                 {agentInfo?.agentWallet || "Not connected"}
               </code>
               {agentInfo?.agentWallet && (
                 <button
-                  onClick={() =>
-                    handleCopy(agentInfo.agentWallet, "settings-wallet")
-                  }
+                  onClick={() => handleCopy(agentInfo.agentWallet, "settings-wallet")}
                   className={`px-3 py-2 rounded-lg text-xs font-medium transition-all cursor-pointer ${copiedId === "settings-wallet" ? "bg-green-100 text-green-700" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}
                 >
                   {copiedId === "settings-wallet" ? "Copied" : "Copy"}

--- a/dashboard/src/components/tabs/wallet-tab.tsx
+++ b/dashboard/src/components/tabs/wallet-tab.tsx
@@ -53,13 +53,13 @@ export function WalletTab({ agentInfo, walletBalance, walletXlm }: WalletTabProp
         <div className="grid grid-cols-2 gap-4 mb-6">
           <div className="bg-sky-50 rounded-lg p-4 text-center border border-sky-200">
             <div className="text-2xl font-bold text-sky-700">
-              ${walletBalance || "0.00"}
+              ${walletBalance ?? "0.00"}
             </div>
             <div className="text-xs text-slate-500 mt-1">USDC Balance</div>
           </div>
           <div className="bg-slate-50 rounded-lg p-4 text-center border border-slate-200">
             <div className="text-2xl font-bold text-slate-700">
-              {walletXlm || "0.00"}
+              {walletXlm ?? "0.00"}
             </div>
             <div className="text-xs text-slate-500 mt-1">XLM Balance</div>
           </div>

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -98,5 +98,15 @@ export type RecipientProfile = {
   name: string;
   age?: number;
   facility?: string;
+  medications?: string[];
+  doctor?: string;
+  insurance?: string;
+};
+
+export type CaregiverProfile = {
+  name: string;
+  relationship?: string;
+  location?: string;
+  notifications?: string;
 };
 

--- a/dashboard/src/lib/useProfile.ts
+++ b/dashboard/src/lib/useProfile.ts
@@ -1,16 +1,27 @@
-import { useEffect, useState } from "react";
-import type { RecipientProfile } from "./types";
+import { useCallback, useEffect, useState } from "react";
+import type { CaregiverProfile, RecipientProfile } from "./types";
 
 const AGENT_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3004";
 
-const DEFAULT_PROFILE: RecipientProfile = {
+const DEFAULT_RECIPIENT: RecipientProfile = {
   name: "Rosa Garcia",
   age: 78,
   facility: "General Hospital",
+  medications: ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"],
+  doctor: "Dr. Chen, General Hospital",
+  insurance: "Medicare Part D",
+};
+
+const DEFAULT_CAREGIVER: CaregiverProfile = {
+  name: "Maria Garcia",
+  relationship: "Daughter",
+  location: "Phoenix, AZ (800 miles from Rosa)",
+  notifications: "Email + SMS",
 };
 
 export function useProfile() {
-  const [recipient, setRecipient] = useState<RecipientProfile>(DEFAULT_PROFILE);
+  const [recipient, setRecipient] = useState<RecipientProfile>(DEFAULT_RECIPIENT);
+  const [caregiver, setCaregiver] = useState<CaregiverProfile>(DEFAULT_CAREGIVER);
 
   useEffect(() => {
     let mounted = true;
@@ -18,15 +29,26 @@ export function useProfile() {
       try {
         const res = await fetch(`${AGENT_URL}/agent/profile`);
         if (!res.ok) return;
-        const data = (await res.json()) as Partial<RecipientProfile>;
+        const data = await res.json();
         if (!mounted) return;
+        const r = data.recipient ?? {};
+        const c = data.caregiver ?? {};
         setRecipient({
-          name: data.name?.trim() || DEFAULT_PROFILE.name,
-          age: typeof data.age === "number" ? data.age : DEFAULT_PROFILE.age,
-          facility: data.facility?.trim() || DEFAULT_PROFILE.facility,
+          name: r.name?.trim() || DEFAULT_RECIPIENT.name,
+          age: typeof r.age === "number" ? r.age : DEFAULT_RECIPIENT.age,
+          facility: r.facility?.trim() || DEFAULT_RECIPIENT.facility,
+          medications: Array.isArray(r.medications) ? r.medications : DEFAULT_RECIPIENT.medications,
+          doctor: r.doctor?.trim() || DEFAULT_RECIPIENT.doctor,
+          insurance: r.insurance?.trim() || DEFAULT_RECIPIENT.insurance,
+        });
+        setCaregiver({
+          name: c.name?.trim() || DEFAULT_CAREGIVER.name,
+          relationship: c.relationship?.trim() || DEFAULT_CAREGIVER.relationship,
+          location: c.location?.trim() || DEFAULT_CAREGIVER.location,
+          notifications: c.notifications?.trim() || DEFAULT_CAREGIVER.notifications,
         });
       } catch {
-        // Keep default profile for dashboard demo mode.
+        // Keep defaults for dashboard demo mode.
       }
     };
     fetchProfile();
@@ -35,5 +57,33 @@ export function useProfile() {
     };
   }, []);
 
-  return { recipient };
+  const updateProfile = useCallback(
+    async (patch: {
+      recipient?: Partial<RecipientProfile>;
+      caregiver?: Partial<CaregiverProfile>;
+    }) => {
+      const prevRecipient = recipient;
+      const prevCaregiver = caregiver;
+      // Optimistic update
+      if (patch.recipient) setRecipient((p) => ({ ...p, ...patch.recipient }));
+      if (patch.caregiver) setCaregiver((p) => ({ ...p, ...patch.caregiver }));
+      try {
+        const res = await fetch(`${AGENT_URL}/agent/profile`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(patch),
+        });
+        if (!res.ok) {
+          setRecipient(prevRecipient);
+          setCaregiver(prevCaregiver);
+        }
+      } catch {
+        setRecipient(prevRecipient);
+        setCaregiver(prevCaregiver);
+      }
+    },
+    [recipient, caregiver],
+  );
+
+  return { recipient, caregiver, updateProfile };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.0",
@@ -43,6 +44,8 @@
         "ioredis-mock": "^8.9.0",
         "jsdom": "^25.0.0",
         "pino-pretty": "^13.1.3",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "supertest": "^7.2.2",
         "typescript": "5.8.3",
         "vitest": "^2.1.8"
@@ -2311,6 +2314,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2384,6 +2407,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.1.0.tgz",
       "integrity": "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -3635,6 +3665,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -4730,6 +4767,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5298,6 +5345,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -5423,6 +5498,36 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5676,6 +5781,13 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
@@ -57,6 +58,8 @@
     "ioredis-mock": "^8.9.0",
     "jsdom": "^25.0.0",
     "pino-pretty": "^13.1.3",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "supertest": "^7.2.2",
     "typescript": "5.8.3",
     "vitest": "^2.1.8"

--- a/server.ts
+++ b/server.ts
@@ -118,6 +118,27 @@ const agentKeypair = Keypair.fromSecret(env.data.AGENT_SECRET_KEY);
 const MAX_TOOL_CALLS_PER_RUN = parseInt(process.env.MAX_TOOL_CALLS_PER_RUN || "30", 10);
 let toolCallCapHitsTotal = 0;
 
+// --- Mutable profile (issue #79) ---
+const _DEFAULT_PROFILE = {
+  recipient: {
+    name: "Rosa Garcia",
+    age: 78,
+    medications: ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"],
+    doctor: "Dr. Chen, General Hospital",
+    insurance: "Medicare Part D",
+  },
+  caregiver: {
+    name: "Maria Garcia",
+    relationship: "Daughter",
+    location: "Phoenix, AZ (800 miles from Rosa)",
+    notifications: "Email + SMS",
+  },
+};
+let _profileData = {
+  recipient: { ..._DEFAULT_PROFILE.recipient, medications: [..._DEFAULT_PROFILE.recipient.medications] },
+  caregiver: { ..._DEFAULT_PROFILE.caregiver },
+};
+
 // --- Express App ---
 const app = express();
 const sentry = await initSentry({ service: "careguard-server" });
@@ -191,6 +212,23 @@ app.get("/ready", async (_req, res) => {
 
   const allOk = Object.values(checks).every((v) => v === true);
   res.status(allOk ? 200 : 503).json({ status: allOk ? "ok" : "degraded", checks });
+});
+
+// --- Profile (issue #79) ---
+app.get("/agent/profile", (_req, res) => { res.json(_profileData); });
+
+app.patch("/agent/profile", (req, res) => {
+  const { recipient, caregiver } = req.body ?? {};
+  if (recipient && typeof recipient === "object") {
+    _profileData.recipient = { ..._profileData.recipient, ...recipient };
+    if (Array.isArray(recipient.medications)) {
+      _profileData.recipient.medications = recipient.medications;
+    }
+  }
+  if (caregiver && typeof caregiver === "object") {
+    _profileData.caregiver = { ..._profileData.caregiver, ...caregiver };
+  }
+  res.json(_profileData);
 });
 
 // ============================================================
@@ -1078,8 +1116,19 @@ app.get("/agent/transactions", (req, res) => {
   });
 });
 app.post("/agent/policy", (req, res) => {
-  setSpendingPolicy(req.body);
-  res.json({ success: true, policy: req.body });
+  const body = req.body;
+  if (!body || typeof body !== "object") {
+    return res.status(400).json({ error: "Invalid policy" });
+  }
+  const fields = ["dailyLimit", "monthlyLimit", "medicationMonthlyBudget", "billMonthlyBudget", "approvalThreshold"] as const;
+  const errors: string[] = [];
+  for (const f of fields) {
+    const v = body[f];
+    if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) errors.push(`${f} must be a positive finite number`);
+  }
+  if (errors.length > 0) return res.status(400).json({ error: "Invalid policy", details: errors });
+  setSpendingPolicy(body);
+  res.json({ success: true, policy: body });
 });
 app.post("/agent/reset", (_req, res) => {
   resetSpendingTracker();


### PR DESCRIPTION
 Closes #79
  Closes #65
  Closes #42
  Closes #49

  ## What changed

  ### #79 — Settings tab wired to backend
  - `agent/server.ts` + `server.ts`: `DEFAULT_PROFILE` made mutable; `PATCH /agent/profile` added (deep merge,
  partial updates keep unset fields)
  `CaregiverProfile` type added
  - `dashboard/src/lib/useProfile.ts`: maps nested `data.recipient.*` correctly (was flat `data.*`); exposes
  `caregiver` state + `updateProfile()` with optimistic update and rollback on error
  - `settings-tab.tsx`: all hardcoded strings replaced with prop-driven values; Edit/Save/Cancel flow; reads
  `/agent/status` via `agentPaused` prop
  - `dashboard/src/__tests__/settings-tab.test.tsx`: 16 tests — load from props, edit mode, save, cancel, agent
  status
  
  ### #49 — Wallet tab React tests
  - `wallet-tab.tsx`: `||` → `??` for balance fallback (fixes silent coercion of `"0"` → `"0.00"`)
  - `dashboard/src/__tests__/wallet-tab.test.tsx`: 13 tests — 2-decimal balances, null/missing trustline,
  clipboard copy (mocked), Stellar Explorer link URL
  
  ### #42 — Integration tests for /agent/* endpoints
  - `agent/__tests__/agent-endpoints.test.ts`: 20 supertest tests — pause/status/run-409, resume, run-400,
  run-200-with-toolCalls (mocked LLM via `vi.hoisted`), policy-valid, policy-invalid, reset, with/without
  run-200-with-toolCalls (mocked LLM via `vi.hoisted`), policy-valid, policy-invalid, reset, with/without
  `X-API-Key` header
  - `server.ts` `/agent/policy`: added input validation (was missing; now matches `agent/server.ts`)

  ### #65 — Release workflow
  - `.github/workflows/release.yml`: triggers on `v*` tag; publishes GitHub Release via release-drafter, then
  commits updated `CHANGELOG.md` via `stefanzweifel/changelog-updater-action`
  - `.github/release-drafter.yml`: groups PRs by label (feat / fix / security / chore / docs)
  - `CHANGELOG.md`: initial file, auto-populated on first `v*` tag push

  ---
  Here's a summary of everything done:

  49 new tests added across 3 files, all passing. No pre-existing passing tests broken (baseline had 10
  pre-existing failures; with changes: 8 failures, all pre-existing).

  - #79: Settings tab now reads from /agent/profile (GET+PATCH), caregiver data is no longer hardcoded,
  Edit/Save/Cancel UX with optimistic rollback
  - #49: Wallet || → ?? bug fixed + 13 component tests covering balances, copy button, explorer link
  - #42: 20 integration tests for all /agent/* endpoints including mocked LLM tool-call flow; /agent/policy
  validation gap in unified server also fixed
  - #65: Release drafter + CHANGELOG updater workflow ready for first v* tag