### PR TITLE
Fixws Issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,12 +52,16 @@ LLM_BASE_URL=https://api.groq.com/openai/v1
 LLM_API_KEY=
 LLM_MODEL=llama-3.3-70b-versatile
 
+# --- Caregiver API Auth ---
+# Required Bearer token for every /agent/* request.
+# Generate with: openssl rand -hex 32
+CAREGIVER_TOKEN=
+
 # --- USDC on Stellar Testnet ---
 USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 
 # --- CORS ---
-# Comma-separated list of allowed origins (production only).
-# In dev (NODE_ENV != production) all origins are allowed with a warning.
+# Comma-separated list of allowed dashboard origins.
 # Example: ALLOWED_ORIGINS=https://careguard.vercel.app,https://staging.careguard.vercel.app
 ALLOWED_ORIGINS=http://localhost:3000
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/audit.log.jsonl
 data/spending.json
 data/orders.json
 .DS_Store
+fix.md

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -58,6 +58,14 @@ Fill in these required values:
 | `MPP_SECRET_KEY` | Run: `openssl rand -hex 32` |
 | `LLM_API_KEY` | [console.groq.com](https://console.groq.com) (or any OpenAI-compatible provider) |
 
+For the dashboard, copy `.env.local.example` to `.env.local` and edit it if your agent API runs on a different URL:
+
+```bash
+cd dashboard
+cp .env.local.example .env.local
+cd ..
+```
+
 ---
 
 ## Step 4: Fund Agent with Testnet USDC

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,9 @@
+# CareGuard Agent
+
+The CareGuard agent coordinates healthcare spending with LLM tool-use and Stellar payments.
+
+## Billing Data
+
+Never invent. The only billing data source is fetch_rosa_bill, which returns a sample bill for the demo. In production this is replaced with real EDI feeds.
+
+When auditing Rosa's bill, the agent should use `fetch_and_audit_bill`, which fetches the sample bill and audits it in one step. The agent must not fabricate bill line items, totals, overcharges, or corrected amounts outside data returned by the billing tools.

--- a/agent/__tests__/agent-endpoints.test.ts
+++ b/agent/__tests__/agent-endpoints.test.ts
@@ -74,8 +74,10 @@ process.env.AGENT_SECRET_KEY = "SCZANGBA5YHTNYVS23C4QSOT45PZCBL2D4ZO5TSRE73UFYS3
 process.env.PHARMACY_1_PUBLIC_KEY = "GBQTESTPHARMACY1PUBKEY";
 process.env.BILL_PROVIDER_PUBLIC_KEY = "GBQTESTBILLPROVIDERPUBKEY";
 process.env.MPP_SECRET_KEY = "test-mpp-secret-key";
+process.env.CAREGIVER_TOKEN = "test-caregiver-token";
 
 const { app } = await import("../../server.ts");
+const auth = (req: any) => req.set("Authorization", "Bearer test-caregiver-token");
 
 // ─────────────────────────────────────────────────────────────────────────────
 // pause / status / run-while-paused
@@ -83,26 +85,25 @@ const { app } = await import("../../server.ts");
 
 describe("POST /agent/pause → GET /agent/status → POST /agent/run (Issue #42)", () => {
   beforeEach(async () => {
-    await request(app).post("/agent/resume");
+    await auth(request(app).post("/agent/resume"));
   });
 
   it("POST /agent/pause sets paused=true", async () => {
-    const res = await request(app).post("/agent/pause");
+    const res = await auth(request(app).post("/agent/pause"));
     expect(res.status).toBe(200);
     expect(res.body.paused).toBe(true);
   });
 
   it("GET /agent/status reflects paused state", async () => {
-    await request(app).post("/agent/pause");
-    const res = await request(app).get("/agent/status");
+    await auth(request(app).post("/agent/pause"));
+    const res = await auth(request(app).get("/agent/status"));
     expect(res.status).toBe(200);
     expect(res.body.paused).toBe(true);
   });
 
   it("POST /agent/run returns 409 when agent is paused", async () => {
-    await request(app).post("/agent/pause");
-    const res = await request(app)
-      .post("/agent/run")
+    await auth(request(app).post("/agent/pause"));
+    const res = await auth(request(app).post("/agent/run"))
       .send({ task: "Compare medication prices" });
     expect(res.status).toBe(409);
     expect(res.body.paused).toBe(true);
@@ -115,16 +116,16 @@ describe("POST /agent/pause → GET /agent/status → POST /agent/run (Issue #42
 
 describe("POST /agent/resume (Issue #42)", () => {
   it("clears paused state", async () => {
-    await request(app).post("/agent/pause");
-    const res = await request(app).post("/agent/resume");
+    await auth(request(app).post("/agent/pause"));
+    const res = await auth(request(app).post("/agent/resume"));
     expect(res.status).toBe(200);
     expect(res.body.paused).toBe(false);
   });
 
   it("GET /agent/status shows paused=false after resume", async () => {
-    await request(app).post("/agent/pause");
-    await request(app).post("/agent/resume");
-    const res = await request(app).get("/agent/status");
+    await auth(request(app).post("/agent/pause"));
+    await auth(request(app).post("/agent/resume"));
+    const res = await auth(request(app).get("/agent/status"));
     expect(res.body.paused).toBe(false);
   });
 });
@@ -135,17 +136,17 @@ describe("POST /agent/resume (Issue #42)", () => {
 
 describe("POST /agent/run — validation (Issue #42)", () => {
   beforeEach(async () => {
-    await request(app).post("/agent/resume");
+    await auth(request(app).post("/agent/resume"));
   });
 
   it("missing task → 400", async () => {
-    const res = await request(app).post("/agent/run").send({});
+    const res = await auth(request(app).post("/agent/run")).send({});
     expect(res.status).toBe(400);
     expect(res.body.error).toBeTruthy();
   });
 
   it("empty string task → 400", async () => {
-    const res = await request(app).post("/agent/run").send({ task: "" });
+    const res = await auth(request(app).post("/agent/run")).send({ task: "" });
     expect(res.status).toBe(400);
   });
 
@@ -179,8 +180,7 @@ describe("POST /agent/run — validation (Issue #42)", () => {
       ],
     });
 
-    const res = await request(app)
-      .post("/agent/run")
+    const res = await auth(request(app).post("/agent/run"))
       .send({ task: "What is the current spending summary?" });
 
     expect(res.status).toBe(200);
@@ -205,33 +205,30 @@ describe("POST /agent/policy (Issue #42)", () => {
   };
 
   it("valid body → 200 with success: true", async () => {
-    const res = await request(app).post("/agent/policy").send(VALID_POLICY);
+    const res = await auth(request(app).post("/agent/policy")).send(VALID_POLICY);
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
   });
 
   it("invalid body (missing fields) → 400", async () => {
-    const res = await request(app).post("/agent/policy").send({ dailyLimit: 100 });
+    const res = await auth(request(app).post("/agent/policy")).send({ dailyLimit: 100 });
     expect(res.status).toBe(400);
   });
 
   it("negative value → 400", async () => {
-    const res = await request(app)
-      .post("/agent/policy")
+    const res = await auth(request(app).post("/agent/policy"))
       .send({ ...VALID_POLICY, dailyLimit: -10 });
     expect(res.status).toBe(400);
   });
 
   it("zero value → 400", async () => {
-    const res = await request(app)
-      .post("/agent/policy")
+    const res = await auth(request(app).post("/agent/policy"))
       .send({ ...VALID_POLICY, monthlyLimit: 0 });
     expect(res.status).toBe(400);
   });
 
   it("non-object body → 400", async () => {
-    const res = await request(app)
-      .post("/agent/policy")
+    const res = await auth(request(app).post("/agent/policy"))
       .set("Content-Type", "application/json")
       .send('"just a string"');
     expect(res.status).toBe(400);
@@ -244,14 +241,14 @@ describe("POST /agent/policy (Issue #42)", () => {
 
 describe("POST /agent/reset (Issue #42)", () => {
   it("returns { success: true }", async () => {
-    const res = await request(app).post("/agent/reset");
+    const res = await auth(request(app).post("/agent/reset"));
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
   });
 
   it("GET /agent/transactions returns empty transactions after reset", async () => {
-    await request(app).post("/agent/reset");
-    const res = await request(app).get("/agent/transactions");
+    await auth(request(app).post("/agent/reset"));
+    const res = await auth(request(app).get("/agent/transactions"));
     expect(res.status).toBe(200);
     expect(res.body.transactions).toEqual([]);
   });
@@ -262,34 +259,31 @@ describe("POST /agent/reset (Issue #42)", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("Agent endpoints — with and without X-API-Key header (Issue #42, #10)", () => {
-  it("GET /agent/status works without X-API-Key header", async () => {
+  it("missing token returns 401", async () => {
     const res = await request(app).get("/agent/status");
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
+    expect(res.headers["www-authenticate"]).toBe("Bearer");
   });
 
-  it("GET /agent/status works with X-API-Key header (no auth required on agent routes)", async () => {
+  it("wrong token returns 403", async () => {
     const res = await request(app)
       .get("/agent/status")
-      .set("X-API-Key", "some-arbitrary-key");
+      .set("Authorization", "Bearer wrong-token");
+    expect(res.status).toBe(403);
+  });
+
+  it("correct token returns 200", async () => {
+    const res = await auth(request(app).get("/agent/status"));
     expect(res.status).toBe(200);
   });
 
-  it("POST /agent/pause works without X-API-Key header", async () => {
-    const res = await request(app).post("/agent/resume");
-    expect(res.status).toBe(200);
-  });
-
-  it("POST /agent/run returns 400 (validation) without X-API-Key header", async () => {
+  it("POST /agent/run requires the Bearer token before validation", async () => {
     const res = await request(app).post("/agent/run").send({});
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
   });
 
-  it("POST /agent/run returns same status with X-API-Key header as without", async () => {
-    const withoutKey = await request(app).post("/agent/run").send({});
-    const withKey = await request(app)
-      .post("/agent/run")
-      .set("X-API-Key", "some-key")
-      .send({});
-    expect(withKey.status).toBe(withoutKey.status);
+  it("POST /agent/run with correct token reaches request validation", async () => {
+    const res = await auth(request(app).post("/agent/run")).send({});
+    expect(res.status).toBe(400);
   });
 });

--- a/agent/__tests__/health.test.ts
+++ b/agent/__tests__/health.test.ts
@@ -46,6 +46,7 @@ process.env.AGENT_SECRET_KEY = "SCZANGBA5YHTNYVS23C4QSOT45PZCBL2D4ZO5TSRE73UFYS3
 process.env.PHARMACY_1_PUBLIC_KEY = "GBQTESTPHARMACY1";
 process.env.BILL_PROVIDER_PUBLIC_KEY = "GBQTESTBILLPROVIDER";
 process.env.MPP_SECRET_KEY = "test-mpp-secret";
+process.env.CAREGIVER_TOKEN = "test-caregiver-token";
 
 const { app } = await import("../../server.ts");
 

--- a/agent/__tests__/llm-bill-fabrication.eval.test.ts
+++ b/agent/__tests__/llm-bill-fabrication.eval.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(resolve("agent/server.ts"), "utf8");
+
+describe("LLM eval: billing amounts are tool-sourced", () => {
+  it("tells the agent not to fabricate bill amounts", () => {
+    expect(serverSource).toContain(
+      "Never invent. The only billing data source is fetch_rosa_bill, which returns a sample bill for the demo. In production this is replaced with real EDI feeds.",
+    );
+    expect(serverSource).toContain("use fetch_and_audit_bill");
+    expect(serverSource).not.toContain("make up bill");
+    expect(serverSource).not.toContain("estimate bill amount");
+  });
+});

--- a/agent/__tests__/pagination.test.ts
+++ b/agent/__tests__/pagination.test.ts
@@ -2,15 +2,16 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
 import { app } from '../../server.ts';
 
+const auth = (req: any) => req.set('Authorization', 'Bearer test-caregiver-token');
+
 describe('Transaction Pagination', () => {
   beforeEach(async () => {
     // Reset the agent to ensure clean state
-    await request(app).post('/agent/reset');
+    await auth(request(app).post('/agent/reset'));
   });
 
   it('should return paginated transactions with default limit', async () => {
-    const response = await request(app)
-      .get('/agent/transactions')
+    const response = await auth(request(app).get('/agent/transactions'))
       .expect(200);
 
     expect(response.body).toHaveProperty('transactions');
@@ -25,8 +26,7 @@ describe('Transaction Pagination', () => {
   });
 
   it('should respect custom limit parameter', async () => {
-    const response = await request(app)
-      .get('/agent/transactions?limit=10')
+    const response = await auth(request(app).get('/agent/transactions?limit=10'))
       .expect(200);
 
     expect(response.body.pagination.limit).toBe(10);
@@ -34,8 +34,7 @@ describe('Transaction Pagination', () => {
   });
 
   it('should respect offset parameter', async () => {
-    const response = await request(app)
-      .get('/agent/transactions?limit=5&offset=10')
+    const response = await auth(request(app).get('/agent/transactions?limit=5&offset=10'))
       .expect(200);
 
     expect(response.body.pagination.offset).toBe(10);
@@ -44,28 +43,25 @@ describe('Transaction Pagination', () => {
 
   it('should return correct pagination metadata', async () => {
     // First page
-    const firstPage = await request(app)
-      .get('/agent/transactions?limit=3')
+    const firstPage = await auth(request(app).get('/agent/transactions?limit=3'))
       .expect(200);
 
-    expect(firstPage.pagination.hasPrevious).toBe(false);
+    expect(firstPage.body.pagination.hasPrevious).toBe(false);
     
-    if (firstPage.pagination.total > 3) {
-      expect(firstPage.pagination.hasMore).toBe(true);
+    if (firstPage.body.pagination.total > 3) {
+      expect(firstPage.body.pagination.hasMore).toBe(true);
       
       // Second page
-      const secondPage = await request(app)
-        .get('/agent/transactions?limit=3&offset=3')
+      const secondPage = await auth(request(app).get('/agent/transactions?limit=3&offset=3'))
         .expect(200);
 
-      expect(secondPage.pagination.hasPrevious).toBe(true);
-      expect(secondPage.pagination.offset).toBe(3);
+      expect(secondPage.body.pagination.hasPrevious).toBe(true);
+      expect(secondPage.body.pagination.offset).toBe(3);
     }
   });
 
   it('should handle empty transaction list', async () => {
-    const response = await request(app)
-      .get('/agent/transactions')
+    const response = await auth(request(app).get('/agent/transactions'))
       .expect(200);
 
     expect(response.body.transactions).toEqual([]);
@@ -75,8 +71,7 @@ describe('Transaction Pagination', () => {
   });
 
   it('should return transactions in reverse chronological order', async () => {
-    const response = await request(app)
-      .get('/agent/transactions?limit=5')
+    const response = await auth(request(app).get('/agent/transactions?limit=5'))
       .expect(200);
 
     if (response.body.transactions.length > 1) {

--- a/agent/__tests__/pay-for-medication.test.ts
+++ b/agent/__tests__/pay-for-medication.test.ts
@@ -5,21 +5,26 @@
 
 // vi.hoisted runs before any vi.mock factory
 const { mockMppFetch, onProgressHolder } = vi.hoisted(() => {
-  process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+  process.env.AGENT_SECRET_KEY =
+    'SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD';
   const onProgressHolder: { fn?: (event: any) => void } = {};
   return { mockMppFetch: vi.fn(), onProgressHolder };
 });
 
-vi.mock("dotenv/config", () => ({}));
-vi.mock("fs", () => ({
-  readFileSync: vi.fn().mockReturnValue("{}"),
+vi.mock('dotenv/config', () => ({}));
+vi.mock('fs', () => ({
+  readFileSync: vi.fn().mockReturnValue('{}'),
   writeFileSync: vi.fn(),
   existsSync: vi.fn().mockReturnValue(false),
   mkdirSync: vi.fn(),
 }));
-vi.mock("@stellar/stellar-sdk", () => ({
-  Keypair: { fromSecret: vi.fn().mockReturnValue({ publicKey: () => "GPUB123", sign: vi.fn() }) },
-  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+vi.mock('@stellar/stellar-sdk', () => ({
+  Keypair: {
+    fromSecret: vi
+      .fn()
+      .mockReturnValue({ publicKey: () => 'GPUB123', sign: vi.fn() }),
+  },
+  Networks: { TESTNET: 'Test SDF Network ; September 2015' },
   TransactionBuilder: vi.fn().mockReturnValue({
     addOperation: vi.fn().mockReturnThis(),
     setTimeout: vi.fn().mockReturnThis(),
@@ -27,34 +32,41 @@ vi.mock("@stellar/stellar-sdk", () => ({
   }),
   Operation: { payment: vi.fn() },
   Asset: vi.fn(),
-  Horizon: { Server: vi.fn().mockReturnValue({ loadAccount: vi.fn(), submitTransaction: vi.fn() }) },
+  Horizon: {
+    Server: vi
+      .fn()
+      .mockReturnValue({ loadAccount: vi.fn(), submitTransaction: vi.fn() }),
+  },
 }));
-vi.mock("@x402/stellar", () => ({
+vi.mock('@x402/stellar', () => ({
   createEd25519Signer: vi.fn().mockReturnValue({}),
   ExactStellarScheme: vi.fn(),
 }));
-vi.mock("@x402/fetch", () => ({
+vi.mock('@x402/fetch', () => ({
   wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
   x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }),
   decodePaymentResponseHeader: vi.fn(),
 }));
-vi.mock("@stellar/mpp/charge/client", () => ({
+vi.mock('@stellar/mpp/charge/client', () => ({
   stellar: vi.fn().mockImplementation((opts: any) => {
     if (opts?.onProgress) onProgressHolder.fn = opts.onProgress;
     return {};
   }),
 }));
-vi.mock("mppx/client", () => ({
+vi.mock('mppx/client', () => ({
   Mppx: { create: vi.fn().mockReturnValue({ fetch: mockMppFetch }) },
 }));
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   payForMedication,
   checkSpendingPolicy,
   resetSpendingTracker,
   setSpendingPolicy,
-} from "../tools.ts";
+  approvePendingTransaction,
+  cancelPendingTransaction,
+  processPendingTransactions,
+} from '../tools.ts';
 
 const DEFAULT_POLICY = {
   dailyLimit: 100,
@@ -72,70 +84,70 @@ beforeEach(() => {
 
 // --- Input validation ---
 
-describe("payForMedication — input validation (Issue #35)", () => {
-  it("rejects 0", async () => {
-    const r = await payForMedication("p1", "Pharma", "Drug", 0);
+describe('payForMedication — input validation (Issue #35)', () => {
+  it('rejects 0', async () => {
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 0);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("positive finite number");
+    expect(r.error).toContain('positive finite number');
   });
 
-  it("rejects negative amount", async () => {
-    const r = await payForMedication("p1", "Pharma", "Drug", -5);
+  it('rejects negative amount', async () => {
+    const r = await payForMedication('p1', 'Pharma', 'Drug', -5);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("positive finite number");
+    expect(r.error).toContain('positive finite number');
   });
 
-  it("rejects NaN", async () => {
-    const r = await payForMedication("p1", "Pharma", "Drug", NaN);
+  it('rejects NaN', async () => {
+    const r = await payForMedication('p1', 'Pharma', 'Drug', NaN);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("positive finite number");
+    expect(r.error).toContain('positive finite number');
   });
 
-  it("rejects Infinity", async () => {
-    const r = await payForMedication("p1", "Pharma", "Drug", Infinity);
+  it('rejects Infinity', async () => {
+    const r = await payForMedication('p1', 'Pharma', 'Drug', Infinity);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("positive finite number");
+    expect(r.error).toContain('positive finite number');
   });
 
-  it("rejects amounts above MAX_PAYMENT (1000)", async () => {
-    const r = await payForMedication("p1", "Pharma", "Drug", 1001);
+  it('rejects amounts above MAX_PAYMENT (1000)', async () => {
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 1001);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("positive finite number");
+    expect(r.error).toContain('positive finite number');
   });
 });
 
 // --- Policy-blocked path ---
 
-describe("payForMedication — policy-blocked (Issue #35)", () => {
-  it("returns success:false with BLOCKED BY SPENDING POLICY when budget exceeded", async () => {
+describe('payForMedication — policy-blocked (Issue #35)', () => {
+  it('returns success:false with BLOCKED BY SPENDING POLICY when budget exceeded', async () => {
     // Set a very low medication budget so any payment is blocked
     setSpendingPolicy({ ...DEFAULT_POLICY, medicationMonthlyBudget: 5 });
-    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 50);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("BLOCKED BY SPENDING POLICY");
+    expect(r.error).toContain('BLOCKED BY SPENDING POLICY');
     // mppClient.fetch must NOT have been called
     expect(mockMppFetch).not.toHaveBeenCalled();
   });
 
-  it("returns success:false when daily limit would be exceeded", async () => {
+  it('returns success:false when daily limit would be exceeded', async () => {
     setSpendingPolicy({ ...DEFAULT_POLICY, dailyLimit: 10 });
-    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 50);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("BLOCKED BY SPENDING POLICY");
+    expect(r.error).toContain('BLOCKED BY SPENDING POLICY');
     expect(mockMppFetch).not.toHaveBeenCalled();
   });
 });
 
 // --- Approval-required path ---
 
-describe("payForMedication — approval required (Issue #35)", () => {
-  it("records a pending transaction and returns success:false when amount > approvalThreshold", async () => {
+describe('payForMedication — approval required (Issue #35)', () => {
+  it('records a pending transaction and returns success:false when amount > approvalThreshold', async () => {
     // Default approvalThreshold = 75; amount 80 is within budget+daily but needs approval
-    const r = await payForMedication("p1", "Pharma", "Drug", 80);
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 80);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("REQUIRES CAREGIVER APPROVAL");
+    expect(r.error).toContain('REQUIRES CAREGIVER APPROVAL');
     expect((r as any).transaction).toBeDefined();
-    expect((r as any).transaction.status).toBe("pending");
+    expect((r as any).transaction.status).toBe('pending');
     expect((r as any).transaction.amount).toBe(80);
     expect(mockMppFetch).not.toHaveBeenCalled();
   });
@@ -143,114 +155,121 @@ describe("payForMedication — approval required (Issue #35)", () => {
 
 // --- MPP throws ---
 
-describe("payForMedication — MPP failure (Issue #35)", () => {
+describe('payForMedication — MPP failure (Issue #35)', () => {
   it("returns success:false with 'MPP payment failed' when mppClient.fetch throws", async () => {
-    mockMppFetch.mockRejectedValueOnce(new Error("network timeout"));
-    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    mockMppFetch.mockRejectedValueOnce(new Error('network timeout'));
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 50);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("MPP payment failed");
+    expect(r.error).toContain('MPP payment failed');
   });
 
-  it("returns success:false when MPP response data.success is false", async () => {
+  it('returns success:false when MPP response data.success is false', async () => {
     mockMppFetch.mockResolvedValueOnce({
-      json: async () => ({ success: false, error: "insufficient funds" }),
+      json: async () => ({ success: false, error: 'insufficient funds' }),
       headers: { get: () => null },
     });
-    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 50);
     expect(r.success).toBe(false);
-    expect(r.error).toContain("MPP payment failed");
+    expect(r.error).toContain('MPP payment failed');
   });
 });
 
 // --- Success path ---
 
-describe("payForMedication — success path (Issue #35)", () => {
-  it("returns success:true, creates a completed transaction, and sets stellarTxHash from MPP progress event", async () => {
+describe('payForMedication — success path (Issue #35)', () => {
+  it('returns success:true, creates a completed transaction, and sets stellarTxHash from MPP progress event', async () => {
     mockMppFetch.mockImplementationOnce(async () => {
       // Simulate the MPP progress event firing before the response resolves
-      onProgressHolder.fn?.({ type: "paid", hash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" });
+      onProgressHolder.fn?.({
+        type: 'paid',
+        hash: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      });
       return {
-        json: async () => ({ success: true, order: { id: "order-111" } }),
+        json: async () => ({ success: true, order: { id: 'order-111' } }),
         headers: { get: () => null },
       };
     });
 
-    const r = await payForMedication("p1", "TestPharmacy", "Metformin", 50);
+    const r = await payForMedication('p1', 'TestPharmacy', 'Metformin', 50);
     expect(r.success).toBe(true);
     const tx = (r as any).transaction;
-    expect(tx.status).toBe("completed");
+    expect(tx.status).toBe('completed');
     expect(tx.amount).toBe(50);
-    expect(tx.stellarTxHash).toBe("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+    expect(tx.stellarTxHash).toBe(
+      'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+    );
   });
 
-  it("populates mppOrderId from data.order.id — never stored as stellarTxHash", async () => {
+  it('populates mppOrderId from data.order.id — never stored as stellarTxHash', async () => {
     // No onProgress event, no Payment-Receipt header → stellarTxHash stays undefined
     mockMppFetch.mockResolvedValueOnce({
-      json: async () => ({ success: true, order: { id: "order-999" } }),
+      json: async () => ({ success: true, order: { id: 'order-999' } }),
       headers: { get: () => null },
     });
 
-    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 50);
     expect(r.success).toBe(true);
     const tx = (r as any).transaction;
-    expect(tx.mppOrderId).toBe("order-999");
+    expect(tx.mppOrderId).toBe('order-999');
     expect(tx.stellarTxHash).toBeUndefined();
   });
 
-  it("sets stellarTxHash from Payment-Receipt header when no progress event fired", async () => {
+  it('sets stellarTxHash from Payment-Receipt header when no progress event fired', async () => {
     const encodedReceipt = Buffer.from(
-      JSON.stringify({ reference: "receipt-ref-abc", hash: "hashfromheader" })
-    ).toString("base64");
+      JSON.stringify({ reference: 'receipt-ref-abc', hash: 'hashfromheader' }),
+    ).toString('base64');
 
     mockMppFetch.mockResolvedValueOnce({
-      json: async () => ({ success: true, order: { id: "order-222" } }),
-      headers: { get: (h: string) => (h === "Payment-Receipt" ? encodedReceipt : null) },
+      json: async () => ({ success: true, order: { id: 'order-222' } }),
+      headers: {
+        get: (h: string) => (h === 'Payment-Receipt' ? encodedReceipt : null),
+      },
     });
 
-    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 50);
     expect(r.success).toBe(true);
     const tx = (r as any).transaction;
-    expect(tx.stellarTxHash).toBe("receipt-ref-abc");
-    expect(tx.mppOrderId).toBe("order-222");
+    expect(tx.stellarTxHash).toBe('receipt-ref-abc');
+    expect(tx.mppOrderId).toBe('order-222');
   });
 
-  it("accumulates spending in the tracker after a successful payment", async () => {
+  it('accumulates spending in the tracker after a successful payment', async () => {
     mockMppFetch.mockResolvedValueOnce({
-      json: async () => ({ success: true, order: { id: "order-333" } }),
+      json: async () => ({ success: true, order: { id: 'order-333' } }),
       headers: { get: () => null },
     });
 
-    await payForMedication("p1", "Pharma", "Drug", 50);
+    await payForMedication('p1', 'Pharma', 'Drug', 50);
 
     // A second payment of 45 would push today's spending to 95 (< 100 daily limit) — still allowed
-    const check = checkSpendingPolicy(45, "medications");
+    const check = checkSpendingPolicy(45, 'medications');
     expect(check.allowed).toBe(true);
   });
 });
 
 // --- checkSpendingPolicy integration ---
 
-describe("checkSpendingPolicy — basic rules (Issue #35)", () => {
-  it("allows a payment within all limits", () => {
-    const r = checkSpendingPolicy(50, "medications");
+describe('checkSpendingPolicy — basic rules (Issue #35)', () => {
+  it('allows a payment within all limits', () => {
+    const r = checkSpendingPolicy(50, 'medications');
     expect(r.allowed).toBe(true);
     expect(r.requiresApproval).toBe(false);
   });
 
-  it("flags approval required when amount > approvalThreshold but within limits", () => {
-    const r = checkSpendingPolicy(80, "medications");
+  it('flags approval required when amount > approvalThreshold but within limits', () => {
+    const r = checkSpendingPolicy(80, 'medications');
     expect(r.allowed).toBe(true);
     expect(r.requiresApproval).toBe(true);
   });
 
-  it("blocks when amount exceeds daily limit", () => {
-    const r = checkSpendingPolicy(150, "medications");
+  it('blocks when amount exceeds daily limit', () => {
+    const r = checkSpendingPolicy(150, 'medications');
     expect(r.allowed).toBe(false);
   });
 
-  it("blocks when amount exceeds monthly medication budget", () => {
+  it('blocks when amount exceeds monthly medication budget', () => {
     setSpendingPolicy({ ...DEFAULT_POLICY, medicationMonthlyBudget: 20 });
-    const r = checkSpendingPolicy(50, "medications");
+    const r = checkSpendingPolicy(50, 'medications');
     expect(r.allowed).toBe(false);
   });
 });

--- a/agent/__tests__/pending-approvals.test.ts
+++ b/agent/__tests__/pending-approvals.test.ts
@@ -1,0 +1,105 @@
+// Tests for pending approvals: cancel, approve, and auto-approve
+
+// vi.hoisted runs before any vi.mock factory
+const { mockMppFetch, onProgressHolder } = vi.hoisted(() => {
+  process.env.AGENT_SECRET_KEY = 'SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD';
+  const onProgressHolder: { fn?: (event: any) => void } = {};
+  return { mockMppFetch: vi.fn(), onProgressHolder };
+});
+
+vi.mock('dotenv/config', () => ({}));
+vi.mock('fs', () => ({
+  readFileSync: vi.fn().mockReturnValue('{}'),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+}));
+vi.mock('@stellar/stellar-sdk', () => ({
+  Keypair: { fromSecret: vi.fn().mockReturnValue({ publicKey: () => 'GPUB123', sign: vi.fn() }) },
+  Networks: { TESTNET: 'Test SDF Network ; September 2015' },
+  TransactionBuilder: vi.fn().mockReturnValue({ addOperation: vi.fn().mockReturnThis(), setTimeout: vi.fn().mockReturnThis(), build: vi.fn().mockReturnValue({ sign: vi.fn(), signatures: [{ hint: vi.fn() }] }) }),
+  Operation: { payment: vi.fn() },
+  Asset: vi.fn(),
+  Horizon: { Server: vi.fn().mockReturnValue({ loadAccount: vi.fn(), submitTransaction: vi.fn() }) },
+}));
+vi.mock('@x402/stellar', () => ({ createEd25519Signer: vi.fn().mockReturnValue({}), ExactStellarScheme: vi.fn() }));
+vi.mock('@x402/fetch', () => ({ wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()), x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }), decodePaymentResponseHeader: vi.fn() }));
+vi.mock('@stellar/mpp/charge/client', () => ({ stellar: vi.fn().mockImplementation((opts: any) => { if (opts?.onProgress) onProgressHolder.fn = opts.onProgress; return {}; }) }));
+vi.mock('mppx/client', () => ({ Mppx: { create: vi.fn().mockReturnValue({ fetch: mockMppFetch }) } }));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  payForMedication,
+  setSpendingPolicy,
+  resetSpendingTracker,
+  cancelPendingTransaction,
+  approvePendingTransaction,
+  processPendingTransactions,
+  getSpendingTracker,
+} from '../tools.ts';
+
+const DEFAULT_POLICY = {
+  dailyLimit: 100,
+  monthlyLimit: 500,
+  medicationMonthlyBudget: 300,
+  billMonthlyBudget: 500,
+  approvalThreshold: 75,
+};
+
+beforeEach(() => {
+  mockMppFetch.mockReset();
+  resetSpendingTracker();
+  setSpendingPolicy({ ...DEFAULT_POLICY });
+});
+
+describe('Pending approvals flows', () => {
+  it('hold + cancel', async () => {
+    setSpendingPolicy({ ...DEFAULT_POLICY, holdTimeSeconds: 60 });
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 80);
+    expect(r.success).toBe(false);
+    const tx = (r as any).transaction;
+    expect(tx).toBeDefined();
+    expect(tx.status).toBe('pending');
+
+    const cancelled = cancelPendingTransaction(tx.id);
+    expect(cancelled.success).toBe(true);
+    expect(cancelled.transaction.status).toBe('cancelled');
+
+    const tracker = getSpendingTracker();
+    const found = tracker.transactions.find((t: any) => t.id === tx.id);
+    expect(found.status).toBe('cancelled');
+  });
+
+  it('hold + approve', async () => {
+    setSpendingPolicy({ ...DEFAULT_POLICY, holdTimeSeconds: 60 });
+    // Ensure MPP will succeed when approving
+    mockMppFetch.mockResolvedValueOnce({ json: async () => ({ success: true, order: { id: 'o-1' } }), headers: { get: () => null } });
+
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 80);
+    expect(r.success).toBe(false);
+    const tx = (r as any).transaction;
+    const res = await approvePendingTransaction(tx.id);
+    expect(res.success).toBe(true);
+    expect(res.transaction.status).toBe('completed');
+
+    const tracker = getSpendingTracker();
+    const found = tracker.transactions.find((t: any) => t.id === tx.id);
+    expect(found.status).toBe('completed');
+  });
+
+  it('hold + auto-approve', async () => {
+    // immediate auto-approve
+    setSpendingPolicy({ ...DEFAULT_POLICY, holdTimeSeconds: 0 });
+    mockMppFetch.mockResolvedValueOnce({ json: async () => ({ success: true, order: { id: 'o-2' } }), headers: { get: () => null } });
+
+    const r = await payForMedication('p1', 'Pharma', 'Drug', 80);
+    expect(r.success).toBe(false);
+    const tx = (r as any).transaction;
+    // process pending should pick this up immediately
+    await processPendingTransactions();
+
+    const tracker = getSpendingTracker();
+    const found = tracker.transactions.find((t: any) => t.id === tx.id);
+    expect(found.status).toBe('completed');
+  });
+});

--- a/agent/__tests__/tool-call-cap.test.ts
+++ b/agent/__tests__/tool-call-cap.test.ts
@@ -72,8 +72,10 @@ process.env.PHARMACY_1_PUBLIC_KEY = "GBQTESTPHARMACY1";
 process.env.BILL_PROVIDER_PUBLIC_KEY = "GBQTESTBILLPROVIDER";
 process.env.MPP_SECRET_KEY = "test-mpp-secret";
 process.env.MAX_TOOL_CALLS_PER_RUN = "5";
+process.env.CAREGIVER_TOKEN = "test-caregiver-token";
 
 const { app } = await import("../../server.ts");
+const auth = (req: any) => req.set("Authorization", "Bearer test-caregiver-token");
 
 describe("tool call cap", () => {
   beforeEach(() => {
@@ -102,8 +104,7 @@ describe("tool call cap", () => {
       usage: { prompt_tokens: 10, completion_tokens: 5 },
     }));
 
-    const res = await request(app)
-      .post("/agent/run")
+    const res = await auth(request(app).post("/agent/run"))
       .send({ task: "Run the spending summary repeatedly" });
 
     expect(res.status).toBe(200);
@@ -131,8 +132,7 @@ describe("tool call cap", () => {
       };
     });
 
-    const res = await request(app)
-      .post("/agent/run")
+    const res = await auth(request(app).post("/agent/run"))
       .send({ task: "Check spending summary" });
 
     expect(res.status).toBe(200);

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -8,27 +8,34 @@
  * Requires: LLM_API_KEY, AGENT_SECRET_KEY, OZ_FACILITATOR_API_KEY
  */
 
-import "dotenv/config";
-import { createHash } from "crypto";
-import express from "express";
-import OpenAI from "openai";
-import { Keypair, Horizon } from "@stellar/stellar-sdk";
-import { createCorsMiddleware } from "../shared/cors.ts";
-import { applySecurityMiddleware } from "../shared/security-middleware.ts";
-import { logger } from "../shared/logger.ts";
-import { validateTask, getSuspiciousTaskCount } from "../shared/task-validation.ts";
-import { appendAuditEntry, auditRouter } from "../shared/audit-log.ts";
-import { rateLimiters } from "../shared/rate-limit.ts";
-import { agentQueue } from "../shared/agent-queue.ts";
-import { buildScrubSession, scrubText } from "../shared/prompt-scrub.ts";
-import { requestContextMiddleware, setAgentRunId, getRequestId } from "../shared/request-context.ts";
-import { requestLoggerMiddleware } from "../shared/request-logger.ts";
+import 'dotenv/config';
+import { createHash } from 'crypto';
+import express from 'express';
+import OpenAI from 'openai';
+import { Keypair, Horizon } from '@stellar/stellar-sdk';
+import { createCorsMiddleware } from '../shared/cors.ts';
+import { applySecurityMiddleware } from '../shared/security-middleware.ts';
+import { logger } from '../shared/logger.ts';
+import {
+  validateTask,
+  getSuspiciousTaskCount,
+} from '../shared/task-validation.ts';
+import { appendAuditEntry, auditRouter } from '../shared/audit-log.ts';
+import { rateLimiters } from '../shared/rate-limit.ts';
+import { agentQueue } from '../shared/agent-queue.ts';
+import { buildScrubSession, scrubText } from '../shared/prompt-scrub.ts';
+import {
+  requestContextMiddleware,
+  setAgentRunId,
+  getRequestId,
+} from '../shared/request-context.ts';
+import { requestLoggerMiddleware } from '../shared/request-logger.ts';
 import {
   metricsHandler,
   agentRunsTotal,
   agentToolCallsTotal,
   agentLlmTokensTotal,
-} from "../shared/metrics.ts";
+} from '../shared/metrics.ts';
 import {
   comparePharmacyPrices,
   auditBill,
@@ -43,17 +50,22 @@ import {
   setSpendingPolicy,
   getSpendingTracker,
   resetSpendingTracker,
+  approvePendingTransaction,
+  cancelPendingTransaction,
   TOOL_DEFINITIONS,
-} from "./tools.ts";
+} from './tools.ts';
 
-const PORT = parseInt(process.env.AGENT_PORT || "3004");
+const PORT = parseInt(process.env.AGENT_PORT || '3004');
 
-if (!process.env.LLM_API_KEY) throw new Error("LLM_API_KEY required in .env");
-if (!process.env.AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");
-if (!process.env.CAREGIVER_TOKEN) throw new Error("CAREGIVER_TOKEN required in .env");
+if (!process.env.LLM_API_KEY) throw new Error('LLM_API_KEY required in .env');
+if (!process.env.AGENT_SECRET_KEY)
+  throw new Error('AGENT_SECRET_KEY required in .env');
+if (!process.env.CAREGIVER_TOKEN)
+  throw new Error('CAREGIVER_TOKEN required in .env');
 
-const LLM_BASE_URL = process.env.LLM_BASE_URL || "https://api.groq.com/openai/v1";
-const LLM_MODEL = process.env.LLM_MODEL || "llama-3.3-70b-versatile";
+const LLM_BASE_URL =
+  process.env.LLM_BASE_URL || 'https://api.groq.com/openai/v1';
+const LLM_MODEL = process.env.LLM_MODEL || 'llama-3.3-70b-versatile';
 
 const llm = new OpenAI({
   apiKey: process.env.LLM_API_KEY,
@@ -61,7 +73,7 @@ const llm = new OpenAI({
 });
 
 const agentKeypair = Keypair.fromSecret(process.env.AGENT_SECRET_KEY);
-const horizonServer = new Horizon.Server("https://horizon-testnet.stellar.org");
+const horizonServer = new Horizon.Server('https://horizon-testnet.stellar.org');
 const CAREGIVER_TOKEN = process.env.CAREGIVER_TOKEN;
 
 const SYSTEM_PROMPT = `You are CareGuard, an AI agent that manages healthcare spending for elderly care recipients on the Stellar blockchain. You work on behalf of a family caregiver to ensure their loved one gets the best prices on medications and catches errors in medical bills.
@@ -90,45 +102,56 @@ Current care recipient: Rosa Garcia (age 78)
 Caregiver: Maria Garcia (daughter)`;
 
 // PHI scrubbing — active unless LLM_PII_SCRUB=false (e.g. provider has a BAA)
-const _piiScrub = process.env.LLM_PII_SCRUB !== "false";
+const _piiScrub = process.env.LLM_PII_SCRUB !== 'false';
 const _scrubSession = _piiScrub
-  ? buildScrubSession(["Rosa Garcia"], ["Maria Garcia"])
+  ? buildScrubSession(['Rosa Garcia'], ['Maria Garcia'])
   : null;
 const SCRUBBED_SYSTEM_PROMPT = _scrubSession
   ? scrubText(SYSTEM_PROMPT, _scrubSession)
   : SYSTEM_PROMPT;
 
 // Convert tool definitions to OpenAI-compatible function format
-const LLM_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = TOOL_DEFINITIONS.map((t) => ({
-  type: "function" as const,
-  function: {
-    name: t.name,
-    description: t.description,
-    parameters: {
-      ...t.input_schema,
-      // Strict mode: required by Groq and other providers
-      additionalProperties: false,
+const LLM_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] =
+  TOOL_DEFINITIONS.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: {
+        ...t.input_schema,
+        // Strict mode: required by Groq and other providers
+        additionalProperties: false,
+      },
     },
-  },
-}));
+  }));
 
 type ToolResult = Record<string, unknown>;
 
 // Execute a tool call
-async function executeTool(name: string, input: Record<string, unknown>): Promise<ToolResult> {
+async function executeTool(
+  name: string,
+  input: Record<string, unknown>,
+): Promise<ToolResult> {
   try {
     let result: any;
     switch (name) {
-      case "compare_pharmacy_prices": result = await comparePharmacyPrices(input.drug_name, input.zip_code); break;
-      case "audit_medical_bill": {
+      case 'compare_pharmacy_prices':
+        result = await comparePharmacyPrices(input.drug_name, input.zip_code);
+        break;
+      case 'audit_medical_bill': {
         let items;
-        if (typeof input.line_items_json === "string") {
+        if (typeof input.line_items_json === 'string') {
           try {
             items = JSON.parse(input.line_items_json);
           } catch (e: any) {
             const sample = input.line_items_json.slice(0, 200);
-            agentToolCallsTotal.inc({ tool: name, status: "error" });
-            return { ok: false, reason: "INVALID_LINE_ITEMS_JSON", sample, error: e.message };
+            agentToolCallsTotal.inc({ tool: name, status: 'error' });
+            return {
+              ok: false,
+              reason: 'INVALID_LINE_ITEMS_JSON',
+              sample,
+              error: e.message,
+            };
           }
         } else {
           items = input.line_items || input.line_items_json;
@@ -136,24 +159,50 @@ async function executeTool(name: string, input: Record<string, unknown>): Promis
         result = await auditBill(items);
         break;
       }
-      case "fetch_rosa_bill": result = await fetchRosaBill(); break;
-      case "fetch_and_audit_bill": result = await fetchAndAuditBill(); break;
-      case "check_drug_interactions": result = await checkDrugInteractions(input.medications); break;
-      case "pay_for_medication": result = await payForMedication(input.pharmacy_id, input.pharmacy_name, input.drug_name, parseFloat(input.amount)); break;
-      case "pay_bill": result = await payBill(input.provider_id, input.provider_name, input.description, parseFloat(input.amount)); break;
-      case "check_spending_policy": result = checkSpendingPolicy(parseFloat(input.amount), input.category); break;
-      case "get_spending_summary": result = getSpendingSummary(); break;
-      case "get_wallet_balance": result = await getWalletBalance(); break;
-      default: result = { error: `Unknown tool: ${name}` };
+      case 'fetch_rosa_bill':
+        result = await fetchRosaBill();
+        break;
+      case 'fetch_and_audit_bill':
+        result = await fetchAndAuditBill();
+        break;
+      case 'check_drug_interactions':
+        result = await checkDrugInteractions(input.medications);
+        break;
+      case 'pay_for_medication':
+        result = await payForMedication(
+          input.pharmacy_id,
+          input.pharmacy_name,
+          input.drug_name,
+          parseFloat(input.amount),
+        );
+        break;
+      case 'pay_bill':
+        result = await payBill(
+          input.provider_id,
+          input.provider_name,
+          input.description,
+          parseFloat(input.amount),
+        );
+        break;
+      case 'check_spending_policy':
+        result = checkSpendingPolicy(parseFloat(input.amount), input.category);
+        break;
+      case 'get_spending_summary':
+        result = getSpendingSummary();
+        break;
+      case 'get_wallet_balance':
+        result = await getWalletBalance();
+        break;
+      default:
+        result = { error: `Unknown tool: ${name}` };
     }
-    agentToolCallsTotal.inc({ tool: name, status: "success" });
+    agentToolCallsTotal.inc({ tool: name, status: 'success' });
     return result;
   } catch (err: any) {
-    agentToolCallsTotal.inc({ tool: name, status: "error" });
+    agentToolCallsTotal.inc({ tool: name, status: 'error' });
     throw err;
   }
 }
-
 
 // Run the agent with a task — full agentic loop
 async function runAgent(task: string) {
@@ -162,12 +211,19 @@ async function runAgent(task: string) {
   setAgentRunId(runId);
 
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
-    { role: "system", content: SCRUBBED_SYSTEM_PROMPT },
-    { role: "user", content: userTask },
+    { role: 'system', content: SCRUBBED_SYSTEM_PROMPT },
+    { role: 'user', content: userTask },
   ];
-  const toolCalls: Array<{ tool: string; input: Record<string, unknown>; result: ToolResult }> = [];
-  let finalResponse = "";
-  let llmUsage: { promptTokens: number; completionTokens: number } = { promptTokens: 0, completionTokens: 0 };
+  const toolCalls: Array<{
+    tool: string;
+    input: Record<string, unknown>;
+    result: ToolResult;
+  }> = [];
+  let finalResponse = '';
+  let llmUsage: { promptTokens: number; completionTokens: number } = {
+    promptTokens: 0,
+    completionTokens: 0,
+  };
   let runToolCalls = 0;
   let truncated = false;
 
@@ -181,17 +237,24 @@ async function runAgent(task: string) {
         messages,
       });
     } catch (llmErr: any) {
-      logger.error({ err: llmErr.message, iteration }, "LLM API error");
+      logger.error({ err: llmErr.message, iteration }, 'LLM API error');
       if (toolCalls.length > 0 && !finalResponse) {
-        finalResponse = toolCalls.map(tc => {
-          if (tc.result?.error) return `${tc.tool}: ${tc.result.error}`;
-          if (tc.tool === "compare_pharmacy_prices" && tc.result?.cheapest) return `${tc.result.drug}: cheapest at $${tc.result.cheapest.price} (${tc.result.cheapest.pharmacyName}), save $${tc.result.potentialSavings}/mo`;
-          if (tc.tool === "audit_medical_bill" && tc.result?.totalOvercharge) return `Bill audit: $${tc.result.totalOvercharge} in overcharges found (${tc.result.errorCount} errors)`;
-          if (tc.tool === "check_drug_interactions" && tc.result?.summary) return tc.result.summary;
-          if (tc.tool === "pay_for_medication" && tc.result?.success) return `Paid $${tc.result.transaction.amount} for ${tc.result.transaction.description}`;
-          if (tc.tool === "pay_bill" && tc.result?.success) return `Paid bill: $${tc.result.transaction.amount}`;
-          return `${tc.tool}: completed`;
-        }).join("\n");
+        finalResponse = toolCalls
+          .map((tc) => {
+            if (tc.result?.error) return `${tc.tool}: ${tc.result.error}`;
+            if (tc.tool === 'compare_pharmacy_prices' && tc.result?.cheapest)
+              return `${tc.result.drug}: cheapest at $${tc.result.cheapest.price} (${tc.result.cheapest.pharmacyName}), save $${tc.result.potentialSavings}/mo`;
+            if (tc.tool === 'audit_medical_bill' && tc.result?.totalOvercharge)
+              return `Bill audit: $${tc.result.totalOvercharge} in overcharges found (${tc.result.errorCount} errors)`;
+            if (tc.tool === 'check_drug_interactions' && tc.result?.summary)
+              return tc.result.summary;
+            if (tc.tool === 'pay_for_medication' && tc.result?.success)
+              return `Paid $${tc.result.transaction.amount} for ${tc.result.transaction.description}`;
+            if (tc.tool === 'pay_bill' && tc.result?.success)
+              return `Paid bill: $${tc.result.transaction.amount}`;
+            return `${tc.tool}: completed`;
+          })
+          .join('\n');
       } else if (!finalResponse) {
         finalResponse = `LLM error: ${llmErr.message}`;
       }
@@ -204,8 +267,8 @@ async function runAgent(task: string) {
       const completionTokens = response.usage.completion_tokens || 0;
       llmUsage.promptTokens += promptTokens;
       llmUsage.completionTokens += completionTokens;
-      agentLlmTokensTotal.inc({ kind: "prompt" }, promptTokens);
-      agentLlmTokensTotal.inc({ kind: "completion" }, completionTokens);
+      agentLlmTokensTotal.inc({ kind: 'prompt' }, promptTokens);
+      agentLlmTokensTotal.inc({ kind: 'completion' }, completionTokens);
     }
 
     const choice = response.choices[0];
@@ -224,14 +287,19 @@ async function runAgent(task: string) {
     if (runToolCalls + message.tool_calls.length > MAX_TOOL_CALLS_PER_RUN) {
       toolCallCapHitsTotal++;
       truncated = true;
-      appendAuditEntry({ event: "agent.tool_cap_exceeded", actor: "agent", details: { max: MAX_TOOL_CALLS_PER_RUN, ran: runToolCalls } });
-      finalResponse = finalResponse || "Tool call limit reached; partial results returned.";
+      appendAuditEntry({
+        event: 'agent.tool_cap_exceeded',
+        actor: 'agent',
+        details: { max: MAX_TOOL_CALLS_PER_RUN, ran: runToolCalls },
+      });
+      finalResponse =
+        finalResponse || 'Tool call limit reached; partial results returned.';
       break;
     }
     runToolCalls += message.tool_calls.length;
 
     for (const toolCall of message.tool_calls) {
-      if (toolCall.type !== "function") continue;
+      if (toolCall.type !== 'function') continue;
       const fnName = toolCall.function.name;
       let fnArgs: any;
       try {
@@ -240,72 +308,93 @@ async function runAgent(task: string) {
         fnArgs = {};
       }
 
-      logger.info({ tool: fnName, args: JSON.stringify(fnArgs).slice(0, 100) }, "tool call");
+      logger.info(
+        { tool: fnName, args: JSON.stringify(fnArgs).slice(0, 100) },
+        'tool call',
+      );
 
       let result: ToolResult;
       try {
         result = await executeTool(fnName, fnArgs);
         toolCalls.push({ tool: fnName, input: fnArgs, result });
       } catch (err: any) {
-        logger.error({ tool: fnName, err: err.message }, "tool error");
+        logger.error({ tool: fnName, err: err.message }, 'tool error');
         result = { error: err.message };
         toolCalls.push({ tool: fnName, input: fnArgs, result });
       }
 
       appendAuditEntry({
-        event: "tool_call",
-        actor: "agent",
+        event: 'tool_call',
+        actor: 'agent',
         details: {
           tool: fnName,
           inputs: fnArgs,
-          resultHash: createHash("sha256").update(JSON.stringify(result || {})).digest("hex")
-        }
+          resultHash: createHash('sha256')
+            .update(JSON.stringify(result || {}))
+            .digest('hex'),
+        },
       });
 
       messages.push({
-        role: "tool",
+        role: 'tool',
         tool_call_id: toolCall.id,
         content: JSON.stringify(result),
       });
     }
 
-    if (choice.finish_reason === "stop") break;
+    if (choice.finish_reason === 'stop') break;
   }
 
-  return { response: finalResponse, toolCalls, spending: getSpendingSummary(), llmUsage, truncated };
+  return {
+    response: finalResponse,
+    toolCalls,
+    spending: getSpendingSummary(),
+    llmUsage,
+    truncated,
+  };
 }
 
 // Express API
 const app = express();
 
-function requireCaregiverToken(req: express.Request, res: express.Response, next: express.NextFunction) {
+function requireCaregiverToken(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+) {
   const auth = req.headers.authorization;
-  if (!auth?.startsWith("Bearer ")) {
-    res.status(401).setHeader("WWW-Authenticate", "Bearer").json({ error: "Missing caregiver token" });
+  if (!auth?.startsWith('Bearer ')) {
+    res
+      .status(401)
+      .setHeader('WWW-Authenticate', 'Bearer')
+      .json({ error: 'Missing caregiver token' });
     return;
   }
-  if (auth.slice("Bearer ".length) !== CAREGIVER_TOKEN) {
-    res.status(403).json({ error: "Invalid caregiver token" });
+  if (auth.slice('Bearer '.length) !== CAREGIVER_TOKEN) {
+    res.status(403).json({ error: 'Invalid caregiver token' });
     return;
   }
   next();
 }
 
-app.use("/agent", rateLimiters.agent);
-app.use("/health", rateLimiters.health);
+app.use('/agent', rateLimiters.agent);
+app.use('/health', rateLimiters.health);
 app.use(rateLimiters.default);
 
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? '20kb' }));
 app.use(requestContextMiddleware());
 app.use(requestLoggerMiddleware());
-app.use("/agent", requireCaregiverToken);
-app.use("/agent/audit", auditRouter);
-app.get("/metrics", metricsHandler());
+app.use('/agent', requireCaregiverToken);
+app.use('/agent/audit', auditRouter);
+app.get('/metrics', metricsHandler());
 
 // Per-run tool call cap
-const MAX_TOOL_CALLS_PER_RUN = parseInt(process.env.MAX_TOOL_CALLS_PER_RUN || "30", 10);
+const MAX_TOOL_CALLS_PER_RUN = parseInt(
+  process.env.MAX_TOOL_CALLS_PER_RUN || '30',
+  10,
+);
 let toolCallCapHitsTotal = 0;
 
 let agentPaused = false;
@@ -318,7 +407,7 @@ interface WalletCacheEntry {
 const walletCache = new Map<string, WalletCacheEntry>();
 const WALLET_CACHE_TTL_MS = 5000;
 
-app.get("/agent/wallet", async (req, res) => {
+app.get('/agent/wallet', async (req, res) => {
   const address = agentKeypair.publicKey();
   const now = Date.now();
   const cached = walletCache.get(address);
@@ -327,11 +416,14 @@ app.get("/agent/wallet", async (req, res) => {
   }
   try {
     const account = await horizonServer.loadAccount(address);
-    const usdc = account.balances.find((b: any) => b.asset_code === "USDC" && b.asset_issuer === process.env.USDC_ISSUER);
-    const xlm = account.balances.find((b: any) => b.asset_type === "native");
+    const usdc = account.balances.find(
+      (b: any) =>
+        b.asset_code === 'USDC' && b.asset_issuer === process.env.USDC_ISSUER,
+    );
+    const xlm = account.balances.find((b: any) => b.asset_type === 'native');
     const data = {
-      usdc: usdc ? parseFloat((usdc as any).balance).toFixed(2) : "0.00",
-      xlm: xlm ? parseFloat((xlm as any).balance).toFixed(2) : "0.00",
+      usdc: usdc ? parseFloat((usdc as any).balance).toFixed(2) : '0.00',
+      xlm: xlm ? parseFloat((xlm as any).balance).toFixed(2) : '0.00',
       address,
     };
     walletCache.set(address, { data, expiresAt: now + WALLET_CACHE_TTL_MS });
@@ -342,168 +434,224 @@ app.get("/agent/wallet", async (req, res) => {
 });
 
 // Pending approvals
-app.get("/agent/pending-approvals", (_req, res) => {
+app.get('/agent/pending-approvals', (_req, res) => {
   const tracker = getSpendingTracker();
-  const pending = tracker.transactions.filter((t: any) => t.status === "pending");
+  const pending = tracker.transactions.filter(
+    (t: any) => t.status === 'pending',
+  );
   res.json({ approvals: pending });
 });
 
-// Approve or reject a pending transaction
-app.post("/agent/approvals/:txId", async (req, res) => {
+// Approve or cancel a pending transaction
+app.post('/agent/approvals/:txId', async (req, res) => {
   const { txId } = req.params;
   const { approve } = req.body;
   const tracker = getSpendingTracker();
-  const txIndex = tracker.transactions.findIndex((t: any) => t.id === txId);
-  if (txIndex === -1) return res.status(404).json({ error: "Transaction not found" });
-  const tx = tracker.transactions[txIndex];
-  if (tx.status !== "pending") return res.status(400).json({ error: "Transaction is not pending" });
+  const tx = tracker.transactions.find((t: any) => t.id === txId);
+  if (!tx) return res.status(404).json({ error: 'Transaction not found' });
+  if (tx.status !== 'pending')
+    return res.status(400).json({ error: 'Transaction is not pending' });
 
   if (!approve) {
-    tx.status = "rejected";
-    saveSpending(tracker);
-    return res.json({ success: true, status: "rejected" });
+    const result = cancelPendingTransaction(txId);
+    if (result.success) {
+      return res.json({
+        success: true,
+        status: 'cancelled',
+        transaction: result.transaction,
+      });
+    }
+    return res.status(500).json({ success: false, error: result.error });
   }
 
-  // Approve: re-execute the payment bypassing approval gate
   try {
-    let result;
-    if (tx.category === "medications") {
-      // Extract details from description: "Drug from Pharmacy"
-      const match = tx.description.match(/(.+) from (.+)/);
-      if (!match) throw new Error("Cannot parse transaction description");
-      const [, drugName, pharmacyName] = match;
-      // Find pharmacy ID from description or use a default
-      const pharmacyId = tx.recipient;
-      result = await payForMedication(pharmacyId, pharmacyName, drugName, tx.amount, true);
-    } else if (tx.category === "bills") {
-      const match = tx.description.match(/(.+) — (.+)/);
-      if (!match) throw new Error("Cannot parse transaction description");
-      const [, description, providerName] = match;
-      const providerId = tx.recipient;
-      result = await payBill(providerId, providerName, description, tx.amount, true);
-    } else {
-      throw new Error("Unknown transaction category");
-    }
-
+    const result = await approvePendingTransaction(txId);
     if (result.success) {
-      tx.status = "completed";
-      tx.stellarTxHash = result.transaction?.stellarTxHash;
-      tracker.transactions[txIndex] = tx;
-      saveSpending(tracker);
-      return res.json({ success: true, status: "completed", transaction: result.transaction });
-    } else {
-      tx.status = "rejected";
-      saveSpending(tracker);
-      return res.status(400).json({ success: false, error: result.error, status: "rejected" });
+      return res.json({
+        success: true,
+        status: 'completed',
+        transaction: result.transaction,
+      });
     }
+    return res
+      .status(400)
+      .json({ success: false, error: result.error, status: 'rejected' });
   } catch (err: any) {
     return res.status(500).json({ error: `Approval failed: ${err.message}` });
   }
 });
 
-app.get("/", (_req, res) => {
+app.get('/', (_req, res) => {
   res.json({
-    service: "CareGuard AI Agent",
-    version: "1.0.0",
-    network: "stellar:testnet",
+    service: 'CareGuard AI Agent',
+    version: '1.0.0',
+    network: 'stellar:testnet',
     llm: `${LLM_BASE_URL} / ${LLM_MODEL}`,
     agentWallet: agentKeypair.publicKey(),
-    careRecipient: "Rosa Garcia",
-    caregiver: "Maria Garcia",
+    careRecipient: 'Rosa Garcia',
+    caregiver: 'Maria Garcia',
     paused: agentPaused,
   });
 });
 
-app.get("/agent/status", (_req, res) => { res.json({ paused: agentPaused }); });
-app.post("/agent/pause", (_req, res) => { agentPaused = true; logger.info("agent paused by caregiver"); res.json({ paused: true }); });
-app.post("/agent/resume", (_req, res) => { agentPaused = false; logger.info("agent resumed by caregiver"); res.json({ paused: false }); });
+app.get('/agent/status', (_req, res) => {
+  res.json({ paused: agentPaused });
+});
+app.post('/agent/pause', (_req, res) => {
+  agentPaused = true;
+  logger.info('agent paused by caregiver');
+  res.json({ paused: true });
+});
+app.post('/agent/resume', (_req, res) => {
+  agentPaused = false;
+  logger.info('agent resumed by caregiver');
+  res.json({ paused: false });
+});
 
-app.post("/agent/run", async (req, res) => {
+app.post('/agent/run', async (req, res) => {
   const validation = validateTask(req.body?.task);
-  if (!validation.ok) { res.status(400).json({ error: validation.error }); return; }
-  if (agentPaused) { res.status(409).json({ error: "Agent is paused. Resume from the dashboard to continue.", paused: true }); return; }
+  if (!validation.ok) {
+    res.status(400).json({ error: validation.error });
+    return;
+  }
+  if (agentPaused) {
+    res
+      .status(409)
+      .json({
+        error: 'Agent is paused. Resume from the dashboard to continue.',
+        paused: true,
+      });
+    return;
+  }
 
   const task = validation.task!;
-  logger.info({ task, suspicious: validation.suspicious }, "agent task received");
+  logger.info(
+    { task, suspicious: validation.suspicious },
+    'agent task received',
+  );
 
   try {
     const result = await agentQueue.enqueue(() => runAgent(task));
-    agentRunsTotal.inc({ status: "success" });
-    logger.info({ toolCalls: result.toolCalls.length, truncated: result.truncated, promptTokens: result.llmUsage.promptTokens, completionTokens: result.llmUsage.completionTokens }, "agent task complete");
+    agentRunsTotal.inc({ status: 'success' });
+    logger.info(
+      {
+        toolCalls: result.toolCalls.length,
+        truncated: result.truncated,
+        promptTokens: result.llmUsage.promptTokens,
+        completionTokens: result.llmUsage.completionTokens,
+      },
+      'agent task complete',
+    );
     res.json(result);
   } catch (err: any) {
     if (err.status === 429) {
-      res.status(429).set("Retry-After", String(err.retryAfter)).json({ error: err.message });
+      res
+        .status(429)
+        .set('Retry-After', String(err.retryAfter))
+        .json({ error: err.message });
       return;
     }
-    agentRunsTotal.inc({ status: "error" });
-    logger.error({ err: err.message }, "agent run error");
+    agentRunsTotal.inc({ status: 'error' });
+    logger.error({ err: err.message }, 'agent run error');
     res.status(500).json({ error: err.message });
   }
 });
 
-app.get("/agent/spending", (_req, res) => { res.json(getSpendingSummary()); });
-app.get("/agent/transactions", (_req, res) => { res.json(getSpendingTracker()); });
-function validatePolicyPayload(body: any): { ok: true; policy: any } | { ok: false; errors: string[] } {
+app.get('/agent/spending', (_req, res) => {
+  res.json(getSpendingSummary());
+});
+app.get('/agent/transactions', (_req, res) => {
+  res.json(getSpendingTracker());
+});
+function validatePolicyPayload(
+  body: any,
+): { ok: true; policy: any } | { ok: false; errors: string[] } {
   const errors: string[] = [];
-  if (!body || typeof body !== "object") return { ok: false, errors: ["body must be a JSON object"] };
-  const fields = ["dailyLimit", "monthlyLimit", "medicationMonthlyBudget", "billMonthlyBudget", "approvalThreshold"] as const;
+  if (!body || typeof body !== 'object')
+    return { ok: false, errors: ['body must be a JSON object'] };
+  const fields = [
+    'dailyLimit',
+    'monthlyLimit',
+    'medicationMonthlyBudget',
+    'billMonthlyBudget',
+    'approvalThreshold',
+  ] as const;
   for (const f of fields) {
     const v = body[f];
-    if (typeof v !== "number" || !Number.isFinite(v)) errors.push(`${f} must be a finite number`);
+    if (typeof v !== 'number' || !Number.isFinite(v))
+      errors.push(`${f} must be a finite number`);
     else if (v <= 0) errors.push(`${f} must be greater than 0`);
   }
-  if (typeof body.dailyLimit === "number" && typeof body.monthlyLimit === "number" && body.dailyLimit > body.monthlyLimit) {
-    errors.push("dailyLimit cannot exceed monthlyLimit");
+  if (
+    typeof body.dailyLimit === 'number' &&
+    typeof body.monthlyLimit === 'number' &&
+    body.dailyLimit > body.monthlyLimit
+  ) {
+    errors.push('dailyLimit cannot exceed monthlyLimit');
   }
-  if (typeof body.approvalThreshold === "number" && typeof body.dailyLimit === "number" && body.approvalThreshold > body.dailyLimit) {
-    errors.push("approvalThreshold cannot exceed dailyLimit");
+  if (
+    typeof body.approvalThreshold === 'number' &&
+    typeof body.dailyLimit === 'number' &&
+    body.approvalThreshold > body.dailyLimit
+  ) {
+    errors.push('approvalThreshold cannot exceed dailyLimit');
   }
   if (errors.length > 0) return { ok: false, errors };
   const policy = Object.fromEntries(fields.map((f) => [f, body[f]]));
   return { ok: true, policy };
 }
 
-app.post("/agent/policy", (req, res) => {
+app.post('/agent/policy', (req, res) => {
   const result = validatePolicyPayload(req.body);
-  if (!result.ok) return res.status(400).json({ error: "Invalid policy", details: result.errors });
+  if (!result.ok)
+    return res
+      .status(400)
+      .json({ error: 'Invalid policy', details: result.errors });
   setSpendingPolicy(result.policy);
   res.json({ success: true, policy: result.policy });
 });
-app.post("/agent/reset", (_req, res) => { resetSpendingTracker(); res.json({ success: true }); });
+app.post('/agent/reset', (_req, res) => {
+  resetSpendingTracker();
+  res.json({ success: true });
+});
 
 const DEFAULT_PROFILE = {
   recipient: {
-    name: "Rosa Garcia",
+    name: 'Rosa Garcia',
     age: 78,
-    medications: ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"],
-    doctor: "Dr. Chen, General Hospital",
-    insurance: "Medicare Part D",
+    medications: ['Lisinopril', 'Metformin', 'Atorvastatin', 'Amlodipine'],
+    doctor: 'Dr. Chen, General Hospital',
+    insurance: 'Medicare Part D',
   },
   caregiver: {
-    name: "Maria Garcia",
-    relationship: "Daughter",
-    location: "Phoenix, AZ (800 miles from Rosa)",
-    notifications: "Email + SMS",
+    name: 'Maria Garcia',
+    relationship: 'Daughter',
+    location: 'Phoenix, AZ (800 miles from Rosa)',
+    notifications: 'Email + SMS',
   },
 };
 
 let profileData = {
-  recipient: { ...DEFAULT_PROFILE.recipient, medications: [...DEFAULT_PROFILE.recipient.medications] },
+  recipient: {
+    ...DEFAULT_PROFILE.recipient,
+    medications: [...DEFAULT_PROFILE.recipient.medications],
+  },
   caregiver: { ...DEFAULT_PROFILE.caregiver },
 };
 
-app.get("/agent/profile", (_req, res) => { res.json(profileData); });
+app.get('/agent/profile', (_req, res) => {
+  res.json(profileData);
+});
 
-app.patch("/agent/profile", (req, res) => {
+app.patch('/agent/profile', (req, res) => {
   const { recipient, caregiver } = req.body ?? {};
-  if (recipient && typeof recipient === "object") {
+  if (recipient && typeof recipient === 'object') {
     profileData.recipient = { ...profileData.recipient, ...recipient };
     if (Array.isArray(recipient.medications)) {
       profileData.recipient.medications = recipient.medications;
     }
   }
-  if (caregiver && typeof caregiver === "object") {
+  if (caregiver && typeof caregiver === 'object') {
     profileData.caregiver = { ...profileData.caregiver, ...caregiver };
   }
   res.json(profileData);
@@ -513,50 +661,85 @@ app.patch("/agent/profile", (req, res) => {
 async function verifyWallet() {
   try {
     const account = await horizonServer.loadAccount(agentKeypair.publicKey());
-    const usdcBalance = account.balances.find((b: any) => b.asset_code === "USDC" && b.asset_issuer === process.env.USDC_ISSUER);
+    const usdcBalance = account.balances.find(
+      (b: any) =>
+        b.asset_code === 'USDC' && b.asset_issuer === process.env.USDC_ISSUER,
+    );
     if (!usdcBalance) {
-      logger.error({ wallet: agentKeypair.publicKey() }, "agent wallet has no USDC trustline — fund at https://faucet.circle.com");
+      logger.error(
+        { wallet: agentKeypair.publicKey() },
+        'agent wallet has no USDC trustline — fund at https://faucet.circle.com',
+      );
       process.exit(1);
     }
-    logger.info({ usdc: usdcBalance.balance, xlm: account.balances.find((b: any) => b.asset_type === "native")?.balance || "0" }, "wallet balances");
+    logger.info(
+      {
+        usdc: usdcBalance.balance,
+        xlm:
+          account.balances.find((b: any) => b.asset_type === 'native')
+            ?.balance || '0',
+      },
+      'wallet balances',
+    );
   } catch (err: any) {
-    logger.error({ err: err.message, wallet: agentKeypair.publicKey() }, "failed to load agent wallet");
+    logger.error(
+      { err: err.message, wallet: agentKeypair.publicKey() },
+      'failed to load agent wallet',
+    );
     process.exit(1);
   }
 }
 
-app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
-  if (err.type === "entity.too.large") {
-    return res.status(413).json({ error: "Request body too large", limit: err.limit });
-  }
-  next(err);
-});
+app.use(
+  (
+    err: any,
+    _req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    if (err.type === 'entity.too.large') {
+      return res
+        .status(413)
+        .json({ error: 'Request body too large', limit: err.limit });
+    }
+    next(err);
+  },
+);
 
 let isDraining = false;
-app.get("/ready", (_req, res) => {
+app.get('/ready', (_req, res) => {
   if (isDraining) {
-    res.status(503).send("Service Unavailable");
+    res.status(503).send('Service Unavailable');
     return;
   }
-  res.send("OK");
+  res.send('OK');
 });
 
 export { app };
 
 const server = app.listen(PORT, async () => {
-  logger.info({ port: PORT, network: "stellar:testnet", llm: LLM_MODEL, llmBaseUrl: LLM_BASE_URL, wallet: agentKeypair.publicKey() }, "CareGuard Agent started");
+  logger.info(
+    {
+      port: PORT,
+      network: 'stellar:testnet',
+      llm: LLM_MODEL,
+      llmBaseUrl: LLM_BASE_URL,
+      wallet: agentKeypair.publicKey(),
+    },
+    'CareGuard Agent started',
+  );
   await verifyWallet();
 });
 
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM received. Draining server...");
+process.on('SIGTERM', () => {
+  logger.info('SIGTERM received. Draining server...');
   isDraining = true;
   server.close(() => {
-    logger.info("Server closed. Exiting process.");
+    logger.info('Server closed. Exiting process.');
     process.exit(0);
   });
   setTimeout(() => {
-    logger.error("Graceful shutdown timeout. Forcing exit.");
+    logger.error('Graceful shutdown timeout. Forcing exit.');
     process.exit(1);
   }, 30000);
 });

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -50,6 +50,7 @@ const PORT = parseInt(process.env.AGENT_PORT || "3004");
 
 if (!process.env.LLM_API_KEY) throw new Error("LLM_API_KEY required in .env");
 if (!process.env.AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");
+if (!process.env.CAREGIVER_TOKEN) throw new Error("CAREGIVER_TOKEN required in .env");
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL || "https://api.groq.com/openai/v1";
 const LLM_MODEL = process.env.LLM_MODEL || "llama-3.3-70b-versatile";
@@ -61,6 +62,7 @@ const llm = new OpenAI({
 
 const agentKeypair = Keypair.fromSecret(process.env.AGENT_SECRET_KEY);
 const horizonServer = new Horizon.Server("https://horizon-testnet.stellar.org");
+const CAREGIVER_TOKEN = process.env.CAREGIVER_TOKEN;
 
 const SYSTEM_PROMPT = `You are CareGuard, an AI agent that manages healthcare spending for elderly care recipients on the Stellar blockchain. You work on behalf of a family caregiver to ensure their loved one gets the best prices on medications and catches errors in medical bills.
 
@@ -276,7 +278,19 @@ async function runAgent(task: string) {
 // Express API
 const app = express();
 
-app.use("/agent/audit", auditRouter);
+function requireCaregiverToken(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer ")) {
+    res.status(401).setHeader("WWW-Authenticate", "Bearer").json({ error: "Missing caregiver token" });
+    return;
+  }
+  if (auth.slice("Bearer ".length) !== CAREGIVER_TOKEN) {
+    res.status(403).json({ error: "Invalid caregiver token" });
+    return;
+  }
+  next();
+}
+
 app.use("/agent", rateLimiters.agent);
 app.use("/health", rateLimiters.health);
 app.use(rateLimiters.default);
@@ -286,6 +300,8 @@ app.use(createCorsMiddleware());
 app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
 app.use(requestContextMiddleware());
 app.use(requestLoggerMiddleware());
+app.use("/agent", requireCaregiverToken);
+app.use("/agent/audit", auditRouter);
 app.get("/metrics", metricsHandler());
 
 // Per-run tool call cap

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -75,7 +75,7 @@ IMPORTANT RULES:
 - If a payment requires caregiver approval, flag it and wait — do not proceed
 - If a payment is blocked by policy, explain why clearly
 - When comparing medication prices, compare ALL medications at once, then check interactions, then order from cheapest
-- When auditing a bill, use fetch_and_audit_bill which fetches Rosa's bill and audits it in one step. Never invent bill data.
+- When auditing a bill, use fetch_and_audit_bill which fetches Rosa's bill and audits it in one step. Never invent. The only billing data source is fetch_rosa_bill, which returns a sample bill for the demo. In production this is replaced with real EDI feeds.
 - Report the total savings found and the cost of the agent's API queries
 
 PAYMENT PROTOCOLS:

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -10,18 +10,29 @@
  *   include them in a PR. See data/README.md for details.
  */
 
-import "dotenv/config";
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
-import { logger } from "../shared/logger.ts";
-import { Keypair, Networks, TransactionBuilder, Operation, Asset, Horizon } from "@stellar/stellar-sdk";
-import { wrapFetchWithPayment, x402Client, decodePaymentResponseHeader } from "@x402/fetch";
-import { createEd25519Signer, ExactStellarScheme } from "@x402/stellar";
-import { Mppx } from "mppx/client";
-import { stellar as stellarCharge } from "@stellar/mpp/charge/client";
-import type { SpendingPolicy, Transaction } from "../shared/types.ts";
-import { SPENDING_TIMEZONE, getLocalDateStr } from "./tz.ts";
+import 'dotenv/config';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { logger } from '../shared/logger.ts';
+import {
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  Operation,
+  Asset,
+  Horizon,
+} from '@stellar/stellar-sdk';
+import {
+  wrapFetchWithPayment,
+  x402Client,
+  decodePaymentResponseHeader,
+} from '@x402/fetch';
+import { createEd25519Signer, ExactStellarScheme } from '@x402/stellar';
+import { Mppx } from 'mppx/client';
+import { stellar as stellarCharge } from '@stellar/mpp/charge/client';
+import type { SpendingPolicy, Transaction } from '../shared/types.ts';
+import { SPENDING_TIMEZONE, getLocalDateStr } from './tz.ts';
 export { SPENDING_TIMEZONE, getLocalDateStr };
-import { appendAuditEntry } from "../shared/audit-log.ts";
+import { appendAuditEntry } from '../shared/audit-log.ts';
 import {
   x402SettlementsTotal,
   paymentsUsdcTotal,
@@ -29,25 +40,33 @@ import {
   policyBlocksTotal,
   agentSpendingUsd,
   agentTransactionsTotal,
-} from "../shared/metrics.ts";
+} from '../shared/metrics.ts';
 
 // Environment
 const AGENT_SECRET_KEY = process.env.AGENT_SECRET_KEY;
-const PHARMACY_API = process.env.PHARMACY_API_URL || "http://localhost:3001";
-const BILL_AUDIT_API = process.env.BILL_AUDIT_API_URL || "http://localhost:3002";
-const DRUG_INTERACTION_API = process.env.DRUG_INTERACTION_API_URL || "http://localhost:3003";
-const PHARMACY_PAYMENT_API = process.env.PHARMACY_PAYMENT_API_URL || "http://localhost:3005";
-const USDC_ISSUER = process.env.USDC_ISSUER || "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-const HORIZON_URL = "https://horizon-testnet.stellar.org";
+const PHARMACY_API = process.env.PHARMACY_API_URL || 'http://localhost:3001';
+const BILL_AUDIT_API =
+  process.env.BILL_AUDIT_API_URL || 'http://localhost:3002';
+const DRUG_INTERACTION_API =
+  process.env.DRUG_INTERACTION_API_URL || 'http://localhost:3003';
+const PHARMACY_PAYMENT_API =
+  process.env.PHARMACY_PAYMENT_API_URL || 'http://localhost:3005';
+const USDC_ISSUER =
+  process.env.USDC_ISSUER ||
+  'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const HORIZON_URL = 'https://horizon-testnet.stellar.org';
 
-if (!AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");
+if (!AGENT_SECRET_KEY) throw new Error('AGENT_SECRET_KEY required in .env');
 
 const agentKeypair = Keypair.fromSecret(AGENT_SECRET_KEY);
 const horizonServer = new Horizon.Server(HORIZON_URL);
 
 // Helper: extract real Stellar tx hash from x402 PAYMENT-RESPONSE header
 function extractX402TxHash(response: Response): string | undefined {
-  const header = response.headers.get("PAYMENT-RESPONSE") || response.headers.get("payment-response") || response.headers.get("X-PAYMENT-RESPONSE");
+  const header =
+    response.headers.get('PAYMENT-RESPONSE') ||
+    response.headers.get('payment-response') ||
+    response.headers.get('X-PAYMENT-RESPONSE');
   if (!header) return undefined;
   try {
     const decoded = decodePaymentResponseHeader(header);
@@ -63,7 +82,7 @@ async function submitTransactionWithRetry(
   server: Horizon.Server,
   tx: any,
   maxRetries = 2,
-  timeoutMs = 35000
+  timeoutMs = 35000,
 ): Promise<any> {
   let lastError: any;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -75,12 +94,20 @@ async function submitTransactionWithRetry(
       // Don't retry if the server responded with a transaction failure
       if (err?.response?.status) throw err;
       // Don't retry if the transaction expired
-      const msg = err?.message ?? "";
-      if (msg.includes("tx_bad_seq") || msg.includes("tx_too_early") || msg.includes("tx_too_late")) throw err;
+      const msg = err?.message ?? '';
+      if (
+        msg.includes('tx_bad_seq') ||
+        msg.includes('tx_too_early') ||
+        msg.includes('tx_too_late')
+      )
+        throw err;
       if (attempt < maxRetries) {
         const delay = Math.pow(2, attempt) * 500;
-        logger.warn({ attempt: attempt + 1, maxRetries, delay }, "[Stellar] submitTransaction timeout, retrying");
-        await new Promise(r => setTimeout(r, delay));
+        logger.warn(
+          { attempt: attempt + 1, maxRetries, delay },
+          '[Stellar] submitTransaction timeout, retrying',
+        );
+        await new Promise((r) => setTimeout(r, delay));
       }
     }
   }
@@ -88,21 +115,29 @@ async function submitTransactionWithRetry(
 }
 
 // Helper: wait for a Stellar transaction to be confirmed on-chain
-async function waitForStellarSettlement(txHash: string, maxRetries = 5, intervalMs = 1000): Promise<boolean> {
+async function waitForStellarSettlement(
+  txHash: string,
+  maxRetries = 5,
+  intervalMs = 1000,
+): Promise<boolean> {
   for (let i = 0; i < maxRetries; i++) {
     try {
       await horizonServer.transactions().transaction(txHash).call();
       return true;
     } catch {
-      if (i < maxRetries - 1) await new Promise(r => setTimeout(r, intervalMs));
+      if (i < maxRetries - 1)
+        await new Promise((r) => setTimeout(r, intervalMs));
     }
   }
   return false;
 }
 
 // --- x402 Client: Auto-handles 402 Payment Required for API queries ---
-const signer = createEd25519Signer(AGENT_SECRET_KEY, "stellar:testnet");
-const x402ClientInstance = new x402Client().register("stellar:testnet", new ExactStellarScheme(signer));
+const signer = createEd25519Signer(AGENT_SECRET_KEY, 'stellar:testnet');
+const x402ClientInstance = new x402Client().register(
+  'stellar:testnet',
+  new ExactStellarScheme(signer),
+);
 const x402Fetch = wrapFetchWithPayment(fetch, x402ClientInstance);
 
 // --- MPP Client: Auto-handles 402 for medication order payments ---
@@ -113,10 +148,16 @@ const mppClient = Mppx.create({
   methods: [
     stellarCharge({
       keypair: agentKeypair,
-      mode: "pull",
+      mode: 'pull',
       onProgress: (event) => {
-        logger.info({ type: event.type, hash: "hash" in event ? (event as any).hash : undefined }, "[MPP] progress");
-        if (event.type === "paid" && "hash" in event) {
+        logger.info(
+          {
+            type: event.type,
+            hash: 'hash' in event ? (event as any).hash : undefined,
+          },
+          '[MPP] progress',
+        );
+        if (event.type === 'paid' && 'hash' in event) {
           lastMppTxHash = (event as any).hash;
         }
       },
@@ -126,7 +167,7 @@ const mppClient = Mppx.create({
 });
 
 // --- Persistent spending tracker ---
-const DATA_DIR = new URL("../data", import.meta.url).pathname;
+const DATA_DIR = new URL('../data', import.meta.url).pathname;
 const SPENDING_FILE = `${DATA_DIR}/spending.json`;
 
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
@@ -139,8 +180,9 @@ interface SpendingTracker {
 }
 
 function loadSpending(): SpendingTracker {
-  if (!existsSync(SPENDING_FILE)) return { medications: 0, bills: 0, serviceFees: 0, transactions: [] };
-  return JSON.parse(readFileSync(SPENDING_FILE, "utf-8"));
+  if (!existsSync(SPENDING_FILE))
+    return { medications: 0, bills: 0, serviceFees: 0, transactions: [] };
+  return JSON.parse(readFileSync(SPENDING_FILE, 'utf-8'));
 }
 
 function saveSpending(data: SpendingTracker) {
@@ -155,7 +197,7 @@ const MAX_PAYMENT = 1000;
 const MAX_ERROR_LENGTH = 500;
 
 function truncateError(message: string): string {
-  return message.replace(/<[^>]*>/g, "").slice(0, MAX_ERROR_LENGTH);
+  return message.replace(/<[^>]*>/g, '').slice(0, MAX_ERROR_LENGTH);
 }
 
 const DEFAULT_POLICY: SpendingPolicy = {
@@ -164,12 +206,16 @@ const DEFAULT_POLICY: SpendingPolicy = {
   medicationMonthlyBudget: 300,
   billMonthlyBudget: 500,
   approvalThreshold: 75,
+  holdTimeSeconds: 0,
 };
 
 function loadPolicy(): SpendingPolicy {
   if (!existsSync(POLICY_FILE)) return { ...DEFAULT_POLICY };
-  try { return JSON.parse(readFileSync(POLICY_FILE, "utf-8")); }
-  catch { return { ...DEFAULT_POLICY }; }
+  try {
+    return JSON.parse(readFileSync(POLICY_FILE, 'utf-8'));
+  } catch {
+    return { ...DEFAULT_POLICY };
+  }
 }
 
 function savePolicy(policy: SpendingPolicy) {
@@ -183,36 +229,51 @@ export function setSpendingPolicy(policy: SpendingPolicy) {
   currentPolicy = policy;
   savePolicy(policy);
   appendAuditEntry({
-    event: "policy.updated",
-    actor: "caregiver",
+    event: 'policy.updated',
+    actor: 'caregiver',
     details: {
       previous: { ...previous },
       current: { ...policy },
     },
   });
 }
-export function getSpendingTracker() { return { ...spendingTracker, policy: currentPolicy }; }
+export function getSpendingTracker() {
+  return { ...spendingTracker, policy: currentPolicy };
+}
 export function resetSpendingTracker() {
-  const previousTotal = spendingTracker.medications + spendingTracker.bills + spendingTracker.serviceFees;
-  spendingTracker = { medications: 0, bills: 0, serviceFees: 0, transactions: [] };
+  const previousTotal =
+    spendingTracker.medications +
+    spendingTracker.bills +
+    spendingTracker.serviceFees;
+  spendingTracker = {
+    medications: 0,
+    bills: 0,
+    serviceFees: 0,
+    transactions: [],
+  };
   saveSpending(spendingTracker);
   appendAuditEntry({
-    event: "spending.reset",
-    actor: "caregiver",
+    event: 'spending.reset',
+    actor: 'caregiver',
     details: { previousTotal: +previousTotal.toFixed(2) },
   });
 }
 
 // --- Tool: Compare pharmacy prices (pays via x402) ---
-export async function comparePharmacyPrices(drugName: string, zipCode: string = "90210") {
+export async function comparePharmacyPrices(
+  drugName: string,
+  zipCode: string = '90210',
+) {
   const url = `${PHARMACY_API}/pharmacy/compare?drug=${encodeURIComponent(drugName)}&zip=${encodeURIComponent(zipCode)}`;
-  logger.info({ drug: drugName }, "[x402] paying for pharmacy price query");
+  logger.info({ drug: drugName }, '[x402] paying for pharmacy price query');
 
   const response = await x402Fetch(url);
 
   if (!response.ok) {
     const error = await response.text();
-    throw new Error(`Pharmacy API error (${response.status}): ${truncateError(error)}`);
+    throw new Error(
+      `Pharmacy API error (${response.status}): ${truncateError(error)}`,
+    );
   }
 
   const data = await response.json();
@@ -224,7 +285,9 @@ export async function comparePharmacyPrices(drugName: string, zipCode: string = 
   if (txHash) {
     const settled = await waitForStellarSettlement(txHash);
     if (!settled) {
-      throw new Error(`x402 settlement not confirmed on-chain for tx ${txHash}`);
+      throw new Error(
+        `x402 settlement not confirmed on-chain for tx ${txHash}`,
+      );
     }
   }
 
@@ -233,16 +296,19 @@ export async function comparePharmacyPrices(drugName: string, zipCode: string = 
   spendingTracker.transactions.push({
     id: `tx-${Date.now()}`,
     timestamp: new Date().toISOString(),
-    type: "service_fee",
+    type: 'service_fee',
     description: `x402 query: pharmacy prices for ${drugName}`,
     amount: 0.002,
-    recipient: data.protocol?.payTo || "pharmacy-price-api",
+    recipient: data.protocol?.payTo || 'pharmacy-price-api',
     stellarTxHash: txHash,
-    status: "completed",
-    category: "service_fees",
+    status: 'completed',
+    category: 'service_fees',
   });
-  agentTransactionsTotal.inc({ status: "completed" });
-  agentSpendingUsd.set({ category: "service_fees" }, spendingTracker.serviceFees);
+  agentTransactionsTotal.inc({ status: 'completed' });
+  agentSpendingUsd.set(
+    { category: 'service_fees' },
+    spendingTracker.serviceFees,
+  );
   saveSpending(spendingTracker);
 
   return data;
@@ -255,7 +321,9 @@ export async function fetchRosaBill() {
   const response = await fetch(`${BILL_AUDIT_API}/bill/sample`);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch bill (${response.status}): service may be starting up. Try again in a moment.`);
+    throw new Error(
+      `Failed to fetch bill (${response.status}): service may be starting up. Try again in a moment.`,
+    );
   }
 
   return await response.json();
@@ -268,7 +336,9 @@ export async function fetchAndAuditBill() {
   // Step 1: Fetch the bill (free)
   const billResponse = await fetch(`${BILL_AUDIT_API}/bill/sample`);
   if (!billResponse.ok) {
-    throw new Error(`Failed to fetch bill (${billResponse.status}): service may be starting up.`);
+    throw new Error(
+      `Failed to fetch bill (${billResponse.status}): service may be starting up.`,
+    );
   }
   const bill = await billResponse.json();
 
@@ -277,44 +347,59 @@ export async function fetchAndAuditBill() {
 }
 
 // --- Tool: Audit a medical bill (pays via x402) ---
-export async function auditBill(lineItems: Array<{ description: string; cptCode: string; quantity: number; chargedAmount: number }>) {
-  logger.info({ lineItemCount: lineItems.length }, "[x402] paying for bill audit");
+export async function auditBill(
+  lineItems: Array<{
+    description: string;
+    cptCode: string;
+    quantity: number;
+    chargedAmount: number;
+  }>,
+) {
+  logger.info(
+    { lineItemCount: lineItems.length },
+    '[x402] paying for bill audit',
+  );
 
   let response: Response;
   try {
     response = await x402Fetch(`${BILL_AUDIT_API}/bill/audit`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ lineItems }),
     });
   } catch (err: any) {
     const baseUrl = BILL_AUDIT_API;
-    const docsHint = "See docs/setup/services.md for local service setup.";
-    const message = typeof err?.message === "string" ? err.message : "Unknown network error";
+    const docsHint = 'See docs/setup/services.md for local service setup.';
+    const message =
+      typeof err?.message === 'string' ? err.message : 'Unknown network error';
     const code = err?.cause?.code || err?.code;
 
-    if (code === "ECONNREFUSED") {
+    if (code === 'ECONNREFUSED') {
       throw new Error(
         `Bill Audit API connection refused (ECONNREFUSED). This is usually a config or startup issue. ` +
-        `Ensure BILL_AUDIT_API_URL points to a running service (currently ${baseUrl}). ${docsHint}`
+          `Ensure BILL_AUDIT_API_URL points to a running service (currently ${baseUrl}). ${docsHint}`,
       );
     }
 
-    if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT" || code === "UND_ERR_SOCKET") {
+    if (
+      code === 'ETIMEDOUT' ||
+      code === 'UND_ERR_CONNECT_TIMEOUT' ||
+      code === 'UND_ERR_SOCKET'
+    ) {
       throw new Error(
         `Bill Audit API request timed out. This is often transient (network hiccup or cold start). ` +
-        `Try again; if it persists, verify the service at ${baseUrl} is reachable. ${docsHint}`
+          `Try again; if it persists, verify the service at ${baseUrl} is reachable. ${docsHint}`,
       );
     }
 
-    if (code === "ENOTFOUND") {
+    if (code === 'ENOTFOUND') {
       throw new Error(
-        `Bill Audit API hostname not found (ENOTFOUND). Check BILL_AUDIT_API_URL (currently ${baseUrl}). ${docsHint}`
+        `Bill Audit API hostname not found (ENOTFOUND). Check BILL_AUDIT_API_URL (currently ${baseUrl}). ${docsHint}`,
       );
     }
 
     throw new Error(
-      `Bill Audit API unreachable. ${message}. Verify the service is reachable at ${baseUrl}. ${docsHint}`
+      `Bill Audit API unreachable. ${message}. Verify the service is reachable at ${baseUrl}. ${docsHint}`,
     );
   }
 
@@ -325,18 +410,20 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
     if (response.status >= 500) {
       throw new Error(
         `Bill Audit API is up but failing (${response.status}). This indicates a downstream/service bug or outage. ` +
-        `Try again later or check the Bill Audit service logs. Details: ${bodyPreview}`
+          `Try again later or check the Bill Audit service logs. Details: ${bodyPreview}`,
       );
     }
 
     if (response.status >= 400 && response.status < 500) {
       throw new Error(
         `Bill Audit API rejected the request (${response.status}). This is likely a caller/input issue. ` +
-        `Verify the payload schema and required env vars. Details: ${bodyPreview}`
+          `Verify the payload schema and required env vars. Details: ${bodyPreview}`,
       );
     }
 
-    throw new Error(`Bill Audit API error (${response.status}): ${bodyPreview}`);
+    throw new Error(
+      `Bill Audit API error (${response.status}): ${bodyPreview}`,
+    );
   }
 
   const data = await response.json();
@@ -347,7 +434,9 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
   if (txHash) {
     const settled = await waitForStellarSettlement(txHash);
     if (!settled) {
-      throw new Error(`x402 settlement not confirmed on-chain for tx ${txHash}`);
+      throw new Error(
+        `x402 settlement not confirmed on-chain for tx ${txHash}`,
+      );
     }
   }
 
@@ -356,16 +445,19 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
   spendingTracker.transactions.push({
     id: `tx-${Date.now()}`,
     timestamp: new Date().toISOString(),
-    type: "service_fee",
-    description: "x402 query: medical bill audit",
+    type: 'service_fee',
+    description: 'x402 query: medical bill audit',
     amount: 0.01,
-    recipient: data.protocol?.payTo || "bill-audit-api",
+    recipient: data.protocol?.payTo || 'bill-audit-api',
     stellarTxHash: txHash,
-    status: "completed",
-    category: "service_fees",
+    status: 'completed',
+    category: 'service_fees',
   });
-  agentTransactionsTotal.inc({ status: "completed" });
-  agentSpendingUsd.set({ category: "service_fees" }, spendingTracker.serviceFees);
+  agentTransactionsTotal.inc({ status: 'completed' });
+  agentSpendingUsd.set(
+    { category: 'service_fees' },
+    spendingTracker.serviceFees,
+  );
   saveSpending(spendingTracker);
 
   return data;
@@ -373,14 +465,21 @@ export async function auditBill(lineItems: Array<{ description: string; cptCode:
 
 // --- Tool: Check drug interactions (pays via x402) ---
 export async function checkDrugInteractions(medications: string[]) {
-  const medsParam = medications.join(",");
-  logger.info({ medicationCount: medications.length }, "[x402] paying for drug interaction check");
+  const medsParam = medications.join(',');
+  logger.info(
+    { medicationCount: medications.length },
+    '[x402] paying for drug interaction check',
+  );
 
-  const response = await x402Fetch(`${DRUG_INTERACTION_API}/drug/interactions?meds=${encodeURIComponent(medsParam)}`);
+  const response = await x402Fetch(
+    `${DRUG_INTERACTION_API}/drug/interactions?meds=${encodeURIComponent(medsParam)}`,
+  );
 
   if (!response.ok) {
     const error = await response.text();
-    throw new Error(`Drug Interaction API error (${response.status}): ${truncateError(error)}`);
+    throw new Error(
+      `Drug Interaction API error (${response.status}): ${truncateError(error)}`,
+    );
   }
 
   const data = await response.json();
@@ -391,7 +490,9 @@ export async function checkDrugInteractions(medications: string[]) {
   if (txHash) {
     const settled = await waitForStellarSettlement(txHash);
     if (!settled) {
-      throw new Error(`x402 settlement not confirmed on-chain for tx ${txHash}`);
+      throw new Error(
+        `x402 settlement not confirmed on-chain for tx ${txHash}`,
+      );
     }
   }
 
@@ -400,99 +501,409 @@ export async function checkDrugInteractions(medications: string[]) {
   spendingTracker.transactions.push({
     id: `tx-${Date.now()}`,
     timestamp: new Date().toISOString(),
-    type: "service_fee",
-    description: `x402 query: drug interactions for ${medications.join(", ")}`,
+    type: 'service_fee',
+    description: `x402 query: drug interactions for ${medications.join(', ')}`,
     amount: 0.001,
-    recipient: data.protocol?.payTo || "drug-interaction-api",
+    recipient: data.protocol?.payTo || 'drug-interaction-api',
     stellarTxHash: txHash,
-    status: "completed",
-    category: "service_fees",
+    status: 'completed',
+    category: 'service_fees',
   });
-  agentTransactionsTotal.inc({ status: "completed" });
-  agentSpendingUsd.set({ category: "service_fees" }, spendingTracker.serviceFees);
+  agentTransactionsTotal.inc({ status: 'completed' });
+  agentSpendingUsd.set(
+    { category: 'service_fees' },
+    spendingTracker.serviceFees,
+  );
   saveSpending(spendingTracker);
 
   return data;
 }
 
 // --- Tool: Check spending policy ---
-export function checkSpendingPolicy(amount: number, category: "medications" | "bills") {
-  const budget = category === "medications" ? currentPolicy.medicationMonthlyBudget : currentPolicy.billMonthlyBudget;
-  const currentSpending = category === "medications" ? spendingTracker.medications : spendingTracker.bills;
+export function checkSpendingPolicy(
+  amount: number,
+  category: 'medications' | 'bills',
+) {
+  const budget =
+    category === 'medications'
+      ? currentPolicy.medicationMonthlyBudget
+      : currentPolicy.billMonthlyBudget;
+  const currentSpending =
+    category === 'medications'
+      ? spendingTracker.medications
+      : spendingTracker.bills;
   const remaining = budget - currentSpending;
 
   if (amount > remaining) {
     return {
       allowed: false,
       reason: `Payment of $${amount.toFixed(2)} exceeds ${category} monthly budget. Budget: $${budget}, spent: $${currentSpending.toFixed(2)}, remaining: $${remaining.toFixed(2)}`,
-      requiresApproval: false, currentSpending, budgetRemaining: remaining,
+      requiresApproval: false,
+      currentSpending,
+      budgetRemaining: remaining,
     };
   }
 
   const today = getLocalDateStr(SPENDING_TIMEZONE);
   const totalToday = spendingTracker.transactions
-    .filter(t => getLocalDateStr(SPENDING_TIMEZONE, new Date(t.timestamp)) === today && t.category === category)
+    .filter(
+      (t) =>
+        getLocalDateStr(SPENDING_TIMEZONE, new Date(t.timestamp)) === today &&
+        t.category === category,
+    )
     .reduce((sum, t) => sum + t.amount, 0);
 
   if (totalToday + amount > currentPolicy.dailyLimit) {
     return {
       allowed: false,
       reason: `Payment of $${amount.toFixed(2)} would exceed daily limit of $${currentPolicy.dailyLimit}. Already spent today: $${totalToday.toFixed(2)}`,
-      requiresApproval: false, currentSpending, budgetRemaining: remaining,
+      requiresApproval: false,
+      currentSpending,
+      budgetRemaining: remaining,
     };
   }
 
-  return { allowed: true, requiresApproval: amount > currentPolicy.approvalThreshold, currentSpending, budgetRemaining: remaining - amount };
+  return {
+    allowed: true,
+    requiresApproval: amount > currentPolicy.approvalThreshold,
+    currentSpending,
+    budgetRemaining: remaining - amount,
+  };
+}
+
+async function executeMedicationPayment(
+  pharmacyId: string,
+  pharmacyName: string,
+  drugName: string,
+  amount: number,
+) {
+  logger.info(
+    { pharmacy: pharmacyName, amount },
+    '[MPP] paying for medication',
+  );
+
+  let stellarTxHash: string | undefined;
+  let mppOrderId: string | undefined;
+  lastMppTxHash = undefined;
+
+  try {
+    const response = await mppClient.fetch(
+      `${PHARMACY_PAYMENT_API}/pharmacy/order`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          drug: drugName,
+          pharmacy: pharmacyName,
+          amount,
+        }),
+      },
+    );
+
+    const data = await response.json();
+    if (!data.success) {
+      throw new Error(data.error || 'MPP payment failed');
+    }
+
+    stellarTxHash = lastMppTxHash;
+    if (!stellarTxHash) {
+      const receiptHeader =
+        response.headers.get('Payment-Receipt') ||
+        response.headers.get('payment-receipt');
+      if (receiptHeader) {
+        try {
+          const receipt = JSON.parse(
+            Buffer.from(receiptHeader, 'base64').toString(),
+          );
+          stellarTxHash =
+            receipt.reference || receipt.hash || receipt.transaction;
+        } catch {
+          stellarTxHash = receiptHeader;
+        }
+      }
+    }
+
+    mppOrderId = data.order?.id;
+  } catch (err: any) {
+    stellarTxSubmittedTotal.inc({ result: 'error' });
+    return { success: false, error: `MPP payment failed: ${err.message}` };
+  }
+
+  stellarTxSubmittedTotal.inc({ result: 'success' });
+  paymentsUsdcTotal.inc({ type: 'medication' });
+
+  return { success: true, stellarTxHash, mppOrderId };
+}
+
+async function executeBillPayment(
+  providerId: string,
+  providerName: string,
+  description: string,
+  amount: number,
+) {
+  const recipientKey = process.env.BILL_PROVIDER_PUBLIC_KEY;
+  if (!recipientKey) {
+    return { success: false, error: 'BILL_PROVIDER_PUBLIC_KEY not configured' };
+  }
+
+  logger.info(
+    { provider: providerName, amount },
+    '[Stellar] transferring USDC',
+  );
+
+  let stellarTxHash: string | undefined;
+  try {
+    const account = await horizonServer.loadAccount(agentKeypair.publicKey());
+    const usdcAsset = new Asset('USDC', USDC_ISSUER);
+
+    const stellarTx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: recipientKey,
+          asset: usdcAsset,
+          amount: amount.toFixed(7),
+        }),
+      )
+      .setTimeout(30)
+      .build();
+
+    stellarTx.sign(agentKeypair);
+
+    const sigHint = stellarTx.signatures[0]?.hint();
+    if (!sigHint || !sigHint.equals(agentKeypair.signatureHint())) {
+      throw new Error(
+        `Signer mismatch: expected ${agentKeypair.publicKey()} — refusing to submit`,
+      );
+    }
+
+    const result = await submitTransactionWithRetry(horizonServer, stellarTx);
+    stellarTxHash = result.hash;
+    logger.info({ txHash: stellarTxHash }, '[Stellar] TX confirmed');
+  } catch (err: any) {
+    stellarTxSubmittedTotal.inc({ result: 'error' });
+    const errorDetail =
+      err?.response?.data?.extras?.result_codes || err.message;
+    return {
+      success: false,
+      error: `Stellar USDC transfer failed: ${JSON.stringify(errorDetail)}`,
+    };
+  }
+
+  stellarTxSubmittedTotal.inc({ result: 'success' });
+  paymentsUsdcTotal.inc({ type: 'bill' });
+
+  return { success: true, stellarTxHash };
+}
+
+async function getPendingTransaction(txId: string) {
+  const tracker = getSpendingTracker();
+  const tx = tracker.transactions.find((t: any) => t.id === txId);
+  if (!tx) {
+    return { error: 'Transaction not found' };
+  }
+  if (tx.status !== 'pending') {
+    return { error: 'Transaction is not pending' };
+  }
+  return { tx, tracker };
+}
+
+export async function approvePendingTransaction(txId: string) {
+  const tracker = loadSpending();
+  const tx = tracker.transactions.find((t: any) => t.id === txId);
+  if (!tx) return { success: false, error: 'Transaction not found' };
+  if (tx.status !== 'pending')
+    return { success: false, error: 'Transaction is not pending' };
+
+  let result: any;
+  try {
+    if (tx.category === 'medications') {
+      const match = tx.description.match(/(.+) from (.+)/);
+      if (!match) throw new Error('Cannot parse transaction description');
+      const [, drugName, pharmacyName] = match;
+      result = await executeMedicationPayment(
+        tx.recipient,
+        pharmacyName,
+        drugName,
+        tx.amount,
+      );
+    } else if (tx.category === 'bills') {
+      const match = tx.description.match(/(.+) — (.+)/);
+      if (!match) throw new Error('Cannot parse transaction description');
+      const [, description, providerName] = match;
+      result = await executeBillPayment(
+        tx.recipient,
+        providerName,
+        description,
+        tx.amount,
+      );
+    } else {
+      throw new Error('Unknown transaction category');
+    }
+  } catch (err: any) {
+    tx.status = 'rejected';
+    saveSpending(tracker);
+    spendingTracker = tracker;
+    return { success: false, error: err.message };
+  }
+
+  if (!result.success) {
+    tx.status = 'rejected';
+    saveSpending(tracker);
+    spendingTracker = tracker;
+    return { success: false, error: result.error };
+  }
+
+  tx.status = 'completed';
+  tx.stellarTxHash = result.stellarTxHash;
+  if (result.mppOrderId) tx.mppOrderId = result.mppOrderId;
+
+  if (tx.category === 'medications') {
+    spendingTracker.medications += tx.amount;
+    agentSpendingUsd.set(
+      { category: 'medications' },
+      spendingTracker.medications,
+    );
+  } else if (tx.category === 'bills') {
+    spendingTracker.bills += tx.amount;
+    agentSpendingUsd.set({ category: 'bills' }, spendingTracker.bills);
+  }
+  agentTransactionsTotal.inc({ status: 'completed' });
+  tracker.transactions = tracker.transactions.map((t: any) =>
+    t.id === tx.id ? tx : t,
+  );
+  saveSpending(tracker);
+  spendingTracker = tracker;
+
+  return { success: true, transaction: tx };
+}
+
+export function cancelPendingTransaction(txId: string) {
+  const tracker = loadSpending();
+  const tx = tracker.transactions.find((t: any) => t.id === txId);
+  if (!tx) return { success: false, error: 'Transaction not found' };
+  if (tx.status !== 'pending')
+    return { success: false, error: 'Transaction is not pending' };
+
+  tx.status = 'cancelled';
+  tracker.transactions = tracker.transactions.map((t: any) =>
+    t.id === tx.id ? tx : t,
+  );
+  saveSpending(tracker);
+  spendingTracker = tracker;
+  return { success: true, transaction: tx };
+}
+
+export async function processPendingTransactions() {
+  const tracker = loadSpending();
+  const now = Date.now();
+  const pending = tracker.transactions.filter(
+    (t: any) =>
+      t.status === 'pending' &&
+      t.pendingUntil &&
+      new Date(t.pendingUntil).getTime() <= now,
+  );
+  for (const tx of pending) {
+    await approvePendingTransaction(tx.id);
+  }
+  return { processed: pending.map((t: any) => t.id) };
 }
 
 // --- Tool: Pay for medication via MPP Charge (real Stellar payment) ---
-export async function payForMedication(pharmacyId: string, pharmacyName: string, drugName: string, amount: number, skipApproval: boolean = false) {
+export async function payForMedication(
+  pharmacyId: string,
+  pharmacyName: string,
+  drugName: string,
+  amount: number,
+  skipApproval: boolean = false,
+) {
   if (!Number.isFinite(amount) || amount <= 0 || amount > MAX_PAYMENT) {
-    return { success: false, error: `Invalid payment amount: $${amount}. Amount must be a positive finite number <= $${MAX_PAYMENT}.` };
+    return {
+      success: false,
+      error: `Invalid payment amount: $${amount}. Amount must be a positive finite number <= $${MAX_PAYMENT}.`,
+    };
   }
-  const policyCheck = checkSpendingPolicy(amount, "medications");
+  const policyCheck = checkSpendingPolicy(amount, 'medications');
   if (!policyCheck.allowed) {
-    const reason = policyCheck.reason.includes("daily") ? "daily_limit" : "budget";
+    const reason = policyCheck.reason.includes('daily')
+      ? 'daily_limit'
+      : 'budget';
     policyBlocksTotal.inc({ reason });
-    return { success: false, error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}` };
+    return {
+      success: false,
+      error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}`,
+    };
   }
   if (policyCheck.requiresApproval && !skipApproval) {
-    policyBlocksTotal.inc({ reason: "approval_required" });
-    const tx: Transaction = {
-      id: `tx-${Date.now()}`, timestamp: new Date().toISOString(), type: "medication",
-      description: `${drugName} from ${pharmacyName}`, amount, recipient: pharmacyId,
-      status: "pending", category: "medications",
+    policyBlocksTotal.inc({ reason: 'approval_required' });
+    const holdSeconds = (currentPolicy as any)?.holdTimeSeconds ?? 0;
+    const submittedAt = new Date().toISOString();
+    const pendingUntil = new Date(
+      Date.now() + holdSeconds * 1000,
+    ).toISOString();
+    const tx: Transaction & { pendingUntil?: string; submittedAt?: string } = {
+      id: `tx-${Date.now()}`,
+      timestamp: submittedAt,
+      type: 'medication',
+      description: `${drugName} from ${pharmacyName}`,
+      amount,
+      recipient: pharmacyId,
+      status: 'pending',
+      category: 'medications',
+      pendingUntil,
+      submittedAt,
     };
     spendingTracker.transactions.push(tx);
-    agentTransactionsTotal.inc({ status: "pending" });
+    agentTransactionsTotal.inc({ status: 'pending' });
     saveSpending(spendingTracker);
-    return { success: false, error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} exceeds the $${currentPolicy.approvalThreshold} approval threshold.`, transaction: tx };
+    return {
+      success: false,
+      error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} exceeds the $${currentPolicy.approvalThreshold} approval threshold.`,
+      transaction: tx,
+    };
   }
 
   // Execute real MPP charge payment to pharmacy
-  logger.info({ pharmacy: pharmacyName, amount }, "[MPP] paying for medication");
+  logger.info(
+    { pharmacy: pharmacyName, amount },
+    '[MPP] paying for medication',
+  );
 
   let stellarTxHash: string | undefined;
   let mppOrderId: string | undefined;
   lastMppTxHash = undefined; // reset before this payment
 
   try {
-    const response = await mppClient.fetch(`${PHARMACY_PAYMENT_API}/pharmacy/order`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ drug: drugName, pharmacy: pharmacyName, amount }),
-    });
+    const response = await mppClient.fetch(
+      `${PHARMACY_PAYMENT_API}/pharmacy/order`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          drug: drugName,
+          pharmacy: pharmacyName,
+          amount,
+        }),
+      },
+    );
 
     const data = await response.json();
     if (data.success) {
       // Try to get tx hash from: 1) MPP progress event, 2) Payment-Receipt header
       stellarTxHash = lastMppTxHash;
       if (!stellarTxHash) {
-        const receiptHeader = response.headers.get("Payment-Receipt") || response.headers.get("payment-receipt");
+        const receiptHeader =
+          response.headers.get('Payment-Receipt') ||
+          response.headers.get('payment-receipt');
         if (receiptHeader) {
           try {
-            const receipt = JSON.parse(Buffer.from(receiptHeader, "base64").toString());
-            stellarTxHash = receipt.reference || receipt.hash || receipt.transaction;
+            const receipt = JSON.parse(
+              Buffer.from(receiptHeader, 'base64').toString(),
+            );
+            stellarTxHash =
+              receipt.reference || receipt.hash || receipt.transaction;
           } catch {
             stellarTxHash = receiptHeader;
           }
@@ -501,69 +912,113 @@ export async function payForMedication(pharmacyId: string, pharmacyName: string,
       // data.order.id is an MPP order identifier — kept separate from stellarTxHash
       mppOrderId = data.order?.id;
     } else {
-      throw new Error(data.error || "MPP payment failed");
+      throw new Error(data.error || 'MPP payment failed');
     }
   } catch (err: any) {
-    stellarTxSubmittedTotal.inc({ result: "error" });
+    stellarTxSubmittedTotal.inc({ result: 'error' });
     return { success: false, error: `MPP payment failed: ${err.message}` };
   }
 
-  stellarTxSubmittedTotal.inc({ result: "success" });
-  paymentsUsdcTotal.inc({ type: "medication" });
+  stellarTxSubmittedTotal.inc({ result: 'success' });
+  paymentsUsdcTotal.inc({ type: 'medication' });
 
   const tx: Transaction = {
-    id: `tx-${Date.now()}`, timestamp: new Date().toISOString(), type: "medication",
-    description: `${drugName} from ${pharmacyName} [MPP Charge]`, amount, recipient: pharmacyId,
-    stellarTxHash, mppOrderId, status: "completed", category: "medications",
+    id: `tx-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    type: 'medication',
+    description: `${drugName} from ${pharmacyName} [MPP Charge]`,
+    amount,
+    recipient: pharmacyId,
+    stellarTxHash,
+    mppOrderId,
+    status: 'completed',
+    category: 'medications',
   };
 
   spendingTracker.medications += amount;
   spendingTracker.transactions.push(tx);
-  agentTransactionsTotal.inc({ status: "completed" });
-  agentSpendingUsd.set({ category: "medications" }, spendingTracker.medications);
+  agentTransactionsTotal.inc({ status: 'completed' });
+  agentSpendingUsd.set(
+    { category: 'medications' },
+    spendingTracker.medications,
+  );
   saveSpending(spendingTracker);
 
   return { success: true, transaction: tx };
 }
 
 // --- Tool: Pay a medical bill via real Stellar USDC transfer ---
-export async function payBill(providerId: string, providerName: string, description: string, amount: number, skipApproval: boolean = false) {
+export async function payBill(
+  providerId: string,
+  providerName: string,
+  description: string,
+  amount: number,
+  skipApproval: boolean = false,
+) {
   if (!Number.isFinite(amount) || amount <= 0 || amount > MAX_PAYMENT) {
-    return { success: false, error: `Invalid payment amount: $${amount}. Amount must be a positive finite number <= $${MAX_PAYMENT}.` };
+    return {
+      success: false,
+      error: `Invalid payment amount: $${amount}. Amount must be a positive finite number <= $${MAX_PAYMENT}.`,
+    };
   }
-  const policyCheck = checkSpendingPolicy(amount, "bills");
+  const policyCheck = checkSpendingPolicy(amount, 'bills');
   if (!policyCheck.allowed) {
-    const reason = policyCheck.reason.includes("daily") ? "daily_limit" : "budget";
+    const reason = policyCheck.reason.includes('daily')
+      ? 'daily_limit'
+      : 'budget';
     policyBlocksTotal.inc({ reason });
-    return { success: false, error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}` };
+    return {
+      success: false,
+      error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}`,
+    };
   }
   if (policyCheck.requiresApproval && !skipApproval) {
-    policyBlocksTotal.inc({ reason: "approval_required" });
-    const tx: Transaction = {
-      id: `tx-${Date.now()}`, timestamp: new Date().toISOString(), type: "bill",
-      description: `${description} — ${providerName}`, amount, recipient: providerId,
-      status: "pending", category: "bills",
+    policyBlocksTotal.inc({ reason: 'approval_required' });
+    const holdSeconds = (currentPolicy as any)?.holdTimeSeconds ?? 0;
+    const submittedAt = new Date().toISOString();
+    const pendingUntil = new Date(
+      Date.now() + holdSeconds * 1000,
+    ).toISOString();
+    const tx: Transaction & { pendingUntil?: string; submittedAt?: string } = {
+      id: `tx-${Date.now()}`,
+      timestamp: submittedAt,
+      type: 'bill',
+      description: `${description} — ${providerName}`,
+      amount,
+      recipient: providerId,
+      status: 'pending',
+      category: 'bills',
+      pendingUntil,
+      submittedAt,
     };
     spendingTracker.transactions.push(tx);
-    agentTransactionsTotal.inc({ status: "pending" });
+    agentTransactionsTotal.inc({ status: 'pending' });
     saveSpending(spendingTracker);
-    return { success: false, error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} exceeds the $${currentPolicy.approvalThreshold} approval threshold.`, transaction: tx };
+    return {
+      success: false,
+      error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} exceeds the $${currentPolicy.approvalThreshold} approval threshold.`,
+      transaction: tx,
+    };
   }
 
   // Execute real Stellar USDC transfer
   const recipientKey = process.env.BILL_PROVIDER_PUBLIC_KEY;
-  if (!recipientKey) return { success: false, error: "BILL_PROVIDER_PUBLIC_KEY not configured" };
+  if (!recipientKey)
+    return { success: false, error: 'BILL_PROVIDER_PUBLIC_KEY not configured' };
 
-  logger.info({ provider: providerName, amount }, "[Stellar] transferring USDC");
+  logger.info(
+    { provider: providerName, amount },
+    '[Stellar] transferring USDC',
+  );
 
   let stellarTxHash: string | undefined;
 
   try {
     const account = await horizonServer.loadAccount(agentKeypair.publicKey());
-    const usdcAsset = new Asset("USDC", USDC_ISSUER);
+    const usdcAsset = new Asset('USDC', USDC_ISSUER);
 
     const stellarTx = new TransactionBuilder(account, {
-      fee: "100",
+      fee: '100',
       networkPassphrase: Networks.TESTNET,
     })
       .addOperation(
@@ -571,7 +1026,7 @@ export async function payBill(providerId: string, providerName: string, descript
           destination: recipientKey,
           asset: usdcAsset,
           amount: amount.toFixed(7),
-        })
+        }),
       )
       .setTimeout(30)
       .build();
@@ -583,33 +1038,45 @@ export async function payBill(providerId: string, providerName: string, descript
     const sigHint = stellarTx.signatures[0]?.hint();
     if (!sigHint || !sigHint.equals(agentKeypair.signatureHint())) {
       throw new Error(
-        `Signer mismatch: expected ${agentKeypair.publicKey()} — refusing to submit`
+        `Signer mismatch: expected ${agentKeypair.publicKey()} — refusing to submit`,
       );
     }
-    console.log(`  [Stellar] Signer verified: ${agentKeypair.publicKey().slice(0, 8)}...`);
+    console.log(
+      `  [Stellar] Signer verified: ${agentKeypair.publicKey().slice(0, 8)}...`,
+    );
 
     const result = await submitTransactionWithRetry(horizonServer, stellarTx);
     stellarTxHash = result.hash;
-    logger.info({ txHash: stellarTxHash }, "[Stellar] TX confirmed");
+    logger.info({ txHash: stellarTxHash }, '[Stellar] TX confirmed');
   } catch (err: any) {
-    stellarTxSubmittedTotal.inc({ result: "error" });
-    const errorDetail = err?.response?.data?.extras?.result_codes || err.message;
-    return { success: false, error: `Stellar USDC transfer failed: ${JSON.stringify(errorDetail)}` };
+    stellarTxSubmittedTotal.inc({ result: 'error' });
+    const errorDetail =
+      err?.response?.data?.extras?.result_codes || err.message;
+    return {
+      success: false,
+      error: `Stellar USDC transfer failed: ${JSON.stringify(errorDetail)}`,
+    };
   }
 
-  stellarTxSubmittedTotal.inc({ result: "success" });
-  paymentsUsdcTotal.inc({ type: "bill" });
+  stellarTxSubmittedTotal.inc({ result: 'success' });
+  paymentsUsdcTotal.inc({ type: 'bill' });
 
   const tx: Transaction = {
-    id: `tx-${Date.now()}`, timestamp: new Date().toISOString(), type: "bill",
-    description: `${description} — ${providerName} [Stellar USDC]`, amount, recipient: providerId,
-    stellarTxHash, status: "completed", category: "bills",
+    id: `tx-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    type: 'bill',
+    description: `${description} — ${providerName} [Stellar USDC]`,
+    amount,
+    recipient: providerId,
+    stellarTxHash,
+    status: 'completed',
+    category: 'bills',
   };
 
   spendingTracker.bills += amount;
   spendingTracker.transactions.push(tx);
-  agentTransactionsTotal.inc({ status: "completed" });
-  agentSpendingUsd.set({ category: "bills" }, spendingTracker.bills);
+  agentTransactionsTotal.inc({ status: 'completed' });
+  agentSpendingUsd.set({ category: 'bills' }, spendingTracker.bills);
   saveSpending(spendingTracker);
 
   return { success: true, transaction: tx };
@@ -617,7 +1084,10 @@ export async function payBill(providerId: string, providerName: string, descript
 
 // --- Tool: Get spending summary ---
 export function getSpendingSummary() {
-  const total = spendingTracker.medications + spendingTracker.bills + spendingTracker.serviceFees;
+  const total =
+    spendingTracker.medications +
+    spendingTracker.bills +
+    spendingTracker.serviceFees;
   return {
     policy: currentPolicy,
     spending: {
@@ -627,8 +1097,12 @@ export function getSpendingSummary() {
       total: +total.toFixed(2),
     },
     budgetRemaining: {
-      medications: +(currentPolicy.medicationMonthlyBudget - spendingTracker.medications).toFixed(2),
-      bills: +(currentPolicy.billMonthlyBudget - spendingTracker.bills).toFixed(2),
+      medications: +(
+        currentPolicy.medicationMonthlyBudget - spendingTracker.medications
+      ).toFixed(2),
+      bills: +(currentPolicy.billMonthlyBudget - spendingTracker.bills).toFixed(
+        2,
+      ),
     },
     transactionCount: spendingTracker.transactions.length,
     recentTransactions: spendingTracker.transactions.slice(-5),
@@ -638,29 +1112,36 @@ export function getSpendingSummary() {
 // --- Tool: Get wallet balance from Horizon ---
 export async function getWalletBalance() {
   const address = agentKeypair.publicKey();
-  logger.info({ address }, "[Horizon] fetching wallet balance");
+  logger.info({ address }, '[Horizon] fetching wallet balance');
 
   try {
     const account = await horizonServer.loadAccount(address);
-    
+
     const usdcBalance = account.balances.find(
-      (b: any) => b.asset_code === "USDC" && b.asset_issuer === USDC_ISSUER
+      (b: any) => b.asset_code === 'USDC' && b.asset_issuer === USDC_ISSUER,
     );
-    
+
     const xlmBalance = account.balances.find(
-      (b: any) => b.asset_type === "native"
+      (b: any) => b.asset_type === 'native',
     );
 
     return {
       address,
       balances: {
-        usdc: usdcBalance ? parseFloat((usdcBalance as any).balance).toFixed(2) : "0.00",
-        xlm: xlmBalance ? parseFloat((xlmBalance as any).balance).toFixed(2) : "0.00",
+        usdc: usdcBalance
+          ? parseFloat((usdcBalance as any).balance).toFixed(2)
+          : '0.00',
+        xlm: xlmBalance
+          ? parseFloat((xlmBalance as any).balance).toFixed(2)
+          : '0.00',
       },
       timestamp: new Date().toISOString(),
     };
   } catch (err: any) {
-    logger.error({ err: err.message, address }, "[Horizon] failed to fetch balance");
+    logger.error(
+      { err: err.message, address },
+      '[Horizon] failed to fetch balance',
+    );
     throw new Error(`Failed to fetch wallet balance: ${err.message}`);
   }
 }
@@ -668,119 +1149,167 @@ export async function getWalletBalance() {
 // Claude API tool definitions
 export const TOOL_DEFINITIONS = [
   {
-    name: "compare_pharmacy_prices",
-    description: "Compare medication prices across multiple pharmacies. Pays $0.002 USDC per query via x402 on Stellar. Returns prices sorted cheapest to most expensive, with potential savings.",
+    name: 'compare_pharmacy_prices',
+    description:
+      'Compare medication prices across multiple pharmacies. Pays $0.002 USDC per query via x402 on Stellar. Returns prices sorted cheapest to most expensive, with potential savings.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        drug_name: { type: "string", description: "Name of the medication (e.g., Lisinopril, Metformin)" },
-        zip_code: { type: "string", description: "ZIP code for pharmacy location (default: 90210)" },
-      },
-      required: ["drug_name"],
-    },
-  },
-  {
-    name: "audit_medical_bill",
-    description: "Audit a medical bill for errors (duplicates, upcoding, overcharges). 80% of medical bills contain errors. Pays $0.01 USDC per audit via x402 on Stellar. Pass line_items as a JSON string array of objects with fields: description, cptCode, quantity, chargedAmount.",
-    input_schema: {
-      type: "object" as const,
-      properties: {
-        line_items_json: {
-          type: "string",
-          description: "JSON string of line items array. Each item: {\"description\":\"...\",\"cptCode\":\"...\",\"quantity\":1,\"chargedAmount\":100}",
+        drug_name: {
+          type: 'string',
+          description: 'Name of the medication (e.g., Lisinopril, Metformin)',
+        },
+        zip_code: {
+          type: 'string',
+          description: 'ZIP code for pharmacy location (default: 90210)',
         },
       },
-      required: ["line_items_json"],
+      required: ['drug_name'],
     },
   },
   {
-    name: "check_drug_interactions",
-    description: "Check for drug-drug interactions. Pays $0.001 USDC per check via x402 on Stellar. Returns severity levels and clinical recommendations.",
+    name: 'audit_medical_bill',
+    description:
+      'Audit a medical bill for errors (duplicates, upcoding, overcharges). 80% of medical bills contain errors. Pays $0.01 USDC per audit via x402 on Stellar. Pass line_items as a JSON string array of objects with fields: description, cptCode, quantity, chargedAmount.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        medications: { type: "array", items: { type: "string" }, description: "List of medication names" },
+        line_items_json: {
+          type: 'string',
+          description:
+            'JSON string of line items array. Each item: {"description":"...","cptCode":"...","quantity":1,"chargedAmount":100}',
+        },
       },
-      required: ["medications"],
+      required: ['line_items_json'],
     },
   },
   {
-    name: "pay_for_medication",
-    description: "Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits.",
+    name: 'check_drug_interactions',
+    description:
+      'Check for drug-drug interactions. Pays $0.001 USDC per check via x402 on Stellar. Returns severity levels and clinical recommendations.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        pharmacy_id: { type: "string" }, pharmacy_name: { type: "string" },
-        drug_name: { type: "string" }, amount: { type: "number" },
+        medications: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of medication names',
+        },
       },
-      required: ["pharmacy_id", "pharmacy_name", "drug_name", "amount"],
+      required: ['medications'],
     },
   },
   {
-    name: "pay_bill",
-    description: "Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount.",
+    name: 'pay_for_medication',
+    description:
+      'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        provider_id: { type: "string" }, provider_name: { type: "string" },
-        description: { type: "string" }, amount: { type: "number" },
+        pharmacy_id: { type: 'string' },
+        pharmacy_name: { type: 'string' },
+        drug_name: { type: 'string' },
+        amount: { type: 'number' },
       },
-      required: ["provider_id", "provider_name", "description", "amount"],
+      required: ['pharmacy_id', 'pharmacy_name', 'drug_name', 'amount'],
     },
   },
   {
-    name: "check_spending_policy",
-    description: "Check if a payment amount is within the caregiver-set spending policy limits before attempting payment.",
+    name: 'pay_bill',
+    description:
+      'Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        amount: { type: "number" }, category: { type: "string", enum: ["medications", "bills"] },
+        provider_id: { type: 'string' },
+        provider_name: { type: 'string' },
+        description: { type: 'string' },
+        amount: { type: 'number' },
       },
-      required: ["amount", "category"],
+      required: ['provider_id', 'provider_name', 'description', 'amount'],
     },
   },
   {
-    name: "fetch_rosa_bill",
-    description: "Fetch Rosa Garcia's hospital bill from General Hospital. Returns the bill with line items including CPT codes and charged amounts.",
+    name: 'check_spending_policy',
+    description:
+      'Check if a payment amount is within the caregiver-set spending policy limits before attempting payment.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        _unused: { type: "string", description: "Not used. Pass empty string." },
+        amount: { type: 'number' },
+        category: { type: 'string', enum: ['medications', 'bills'] },
+      },
+      required: ['amount', 'category'],
+    },
+  },
+  {
+    name: 'fetch_rosa_bill',
+    description:
+      "Fetch Rosa Garcia's hospital bill from General Hospital. Returns the bill with line items including CPT codes and charged amounts.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        _unused: {
+          type: 'string',
+          description: 'Not used. Pass empty string.',
+        },
       },
       required: [] as string[],
     },
   },
   {
-    name: "fetch_and_audit_bill",
-    description: "Fetch Rosa's hospital bill from General Hospital AND audit it for errors in one step. Pays $0.01 USDC via x402. Returns the audit results with errors found, overcharges, and corrected total. Use this instead of calling fetch_rosa_bill + audit_medical_bill separately.",
+    name: 'fetch_and_audit_bill',
+    description:
+      "Fetch Rosa's hospital bill from General Hospital AND audit it for errors in one step. Pays $0.01 USDC via x402. Returns the audit results with errors found, overcharges, and corrected total. Use this instead of calling fetch_rosa_bill + audit_medical_bill separately.",
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        _unused: { type: "string", description: "Not used. Pass empty string." },
+        _unused: {
+          type: 'string',
+          description: 'Not used. Pass empty string.',
+        },
       },
       required: [] as string[],
     },
   },
   {
-    name: "get_spending_summary",
-    description: "Get current spending summary: total spent, budget remaining per category, recent transactions with Stellar tx hashes.",
+    name: 'get_spending_summary',
+    description:
+      'Get current spending summary: total spent, budget remaining per category, recent transactions with Stellar tx hashes.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        _unused: { type: "string", description: "Not used. Pass empty string." },
+        _unused: {
+          type: 'string',
+          description: 'Not used. Pass empty string.',
+        },
       },
       required: [] as string[],
     },
   },
   {
-    name: "get_wallet_balance",
-    description: "Get the current on-chain wallet balance (USDC and XLM) from Stellar Horizon. Returns real-time balance data.",
+    name: 'get_wallet_balance',
+    description:
+      'Get the current on-chain wallet balance (USDC and XLM) from Stellar Horizon. Returns real-time balance data.',
     input_schema: {
-      type: "object" as const,
+      type: 'object' as const,
       properties: {
-        _unused: { type: "string", description: "Not used. Pass empty string." },
+        _unused: {
+          type: 'string',
+          description: 'Not used. Pass empty string.',
+        },
       },
       required: [] as string[],
     },
   },
 ];
+
+// Start scanner (runs in-process). Interval is conservative (5s).
+setInterval(() => {
+  processPendingTransactions().catch((err) => {
+    logger.error(
+      { err: err?.message || err },
+      '[PendingScanner] error scanning pending transactions',
+    );
+  });
+}, 5000);

--- a/dashboard/.env.local.example
+++ b/dashboard/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3004

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/dashboard/src/__tests__/policy-schema.test.ts
+++ b/dashboard/src/__tests__/policy-schema.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { validatePolicy } from "../lib/schemas";
+import { describe, expect, it } from 'vitest';
+import { validatePolicy } from '../lib/schemas';
 
 const valid = {
   dailyLimit: 100,
@@ -7,63 +7,82 @@ const valid = {
   medicationMonthlyBudget: 300,
   billMonthlyBudget: 200,
   approvalThreshold: 75,
+  holdTimeSeconds: 0,
 };
 
-describe("validatePolicy", () => {
-  it("accepts a valid policy", () => {
+describe('validatePolicy', () => {
+  it('accepts a valid policy', () => {
     const r = validatePolicy(valid);
     expect(r.isValid).toBe(true);
     expect(r.errors).toEqual([]);
   });
 
-  it("rejects negative dailyLimit", () => {
+  it('rejects negative dailyLimit', () => {
     const r = validatePolicy({ ...valid, dailyLimit: -1 });
     expect(r.isValid).toBe(false);
-    expect(r.errors.find((e) => e.field === "dailyLimit")).toBeDefined();
+    expect(r.errors.find((e) => e.field === 'dailyLimit')).toBeDefined();
   });
 
-  it("accepts zero values", () => {
+  it('accepts zero values', () => {
     const r = validatePolicy({ ...valid, monthlyLimit: 0 });
     expect(r.isValid).toBe(true);
   });
 
-  it("rejects values over 10000", () => {
+  it('rejects values over 10000', () => {
     const r = validatePolicy({ ...valid, monthlyLimit: 10001 });
     expect(r.isValid).toBe(false);
     expect(
       r.errors.some(
-        (e) => e.field === "monthlyLimit" && /10000/.test(e.message),
+        (e) => e.field === 'monthlyLimit' && /10000/.test(e.message),
       ),
     ).toBe(true);
   });
 
-  it("rejects NaN coerced from non-numeric input", () => {
+  it('rejects NaN coerced from non-numeric input', () => {
     const r = validatePolicy({ ...valid, dailyLimit: Number.NaN });
     expect(r.isValid).toBe(false);
   });
 
-  it("rejects dailyLimit greater than monthlyLimit", () => {
+  it('rejects dailyLimit greater than monthlyLimit', () => {
     const r = validatePolicy({ ...valid, dailyLimit: 600 });
     expect(r.isValid).toBe(false);
     expect(
       r.errors.some(
-        (e) => e.field === "dailyLimit" && /monthly/i.test(e.message),
+        (e) => e.field === 'dailyLimit' && /monthly/i.test(e.message),
       ),
     ).toBe(true);
   });
 
-  it("rejects approvalThreshold greater than smallest cap", () => {
+  it('rejects negative holdTimeSeconds', () => {
+    const r = validatePolicy({ ...valid, holdTimeSeconds: -1 });
+    expect(r.isValid).toBe(false);
+    expect(
+      r.errors.some(
+        (e) =>
+          e.field === 'holdTimeSeconds' &&
+          /cannot be negative/i.test(e.message),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts zero holdTimeSeconds', () => {
+    const r = validatePolicy({ ...valid, holdTimeSeconds: 0 });
+    expect(r.isValid).toBe(true);
+  });
+
+  it('rejects approvalThreshold greater than smallest cap', () => {
     const r = validatePolicy({ ...valid, approvalThreshold: 200 });
     expect(r.isValid).toBe(false);
     expect(
       r.errors.some(
         (e) =>
-          e.field === "approvalThreshold" && /smallest budget cap/i.test(e.message),
+          e.field === 'approvalThreshold' &&
+          /smallest budget cap/i.test(e.message),
       ),
     ).toBe(true);
   });
 
-  it("warns when category budgets exceed 120% of monthly limit", () => {
+  it('warns when category budgets exceed 120% of monthly limit', () => {
     const r = validatePolicy({
       ...valid,
       medicationMonthlyBudget: 400,
@@ -73,14 +92,14 @@ describe("validatePolicy", () => {
     expect(r.warnings.length).toBeGreaterThan(0);
   });
 
-  it("rejects missing fields", () => {
+  it('rejects missing fields', () => {
     const r = validatePolicy({ dailyLimit: 100 });
     expect(r.isValid).toBe(false);
   });
 
-  it("rejects non-object input", () => {
+  it('rejects non-object input', () => {
     expect(validatePolicy(null).isValid).toBe(false);
-    expect(validatePolicy("hello").isValid).toBe(false);
+    expect(validatePolicy('hello').isValid).toBe(false);
     expect(validatePolicy(undefined).isValid).toBe(false);
   });
 });

--- a/dashboard/src/components/tabs/approvals-tab.tsx
+++ b/dashboard/src/components/tabs/approvals-tab.tsx
@@ -14,6 +14,7 @@ export interface ApprovalsTabProps {
 export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
   const [approvals, setApprovals] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(false);
+  const [, setTick] = useState(0);
 
   const fetchApprovals = async () => {
     try {
@@ -26,8 +27,13 @@ export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
 
   useEffect(() => {
     fetchApprovals();
+    fetchApprovals();
     const i = setInterval(fetchApprovals, 5000);
-    return () => clearInterval(i);
+    const t = setInterval(() => setTick((s) => s + 1), 1000);
+    return () => {
+      clearInterval(i);
+      clearInterval(t);
+    };
   }, []);
 
   const handleApprove = async (txId: string) => {
@@ -44,7 +50,7 @@ export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
     }
   };
 
-  const handleReject = async (txId: string) => {
+  const handleCancel = async (txId: string) => {
     setLoading(true);
     try {
       const res = await fetch(`${AGENT_URL}/agent/approvals/${txId}`, {
@@ -94,6 +100,19 @@ export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
                     <div className="text-xs text-slate-400 mt-1">
                       {new Date(tx.timestamp).toLocaleString()}
                     </div>
+                    {tx.pendingUntil && (
+                      <div className="text-xs text-amber-600 mt-1">
+                        {(() => {
+                          try {
+                            const ms = new Date(tx.pendingUntil).getTime() - Date.now();
+                            const sec = Math.max(0, Math.ceil(ms / 1000));
+                            return `Auto-approve in ${sec}s`;
+                          } catch {
+                            return null;
+                          }
+                        })()}
+                      </div>
+                    )}
                   </div>
                   <div className="flex gap-2">
                     <button
@@ -104,11 +123,11 @@ export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
                       Approve
                     </button>
                     <button
-                      onClick={() => handleReject(tx.id)}
+                      onClick={() => handleCancel(tx.id)}
                       disabled={loading}
                       className="px-3 py-1.5 bg-red-600 text-white text-xs font-medium rounded-lg hover:bg-red-700 disabled:opacity-50 cursor-pointer"
                     >
-                      Reject
+                      Cancel
                     </button>
                   </div>
                 </div>
@@ -130,8 +149,8 @@ export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
             it creates a pending transaction instead of paying immediately.
           </p>
           <p>
-            You can review and approve or reject each pending transaction here.
-            Approving will execute the payment; rejecting will cancel it.
+            You can review and approve or cancel each pending transaction here.
+            Approving will execute the payment; canceling will stop it.
           </p>
         </div>
       </div>

--- a/dashboard/src/components/tabs/policy-tab.tsx
+++ b/dashboard/src/components/tabs/policy-tab.tsx
@@ -16,6 +16,7 @@ const FIELDS: Array<[keyof SpendingPolicyInput, string]> = [
   ["medicationMonthlyBudget", "Medication Monthly Budget ($)"],
   ["billMonthlyBudget", "Bill Monthly Budget ($)"],
   ["approvalThreshold", "Caregiver Approval Threshold ($)"],
+  ["holdTimeSeconds", "Hold Time Before Auto-Approval (seconds)"],
 ];
 
 export interface PolicyTabProps {

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -1,13 +1,13 @@
-"use client";
+'use client';
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   SpendingDataSchema,
   TransactionSchema,
   AuditLogSchema,
   type SpendingData,
   type Transaction,
-} from "../lib/types";
+} from '../lib/types';
 import type {
   AgentInfo,
   AgentLogEntry,
@@ -15,9 +15,9 @@ import type {
   PaginationData,
   Tab,
   AuditLogEvent,
-} from "../components/types";
+} from '../components/types';
 
-const AGENT_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3004";
+const AGENT_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3004';
 
 const DEFAULT_POLICY = {
   dailyLimit: 100,
@@ -25,6 +25,7 @@ const DEFAULT_POLICY = {
   medicationMonthlyBudget: 300,
   billMonthlyBudget: 500,
   approvalThreshold: 75,
+  holdTimeSeconds: 0,
 };
 
 export type PolicyForm = typeof DEFAULT_POLICY;
@@ -42,15 +43,17 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   const [pageSize, setPageSize] = useState(25);
   const [agentResult, setAgentResult] = useState<AgentResult | null>(null);
   const [loading, setLoading] = useState(false);
-  const [activeTask, setActiveTask] = useState("");
+  const [activeTask, setActiveTask] = useState('');
   const [agentLog, setAgentLog] = useState<AgentLogEntry[]>([]);
   const [agentInfo, setAgentInfo] = useState<AgentInfo | null>(null);
   const [agentConnected, setAgentConnected] = useState(false);
   const [agentPaused, setAgentPaused] = useState(false);
-  const [agentPausedReason, setAgentPausedReason] = useState<string | null>(null);
+  const [agentPausedReason, setAgentPausedReason] = useState<string | null>(
+    null,
+  );
   const [walletBalance, setWalletBalance] = useState<string | null>(null);
   const [walletXlm, setWalletXlm] = useState<string | null>(null);
-  const [liveMessage, setLiveMessage] = useState("");
+  const [liveMessage, setLiveMessage] = useState('');
   const [policyForm, setPolicyForm] = useState<PolicyForm>(DEFAULT_POLICY);
   const [policyDirty, setPolicyDirty] = useState(false);
   const [policySaved, setPolicySaved] = useState(false);
@@ -68,16 +71,17 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
 
   useEffect(() => {
     const connectionState = !agentConnected
-      ? "disconnected"
+      ? 'disconnected'
       : agentPaused
-        ? "paused"
-        : "active";
+        ? 'paused'
+        : 'active';
     const prev = lastConnectionStateRef.current;
     if (prev === connectionState) return;
     lastConnectionStateRef.current = connectionState;
-    if (connectionState === "active") setLiveMessage("Agent connected");
-    if (connectionState === "paused") setLiveMessage("Agent paused");
-    if (connectionState === "disconnected") setLiveMessage("Agent disconnected");
+    if (connectionState === 'active') setLiveMessage('Agent connected');
+    if (connectionState === 'paused') setLiveMessage('Agent paused');
+    if (connectionState === 'disconnected')
+      setLiveMessage('Agent disconnected');
   }, [agentConnected, agentPaused]);
 
   const addLogEntry = useCallback((message: string) => {
@@ -100,15 +104,17 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       setAgentInfo(data);
       setAgentConnected(true);
       setAgentPaused(Boolean(data.paused));
-      setAgentPausedReason(typeof data.pausedReason === "string" ? data.pausedReason : null);
+      setAgentPausedReason(
+        typeof data.pausedReason === 'string' ? data.pausedReason : null,
+      );
       // Fetch wallet balance from server (Issue #134 - server-side cache)
       if (data.agentWallet) {
         try {
           const wres = await fetch(`${AGENT_URL}/agent/wallet`);
           if (wres.ok) {
             const wdata = await wres.json();
-            setWalletBalance(wdata.usdc || "0.00");
-            setWalletXlm(wdata.xlm || "0.00");
+            setWalletBalance(wdata.usdc || '0.00');
+            setWalletXlm(wdata.xlm || '0.00');
           }
         } catch {}
       }
@@ -117,47 +123,53 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     }
   }, []);
 
-  const fetchSpending = useCallback(async (opts?: { forcePolicySync?: boolean }) => {
-    try {
-      const res = await fetch(`${AGENT_URL}/agent/spending`);
-      if (!res.ok) return;
-      const data = SpendingDataSchema.parse(await res.json());
-      setSpending(data);
-      const forcePolicySync = Boolean(opts?.forcePolicySync);
-      const shouldSyncPolicy =
-        forcePolicySync ||
-        (activeTabRef.current !== "policy" && !policyDirtyRef.current);
-      if (shouldSyncPolicy) {
-        setPolicyForm(data.policy);
-        setPolicyDirty(false);
-      }
-    } catch {}
-  }, []);
+  const fetchSpending = useCallback(
+    async (opts?: { forcePolicySync?: boolean }) => {
+      try {
+        const res = await fetch(`${AGENT_URL}/agent/spending`);
+        if (!res.ok) return;
+        const data = SpendingDataSchema.parse(await res.json());
+        setSpending(data);
+        const forcePolicySync = Boolean(opts?.forcePolicySync);
+        const shouldSyncPolicy =
+          forcePolicySync ||
+          (activeTabRef.current !== 'policy' && !policyDirtyRef.current);
+        if (shouldSyncPolicy) {
+          setPolicyForm(data.policy);
+          setPolicyDirty(false);
+        }
+      } catch {}
+    },
+    [],
+  );
 
-  const fetchTransactions = useCallback(async (limit?: number, offset?: number) => {
-    try {
-      const params = new URLSearchParams();
-      if (limit) params.append("limit", limit.toString());
-      if (offset) params.append("offset", offset.toString());
-      const res = await fetch(`${AGENT_URL}/agent/transactions?${params}`);
-      if (!res.ok) return;
-      const data = await res.json();
-      const txs = Array.isArray(data.transactions)
-        ? data.transactions.map((t: unknown) => TransactionSchema.parse(t))
-        : [];
-      setAllTransactions(txs);
-      if (data.pagination) setPagination(data.pagination);
-
-      const auditRes = await fetch(`${AGENT_URL}/agent/audit?limit=100`);
-      if (auditRes.ok) {
-        const auditData = await auditRes.json();
-        const logs = Array.isArray(auditData.data)
-          ? auditData.data.map((l: unknown) => AuditLogSchema.parse(l))
+  const fetchTransactions = useCallback(
+    async (limit?: number, offset?: number) => {
+      try {
+        const params = new URLSearchParams();
+        if (limit) params.append('limit', limit.toString());
+        if (offset) params.append('offset', offset.toString());
+        const res = await fetch(`${AGENT_URL}/agent/transactions?${params}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const txs = Array.isArray(data.transactions)
+          ? data.transactions.map((t: unknown) => TransactionSchema.parse(t))
           : [];
-        setAuditEvents(logs);
-      }
-    } catch {}
-  }, []);
+        setAllTransactions(txs);
+        if (data.pagination) setPagination(data.pagination);
+
+        const auditRes = await fetch(`${AGENT_URL}/agent/audit?limit=100`);
+        if (auditRes.ok) {
+          const auditData = await auditRes.json();
+          const logs = Array.isArray(auditData.data)
+            ? auditData.data.map((l: unknown) => AuditLogSchema.parse(l))
+            : [];
+          setAuditEvents(logs);
+        }
+      } catch {}
+    },
+    [],
+  );
 
   useEffect(() => {
     fetchAgentInfo();
@@ -187,8 +199,8 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       addLogEntry(`[${new Date().toLocaleTimeString()}] Starting: ${label}`);
       try {
         const res = await fetch(`${AGENT_URL}/agent/run`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ task }),
         });
         if (!res.ok) {
@@ -212,7 +224,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         for (const tc of data.toolCalls) {
           const resultPreview = tc.result?.error
             ? `ERROR: ${String(tc.result.error).slice(0, 60)}`
-            : "OK";
+            : 'OK';
           addLogEntry(`  -> ${tc.tool} ${resultPreview}`);
         }
         addLogEntry(
@@ -227,25 +239,28 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         setAgentConnected(false);
       } finally {
         setLoading(false);
-        setActiveTask("");
+        setActiveTask('');
       }
     },
     [agentConnected, addLogEntry, fetchAgentInfo, fetchTransactions, pageSize],
   );
 
-  const updatePolicy = useCallback(async (): Promise<{ ok: boolean; error?: string }> => {
+  const updatePolicy = useCallback(async (): Promise<{
+    ok: boolean;
+    error?: string;
+  }> => {
     try {
       const res = await fetch(`${AGENT_URL}/agent/policy`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(policyForm),
       });
       if (!res.ok) {
-        const errText = await res.text().catch(() => "");
+        const errText = await res.text().catch(() => '');
         addLogEntry(
           `[${new Date().toLocaleTimeString()}] Failed to update policy: ${errText.slice(0, 120)}`,
         );
-        return { ok: false, error: errText || "Failed to update policy" };
+        return { ok: false, error: errText || 'Failed to update policy' };
       }
       const spendingRes = await fetch(`${AGENT_URL}/agent/spending`);
       if (spendingRes.ok) {
@@ -257,7 +272,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       addLogEntry(
         `[${new Date().toLocaleTimeString()}] Policy updated: daily=$${policyForm.dailyLimit}, monthly=$${policyForm.monthlyLimit}, meds=$${policyForm.medicationMonthlyBudget}, bills=$${policyForm.billMonthlyBudget}, approval=$${policyForm.approvalThreshold}`,
       );
-      setLiveMessage("Policy updated");
+      setLiveMessage('Policy updated');
       setPolicySaved(true);
       setTimeout(() => setPolicySaved(false), 3000);
       return { ok: true };
@@ -270,29 +285,29 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   }, [addLogEntry, policyForm]);
 
   const resetAgent = useCallback(async () => {
-    await fetch(`${AGENT_URL}/agent/reset`, { method: "POST" });
+    await fetch(`${AGENT_URL}/agent/reset`, { method: 'POST' });
     setAllTransactions([]);
     setPagination(null);
     setCurrentPage(0);
     setAgentResult(null);
     setAgentLog([]);
     fetchSpending();
-    addLogEntry(
-      `[${new Date().toLocaleTimeString()}] Reset by caregiver`,
-    );
-    setLiveMessage("All transactions and logs cleared");
+    addLogEntry(`[${new Date().toLocaleTimeString()}] Reset by caregiver`);
+    setLiveMessage('All transactions and logs cleared');
   }, [addLogEntry, fetchSpending]);
 
   const togglePause = useCallback(async () => {
-    const endpoint = agentPaused ? "/agent/resume" : "/agent/pause";
+    const endpoint = agentPaused ? '/agent/resume' : '/agent/pause';
     try {
-      const res = await fetch(`${AGENT_URL}${endpoint}`, { method: "POST" });
+      const res = await fetch(`${AGENT_URL}${endpoint}`, { method: 'POST' });
       if (res.ok) {
         const data = await res.json();
         setAgentPaused(data.paused);
-        setAgentPausedReason(typeof data.pausedReason === "string" ? data.pausedReason : null);
+        setAgentPausedReason(
+          typeof data.pausedReason === 'string' ? data.pausedReason : null,
+        );
         addLogEntry(
-          `[${new Date().toLocaleTimeString()}] Agent ${data.paused ? "paused" : "resumed"}`,
+          `[${new Date().toLocaleTimeString()}] Agent ${data.paused ? 'paused' : 'resumed'}`,
         );
       }
     } catch {}

--- a/dashboard/src/lib/schemas.ts
+++ b/dashboard/src/lib/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export const SpendingPolicyInput = z.object({
   dailyLimit: z.number(),
@@ -6,6 +6,7 @@ export const SpendingPolicyInput = z.object({
   medicationMonthlyBudget: z.number(),
   billMonthlyBudget: z.number(),
   approvalThreshold: z.number(),
+  holdTimeSeconds: z.number(),
 });
 
 export type SpendingPolicyInput = z.infer<typeof SpendingPolicyInput>;
@@ -22,11 +23,12 @@ export type PolicyValidation = {
 };
 
 const FIELD_LABEL: Record<keyof SpendingPolicyInput, string> = {
-  dailyLimit: "Daily limit",
-  monthlyLimit: "Monthly limit",
-  medicationMonthlyBudget: "Medication budget",
-  billMonthlyBudget: "Bill budget",
-  approvalThreshold: "Approval threshold",
+  dailyLimit: 'Daily limit',
+  monthlyLimit: 'Monthly limit',
+  medicationMonthlyBudget: 'Medication budget',
+  billMonthlyBudget: 'Bill budget',
+  approvalThreshold: 'Approval threshold',
+  holdTimeSeconds: 'Hold time before auto-approval (seconds)',
 };
 
 export function validatePolicy(input: unknown): PolicyValidation {
@@ -38,7 +40,10 @@ export function validatePolicy(input: unknown): PolicyValidation {
     for (const issue of parsed.error.issues) {
       const field = issue.path[0] as keyof SpendingPolicyInput | undefined;
       if (field && field in FIELD_LABEL) {
-        errors.push({ field, message: `${FIELD_LABEL[field]} must be a number` });
+        errors.push({
+          field,
+          message: `${FIELD_LABEL[field]} must be a number`,
+        });
       }
     }
     return { errors, warnings, isValid: false };
@@ -46,26 +51,40 @@ export function validatePolicy(input: unknown): PolicyValidation {
 
   const v = parsed.data;
   const fields: (keyof SpendingPolicyInput)[] = [
-    "dailyLimit",
-    "monthlyLimit",
-    "medicationMonthlyBudget",
-    "billMonthlyBudget",
-    "approvalThreshold",
+    'dailyLimit',
+    'monthlyLimit',
+    'medicationMonthlyBudget',
+    'billMonthlyBudget',
+    'approvalThreshold',
+    'holdTimeSeconds',
   ];
   for (const f of fields) {
     if (!Number.isFinite(v[f])) {
-      errors.push({ field: f, message: `${FIELD_LABEL[f]} must be a finite number` });
+      errors.push({
+        field: f,
+        message: `${FIELD_LABEL[f]} must be a finite number`,
+      });
     } else if (v[f] < 0) {
-      errors.push({ field: f, message: `${FIELD_LABEL[f]} cannot be negative` });
+      errors.push({
+        field: f,
+        message: `${FIELD_LABEL[f]} cannot be negative`,
+      });
     } else if (v[f] > 10000) {
-      errors.push({ field: f, message: `${FIELD_LABEL[f]} cannot exceed 10000` });
+      errors.push({
+        field: f,
+        message: `${FIELD_LABEL[f]} cannot exceed 10000`,
+      });
     }
   }
 
-  if (Number.isFinite(v.dailyLimit) && Number.isFinite(v.monthlyLimit) && v.dailyLimit > v.monthlyLimit) {
+  if (
+    Number.isFinite(v.dailyLimit) &&
+    Number.isFinite(v.monthlyLimit) &&
+    v.dailyLimit > v.monthlyLimit
+  ) {
     errors.push({
-      field: "dailyLimit",
-      message: "Daily limit cannot exceed monthly limit",
+      field: 'dailyLimit',
+      message: 'Daily limit cannot exceed monthly limit',
     });
   }
 
@@ -74,10 +93,15 @@ export function validatePolicy(input: unknown): PolicyValidation {
     v.medicationMonthlyBudget,
     v.billMonthlyBudget,
   );
-  if (Number.isFinite(v.approvalThreshold) && Number.isFinite(approvalCap) && v.approvalThreshold > approvalCap) {
+  if (
+    Number.isFinite(v.approvalThreshold) &&
+    Number.isFinite(approvalCap) &&
+    v.approvalThreshold > approvalCap
+  ) {
     errors.push({
-      field: "approvalThreshold",
-      message: "Approval threshold cannot exceed the smallest budget cap (daily, medication, bill)",
+      field: 'approvalThreshold',
+      message:
+        'Approval threshold cannot exceed the smallest budget cap (daily, medication, bill)',
     });
   }
 
@@ -88,8 +112,8 @@ export function validatePolicy(input: unknown): PolicyValidation {
     v.medicationMonthlyBudget + v.billMonthlyBudget > v.monthlyLimit * 1.2
   ) {
     warnings.push({
-      field: "medicationMonthlyBudget",
-      message: "Combined category budgets exceed 120% of monthly limit",
+      field: 'medicationMonthlyBudget',
+      message: 'Combined category budgets exceed 120% of monthly limit',
     });
   }
 

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -1,11 +1,11 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 export const BillLineItemSchema = z.object({
   description: z.string(),
   cptCode: z.string().optional(),
   quantity: z.number(),
   chargedAmount: z.number(),
-  status: z.enum(["valid", "duplicate", "upcoded", "unbundled", "error"]),
+  status: z.enum(['valid', 'duplicate', 'upcoded', 'unbundled', 'error']),
   suggestedAmount: z.number().optional(),
   errorDescription: z.string().optional(),
 });
@@ -58,7 +58,7 @@ export type DrugInteractionResult = z.infer<typeof DrugInteractionResultSchema>;
 export const TransactionSchema = z.object({
   id: z.string(),
   timestamp: z.string(),
-  type: z.enum(["medication", "bill", "service_fee"]),
+  type: z.enum(['medication', 'bill', 'service_fee']),
   description: z.string(),
   amount: z.number(),
   recipient: z.string(),
@@ -66,6 +66,7 @@ export const TransactionSchema = z.object({
   mppOrderId: z.string().optional(),
   status: z.string(),
   category: z.string(),
+  pendingUntil: z.string().optional(),
 });
 
 export type Transaction = z.infer<typeof TransactionSchema>;
@@ -86,6 +87,7 @@ export const SpendingDataSchema = z.object({
     medicationMonthlyBudget: z.number(),
     billMonthlyBudget: z.number(),
     approvalThreshold: z.number(),
+    holdTimeSeconds: z.number(),
   }),
   spending: z.object({
     medications: z.number(),
@@ -118,4 +120,3 @@ export type CaregiverProfile = {
   location?: string;
   notifications?: string;
 };
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       express-rate-limit:
         specifier: ^7.5.0
         version: 7.5.1(express@5.2.1)
+      glob:
+        specifier: ^11.0.0
+        version: 11.1.0
       helmet:
         specifier: ^8.2.0
         version: 8.2.0
@@ -558,6 +561,10 @@ packages:
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1283,6 +1290,10 @@ packages:
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base32.js@0.1.0:
     resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
     engines: {node: '>=0.12.0'}
@@ -1304,6 +1315,10 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1410,6 +1425,10 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -1602,6 +1621,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1647,6 +1670,12 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1764,10 +1793,17 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
@@ -1812,6 +1848,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1864,8 +1904,16 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -1958,6 +2006,9 @@ packages:
       typescript:
         optional: true
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -1965,8 +2016,16 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -2206,6 +2265,14 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
@@ -2231,6 +2298,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -2502,6 +2573,11 @@ packages:
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -2876,6 +2952,8 @@ snapshots:
   '@ioredis/as-callback@3.0.0': {}
 
   '@ioredis/commands@1.5.1': {}
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3721,6 +3799,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@4.0.4: {}
+
   base32.js@0.1.0: {}
 
   base64-js@1.5.1: {}
@@ -3744,6 +3824,10 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -3847,6 +3931,12 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css.escape@1.5.1: {}
 
@@ -4079,6 +4169,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -4129,6 +4224,15 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
 
   gopd@1.2.0: {}
 
@@ -4254,9 +4358,15 @@ snapshots:
 
   isarray@2.0.5: {}
 
+  isexe@2.0.0: {}
+
   isows@1.0.7(ws@8.18.3):
     dependencies:
       ws: 8.18.3
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jose@5.10.0: {}
 
@@ -4306,6 +4416,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -4340,7 +4452,13 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -4418,13 +4536,22 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  package-json-from-dist@1.0.1: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
 
+  path-key@3.1.1: {}
+
   path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -4708,6 +4835,12 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   shell-quote@1.8.3: {}
 
   shimmer@1.2.1: {}
@@ -4741,6 +4874,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   sonic-boom@4.2.1:
     dependencies:
@@ -5005,6 +5140,10 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/server.ts
+++ b/server.ts
@@ -82,6 +82,7 @@ const envSchema = z.object({
   MPP_SECRET_KEY: z.string().min(1, "MPP_SECRET_KEY required"),
   LLM_BASE_URL: z.string().min(1).optional(),
   LLM_MODEL: z.string().min(1).optional(),
+  CAREGIVER_TOKEN: z.string().min(1, "CAREGIVER_TOKEN required"),
   OZ_FACILITATOR_API_KEY: z.string().min(1).optional(),
   X402_FACILITATOR_URL: z.string().min(1).optional(),
 });
@@ -110,6 +111,7 @@ if (env.data.STELLAR_NETWORK !== "public" && !env.data.OZ_FACILITATOR_API_KEY) {
 const PORT = env.data.PORT;
 const LLM_BASE_URL = env.data.LLM_BASE_URL || "https://api.groq.com/openai/v1";
 const LLM_MODEL = env.data.LLM_MODEL || "llama-3.3-70b-versatile";
+const CAREGIVER_TOKEN = env.data.CAREGIVER_TOKEN;
 const NETWORK = (
   env.data.STELLAR_NETWORK === "public" ? "stellar:public" : "stellar:testnet"
 ) as `${string}:${string}`;
@@ -146,7 +148,18 @@ let _profileData = {
 const app = express();
 let isDraining = false;
 
-app.use("/agent/audit", auditRouter);
+function requireCaregiverToken(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer ")) {
+    res.status(401).setHeader("WWW-Authenticate", "Bearer").json({ error: "Missing caregiver token" });
+    return;
+  }
+  if (auth.slice("Bearer ".length) !== CAREGIVER_TOKEN) {
+    res.status(403).json({ error: "Invalid caregiver token" });
+    return;
+  }
+  next();
+}
 
 app.use("/agent", rateLimiters.agent);
 app.use("/health", rateLimiters.health);
@@ -162,6 +175,8 @@ app.use((req, res, next) =>
 );
 app.use(requestContextMiddleware());
 app.use(requestLoggerMiddleware());
+app.use("/agent", requireCaregiverToken);
+app.use("/agent/audit", auditRouter);
 
 // --- Prometheus metrics ---
 app.get("/metrics", metricsHandler());
@@ -204,7 +219,7 @@ app.get("/ready", async (_req, res) => {
   const checks: Record<string, boolean | string> = {};
 
   // 1. Required env vars
-  const requiredEnv = ["LLM_API_KEY", "AGENT_SECRET_KEY", "MPP_SECRET_KEY"];
+  const requiredEnv = ["LLM_API_KEY", "AGENT_SECRET_KEY", "MPP_SECRET_KEY", "CAREGIVER_TOKEN"];
   const missingEnv = requiredEnv.filter((k) => !process.env[k]);
   checks.env = missingEnv.length === 0 ? true : `missing: ${missingEnv.join(", ")}`;
 

--- a/shared/__tests__/cors.test.ts
+++ b/shared/__tests__/cors.test.ts
@@ -109,14 +109,16 @@ describe("createCorsMiddleware — production mode", () => {
 });
 
 describe("createCorsMiddleware — development mode", () => {
-  it("allows any origin in dev (wildcard behaviour)", async () => {
+  it("pins origins in dev too", async () => {
     const app = buildApp("development", undefined);
-    const res = await supertest(app)
+    const allowed = await supertest(app)
+      .get("/test")
+      .set("Origin", "http://localhost:3000");
+    const blocked = await supertest(app)
       .get("/test")
       .set("Origin", "http://anything.local");
 
-    expect(res.status).toBe(200);
-    // cors() with wildcard sets '*' or reflects origin
-    expect(res.headers["access-control-allow-origin"]).toBeTruthy();
+    expect(allowed.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
+    expect(blocked.headers["access-control-allow-origin"]).toBeUndefined();
   });
 });

--- a/shared/cors.ts
+++ b/shared/cors.ts
@@ -3,16 +3,6 @@ import type { RequestHandler } from "express";
 import { logger } from "./logger.ts";
 
 export function createCorsMiddleware(): RequestHandler {
-  const nodeEnv = process.env.NODE_ENV ?? "development";
-
-  if (nodeEnv !== "production") {
-    logger.warn(
-      "CORS: running in non-production mode — all origins allowed (wildcard). " +
-        "Set NODE_ENV=production and ALLOWED_ORIGINS to restrict access.",
-    );
-    return cors() as RequestHandler;
-  }
-
   const allowed = parseAllowedOrigins();
   logger.info(`CORS: allowlist = [${allowed.join(", ")}]`);
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -32,7 +32,7 @@ export interface BillLineItem {
   cptCode?: string;
   chargedAmount: number;
   fairMarketRate?: number;
-  status: "valid" | "duplicate" | "upcoded" | "unbundled" | "error";
+  status: 'valid' | 'duplicate' | 'upcoded' | 'unbundled' | 'error';
   errorDescription?: string;
   suggestedAmount?: number;
 }
@@ -52,19 +52,29 @@ export interface SpendingPolicy {
   medicationMonthlyBudget: number;
   billMonthlyBudget: number;
   approvalThreshold: number; // require caregiver approval above this amount
+  holdTimeSeconds: number; // time before pending approvals auto-approve
 }
 
 export interface Transaction {
   id: string;
   timestamp: string;
-  type: "medication" | "bill" | "service_fee";
+  type: 'medication' | 'bill' | 'service_fee';
   description: string;
   amount: number;
   recipient: string;
   stellarTxHash?: string;
   mppOrderId?: string;
-  status: "pending" | "approved" | "completed" | "blocked" | "disputed";
+  status:
+    | 'pending'
+    | 'approved'
+    | 'completed'
+    | 'blocked'
+    | 'disputed'
+    | 'cancelled'
+    | 'rejected';
   category: string;
+  pendingUntil?: string;
+  submittedAt?: string;
 }
 
 export interface AgentAction {
@@ -94,7 +104,12 @@ export interface CareRecipient {
 export interface Alert {
   id: string;
   timestamp: string;
-  type: "approval_needed" | "error_found" | "refill_due" | "budget_warning" | "policy_blocked";
+  type:
+    | 'approval_needed'
+    | 'error_found'
+    | 'refill_due'
+    | 'budget_warning'
+    | 'policy_blocked';
   title: string;
   description: string;
   amount?: number;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,3 +4,4 @@ import "@testing-library/jest-dom/vitest";
 
 // Silence pino output in tests
 process.env.LOG_LEVEL = "silent";
+process.env.CAREGIVER_TOKEN = process.env.CAREGIVER_TOKEN || "test-caregiver-token";


### PR DESCRIPTION
Fixes #263

## What changed
- Added `holdTimeSeconds` to the spending policy (default 0) and persisted policy handling.
- Payments above `approvalThreshold` now create a `pending` transaction with `submittedAt` and `pendingUntil` metadata.
- Added endpoints: `GET /agent/pending-approvals` and `POST /agent/approvals/:txId` (approve/cancel).
- Implemented `approvePendingTransaction`, `cancelPendingTransaction`, and `processPendingTransactions()` with an in-process scanner to auto-approve expired holds.
- Dashboard: approvals queue updated to show pending items, Approve/Cancel actions, and a live “auto-approve in Xs” countdown.
- Added Vitest file pending-approvals.test.ts covering hold+cancel, hold+approve, and hold+auto-approve.
- Updated dashboard client schemas/types to accept `holdTimeSeconds` and transaction `pendingUntil`.

## Why
- Provide a caregiver safety window for high-value transactions so payments can be reviewed and cancelled before on-chain settlement.
- Auto-approve expired holds to avoid indefinite blocking of legitimate payments.
- Bring server, agent tools, and dashboard into alignment with the acceptance criteria in fix.md.

## How to test
- Unit tests:
```bash
pnpm install            # may require 'pnpm approve-builds' for build scripts
pnpm vitest run agent/__tests__/pending-approvals.test.ts
# or run full test suite:
pnpm vitest
```
- Manual E2E:
  1. Start agent and dashboard locally.
  2. Set policy with `holdTimeSeconds` > 0 and `approvalThreshold` to a value below a test payment.
  3. Trigger a payment > `approvalThreshold` (medication or bill).
  4. Verify the transaction appears in the dashboard approvals queue with “Auto-approve in Xs”.
  5. Use the dashboard Approve button → payment executes (completed status).
  6. Repeat and use Cancel → transaction status becomes `cancelled` and no on-chain payment occurs.
  7. Set `holdTimeSeconds` to 0, create a pending transaction, and verify `processPendingTransactions()` auto-approves it immediately (completed status).
- API checks:
  - `GET /agent/pending-approvals` returns pending transactions.
  - `POST /agent/approvals/:txId` with body `{ "approve": true }` approves, `{ "approve": false }` cancels; responses include updated `status` and `transaction`.

## Checklist
- [ ] CI passes (typecheck, lint, tests)
- [ ] No sensitive data files (spending.json, orders.json) committed
- [ ] PR linked to issue #263

Closes #263 
Closes #259 
Closes #255 
Closes #258 