### PR TITLE
Fix issues #268, #269, #280, #283

### DIFF
--- a/agent/__tests__/body-limit.test.ts
+++ b/agent/__tests__/body-limit.test.ts
@@ -30,14 +30,14 @@ function buildApp(defaultLimit: string, billAuditLimit?: string) {
   return app;
 }
 
-const oversized = JSON.stringify({ data: "x".repeat(25_000) });    // ~25kb
+const oversized = JSON.stringify({ data: "x".repeat(70_000) });    // ~70kb
 const medium    = JSON.stringify({ data: "x".repeat(200_000) });   // ~200kb
 const small     = JSON.stringify({ task: "Check drug prices" });
 
-describe("#92 body-size limit — 20kb default", () => {
-  const app = buildApp("20kb");
+describe("#92 body-size limit — 64kb default", () => {
+  const app = buildApp("64kb");
 
-  it("returns 413 when POST body exceeds 20kb", async () => {
+  it("returns 413 when POST body exceeds 64kb", async () => {
     const res = await request(app)
       .post("/agent/run")
       .set("Content-Type", "application/json")
@@ -47,7 +47,7 @@ describe("#92 body-size limit — 20kb default", () => {
     expect(res.body.error).toMatch(/too large/i);
   });
 
-  it("does not 413 when body is within 20kb", async () => {
+  it("does not 413 when body is within 64kb", async () => {
     const res = await request(app)
       .post("/agent/run")
       .set("Content-Type", "application/json")
@@ -70,7 +70,7 @@ describe("#92 body-size limit — bill-audit route gets 256kb", () => {
     expect(res.status).toBe(200);
   });
 
-  it("still 413 on non-bill route with oversized body", async () => {
+  it("still 413 on non-bill route with 70kb oversized body", async () => {
     const res = await request(app)
       .post("/agent/run")
       .set("Content-Type", "application/json")

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -334,7 +334,7 @@ app.use(rateLimiters.default);
 
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
-app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
+app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "64kb" }));
 app.use(requestContextMiddleware());
 app.use(requestLoggerMiddleware());
 app.get("/metrics", metricsHandler());

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -1224,6 +1224,7 @@ export async function getWalletBalance() {
           ? parseFloat((xlmBalance as any).balance).toFixed(2)
           : '0.00',
       },
+      usdcTrustlineMissing: !usdcBalance,
       timestamp: new Date().toISOString(),
     };
   } catch (err: any) {
@@ -1356,7 +1357,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'compare_pharmacy_prices',
     description:
-      'Compare medication prices across multiple pharmacies. Pays $0.002 USDC per query via x402 on Stellar. Returns prices sorted cheapest to most expensive, with potential savings.',
+      'Compare medication prices across multiple pharmacies. Pays $0.002 USDC per query via x402 on Stellar. Returns prices sorted cheapest to most expensive, with potential savings. Each pharmacy has an inStock field: "unknown" means real-time inventory is unavailable (proceed with caution), true means in stock. Never assume a medication is in stock if inStock is "unknown" — confirm with the pharmacy before ordering.',
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -1486,7 +1487,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'get_wallet_balance',
     description:
-      'Get the current on-chain wallet balance (USDC and XLM) from Stellar Horizon. Returns real-time balance data.',
+      'Get the current on-chain wallet balance (USDC and XLM) from Stellar Horizon. Returns real-time balance data. If usdcTrustlineMissing is true, the agent wallet lacks a USDC trustline — instruct the caregiver to fund the wallet at https://faucet.circle.com.',
     input_schema: {
       type: 'object' as const,
       properties: {

--- a/dashboard/src/app/pdf.ts
+++ b/dashboard/src/app/pdf.ts
@@ -209,7 +209,7 @@ export function downloadMedicationPDF(
     autoTable(doc, {
       startY: y,
       head: [["Pharmacy", "Price", "Distance", "In Stock"]],
-      body: r.prices.map((p) => [p.pharmacyName, `$${p.price}`, p.distance || "-", p.inStock ? "Yes" : "No"]),
+      body: r.prices.map((p) => [p.pharmacyName, `$${p.price}`, p.distance || "-", p.inStock === true ? "Yes" : p.inStock === 'unknown' ? "Unknown" : "No"]),
       headStyles: { fillColor: theme.headerColor, fontSize: 7 },
       bodyStyles: { fontSize: 7 },
       alternateRowStyles: { fillColor: [248, 250, 252] },

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -27,7 +27,7 @@ export const PharmacyPriceSchema = z.object({
   pharmacyId: z.string().optional(),
   price: z.number(),
   distance: z.string().optional(),
-  inStock: z.boolean().optional(),
+  inStock: z.union([z.boolean(), z.literal('unknown')]).optional(),
 });
 
 export const PharmacyCompareResultSchema = z.object({

--- a/scripts/setup-wallets.ts
+++ b/scripts/setup-wallets.ts
@@ -59,6 +59,7 @@ async function addUsdcTrustline(keypair: Keypair): Promise<void> {
 }
 
 async function main() {
+  const writeEnv = process.argv.includes("--write-env");
   logger.info("CareGuard Wallet Setup starting");
 
   const wallets: WalletInfo[] = [
@@ -91,12 +92,34 @@ async function main() {
   }
 
   // Step 3: Output .env values — written directly so they are copy-pasteable
-  process.stdout.write("\n=== Add these to your .env file ===\n\n");
+  const envLines: string[] = [];
   for (const wallet of wallets) {
-    process.stdout.write(`${wallet.name}_SECRET_KEY=${wallet.secretKey}\n`);
-    process.stdout.write(`${wallet.name}_PUBLIC_KEY=${wallet.publicKey}\n`);
+    envLines.push(`${wallet.name}_SECRET_KEY=${wallet.secretKey}`);
+    envLines.push(`${wallet.name}_PUBLIC_KEY=${wallet.publicKey}`);
   }
-  process.stdout.write(`\n# USDC Testnet\nUSDC_ISSUER=${USDC_ISSUER}\n`);
+  envLines.push(`\n# USDC Testnet\nUSDC_ISSUER=${USDC_ISSUER}`);
+
+  if (writeEnv) {
+    const confirmMsg = "Write these values to .env in the current directory? (y/N) ";
+    process.stdout.write(confirmMsg);
+    const answer = await new Promise<string>((resolve) => {
+      process.stdin.once("data", (data) => resolve(data.toString().trim().toLowerCase()));
+    });
+    if (answer === "y" || answer === "yes") {
+      const fs = await import("fs");
+      const existing = fs.existsSync(".env") ? fs.readFileSync(".env", "utf-8") : "";
+      const updated = existing + (existing.endsWith("\n") ? "" : "\n") + envLines.join("\n") + "\n";
+      fs.writeFileSync(".env", updated);
+      logger.info(".env file updated");
+    } else {
+      logger.info("Skipped writing .env");
+    }
+  }
+
+  process.stdout.write("\n=== Add these to your .env file ===\n\n");
+  for (const line of envLines) {
+    process.stdout.write(line + "\n");
+  }
   process.stdout.write(`\n=== IMPORTANT ===\nNow get testnet USDC for the AGENT wallet:\n`);
   process.stdout.write(`1. Go to https://faucet.circle.com\n2. Select "Stellar Testnet"\n`);
   process.stdout.write(`3. Paste the AGENT public key: ${wallets[0].publicKey}\n`);

--- a/server.ts
+++ b/server.ts
@@ -484,7 +484,7 @@ app.get("/pharmacy/compare", (req, res) => {
       pharmacyId: p.id,
       price: p.price,
       distance: p.distance,
-      inStock: true,
+      inStock: 'unknown',
     })),
     cheapest: {
       pharmacyName: cheapest.pharmacy,

--- a/services/pharmacy-api/server.ts
+++ b/services/pharmacy-api/server.ts
@@ -91,7 +91,7 @@ app.get("/pharmacy/compare", async (req, res) => {
       protocol: { name: "x402", network: NETWORK, price: "$0.002", payTo: PAY_TO },
       provider: pricingProvider.name,
       prices: sorted.map((p) => ({
-        pharmacyName: p.pharmacy, pharmacyId: p.id, price: p.price, distance: p.distance, inStock: true,
+        pharmacyName: p.pharmacy, pharmacyId: p.id, price: p.price, distance: p.distance, inStock: 'unknown',
       })),
       cheapest: { pharmacyName: cheapest.pharmacy, pharmacyId: cheapest.id, price: cheapest.price, distance: cheapest.distance },
       mostExpensive: { pharmacyName: mostExpensive.pharmacy, pharmacyId: mostExpensive.id, price: mostExpensive.price },

--- a/shared/__tests__/task-validation.test.ts
+++ b/shared/__tests__/task-validation.test.ts
@@ -25,8 +25,14 @@ describe("validateTask", () => {
     expect(result.error).toBeDefined();
   });
 
-  it("rejects task over 2000 chars", () => {
-    const result = validateTask("a".repeat(2001));
+  it("rejects task under 10 chars", () => {
+    const result = validateTask("short");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("rejects task over 5000 chars", () => {
+    const result = validateTask("a".repeat(5001));
     expect(result.ok).toBe(false);
     expect(result.error).toBeDefined();
   });

--- a/shared/task-validation.ts
+++ b/shared/task-validation.ts
@@ -15,7 +15,7 @@ const BLOCKLIST = [
 
 const CONTROL_CHAR_RE = /[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g;
 
-const taskSchema = z.string().min(1).max(2000);
+const taskSchema = z.string().min(10).max(5000);
 
 let suspiciousTaskTotal = 0;
 export function getSuspiciousTaskCount(): number {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -14,7 +14,7 @@ export interface PharmacyPrice {
   pharmacyId: string;
   price: number;
   distance?: string;
-  inStock: boolean;
+  inStock: boolean | 'unknown';
 }
 
 export interface PriceComparisonResult {


### PR DESCRIPTION
## Summary

Four fixes for issues assigned to Smartdevs17.

### #268 — Pharmacy comparison hardcodes `inStock: true`
- Changed type from `boolean` to `boolean | 'unknown'` in `shared/types.ts` and dashboard Zod schema
- Updated both `pharmacy-api/server.ts` and `server.ts` to return `inStock: 'unknown'` since no real inventory system exists yet (depends on #168)
- Updated tool description to tell LLM to treat 'unknown' with caution
- Updated PDF report to show "Unknown" instead of "Yes" for unknown stock

### #269 — `/agent/run` accepts arbitrarily large `task` strings
- Changed zod schema: `z.string().min(10).max(5000)` (was `min(1).max(2000)`)
- Changed body-parser limit from 20KB to 64KB on the agent route
- Updated tests for both changes

### #280 — Setup script output omits `USDC_ISSUER`
- Script already printed `USDC_ISSUER`; added `--write-env` flag that prompts to write all env vars (including `USDC_ISSUER`) to `.env` file

### #283 — USDC asset lookup returns -1 silently
- `getWalletBalance()` now returns `usdcTrustlineMissing: true` when no USDC trustline is found (vs `false` when balance is legitimately 0)
- Updated tool description to tell LLM to instruct caregiver to fund wallet at faucet.circle.com

## Testing
- All 23 tests in affected test files pass (task-validation: 12, body-limit: 5, wallet-balance: 6)
- The 32 pre-existing test failures (rate-limiting, missing `vi.isolateModules`, dashboard schema) are unchanged from main

Closes #268, #269, #280, #283