### PR TITLE
fix: sanitize user inputs, validate amount/CPT-code bounds, and stop fabricating LLM error summaries (#184, #182, #175, #166)

### DIFF
--- a/agent/__tests__/llm-error-fallback.test.ts
+++ b/agent/__tests__/llm-error-fallback.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const serverSource = readFileSync(resolve("agent/server.ts"), "utf8");
+
+describe("LLM error handling — no fabricated summaries", () => {
+  it("returns llm_error status on LLM API errors instead of fabricating a summary", () => {
+    expect(serverSource).toContain('status: "llm_error"');
+    expect(serverSource).toContain("toolCallsCompleted");
+  });
+
+  it("does not fabricate success messages from partial tool calls on LLM error", () => {
+    expect(serverSource).not.toContain("Paid bill: $");
+    expect(serverSource).not.toContain("cheapest at $");
+    expect(serverSource).not.toContain("Bill audit: $");
+  });
+
+  it("increments agentLlmErrorTotal metric on LLM error", () => {
+    expect(serverSource).toContain("agentLlmErrorTotal.inc()");
+  });
+
+  it("imports agentLlmErrorTotal from metrics", () => {
+    expect(serverSource).toContain("agentLlmErrorTotal");
+  });
+});

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -29,6 +29,7 @@ import {
   agentRunsTotal,
   agentToolCallsTotal,
   agentLlmTokensTotal,
+  agentLlmErrorTotal,
 } from "../shared/metrics.ts";
 import {
   comparePharmacyPrices,
@@ -233,19 +234,17 @@ async function runAgent(task: string) {
       });
     } catch (llmErr: any) {
       logger.error({ err: llmErr.message, iteration }, "LLM API error");
-      if (toolCalls.length > 0 && !finalResponse) {
-        finalResponse = toolCalls.map(tc => {
-          if (tc.result?.error) return `${tc.tool}: ${tc.result.error}`;
-          if (tc.tool === "compare_pharmacy_prices" && (tc.result as any)?.cheapest) return `${(tc.result as any).drug}: cheapest at $${(tc.result as any).cheapest.price} (${(tc.result as any).cheapest.pharmacyName}), save $${(tc.result as any).potentialSavings}/mo`;
-          if (tc.tool === "audit_medical_bill" && (tc.result as any)?.totalOvercharge) return `Bill audit: $${(tc.result as any).totalOvercharge} in overcharges found (${(tc.result as any).errorCount} errors)`;
-          if (tc.tool === "check_drug_interactions" && (tc.result as any)?.summary) return (tc.result as any).summary;
-          if (tc.tool === "pay_for_medication" && (tc.result as any)?.success) return `Paid $${(tc.result as any).transaction.amount} for ${(tc.result as any).transaction.description}`;
-          if (tc.tool === "pay_bill" && (tc.result as any)?.success) return `Paid bill: $${(tc.result as any).transaction.amount}`;
-          return `${tc.tool}: completed`;
-        }).join("\n");
-      } else if (!finalResponse) {
-        finalResponse = `LLM error: ${llmErr.message}`;
-      }
+      agentLlmErrorTotal.inc();
+      finalResponse = JSON.stringify({
+        status: "llm_error",
+        toolCallsCompleted: toolCalls.length,
+        message: `LLM API error: ${llmErr.message}. Agent run was interrupted — not all tool calls may have completed.`,
+        toolCalls: toolCalls.map(tc => ({
+          tool: tc.tool,
+          input: tc.input,
+          result: tc.result,
+        })),
+      });
       break;
     }
 

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -1713,14 +1713,14 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'pay_for_medication',
     description:
-      'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits.',
+      'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits. Amount must be between $0.01 and $10,000.',
     input_schema: strictInputSchema({
       type: 'object' as const,
       properties: {
         pharmacy_id: { type: 'string' },
         pharmacy_name: { type: 'string' },
         drug_name: { type: 'string' },
-        amount: { type: 'number' },
+        amount: { type: 'number', description: 'Payment amount in USD (min: 0.01, max: 10000)' },
         days_supply: { type: 'number', description: 'Days supply for adherence tracking (default: 30)' },
         recipient_id: { type: 'string', description: 'Care recipient ID (default: rosa)' },
       },
@@ -1730,14 +1730,14 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'pay_bill',
     description:
-      'Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount.',
+      'Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount. Amount must be between $0.01 and $10,000.',
     input_schema: strictInputSchema({
       type: 'object' as const,
       properties: {
         provider_id: { type: 'string' },
         provider_name: { type: 'string' },
         description: { type: 'string' },
-        amount: { type: 'number' },
+        amount: { type: 'number', description: 'Payment amount in USD (min: 0.01, max: 10000)' },
         recipient_id: { type: 'string', description: 'Care recipient ID (default: rosa)' },
       },
       required: ['provider_id', 'provider_name', 'description', 'amount'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       rate-limit-redis:
         specifier: ^4.2.0
         version: 4.3.1(express-rate-limit@7.5.1(express@5.2.1))
@@ -1036,6 +1039,7 @@ packages:
   '@stellar/stellar-base@14.1.0':
     resolution: {integrity: sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==}
     engines: {node: '>=20.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-sdk@14.6.1':
     resolution: {integrity: sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==}
@@ -1681,6 +1685,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2100,6 +2107,9 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2197,6 +2207,10 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -2298,6 +2312,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -4236,6 +4253,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -4640,6 +4659,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4725,6 +4750,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.12.0: {}
 
   rollup@4.60.2:
     dependencies:
@@ -4874,6 +4901,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 

--- a/services/bill-audit-api/__tests__/cpt-validation.test.ts
+++ b/services/bill-audit-api/__tests__/cpt-validation.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+const CPT_CODE_PATTERN = /^(?:\d{5}|J\d{4})$/;
+
+const BillItemSchema = z.object({
+  description: z.string().min(1, "description is required"),
+  cptCode: z.string().regex(CPT_CODE_PATTERN, "cptCode must be a valid CPT code (5 digits or J followed by 4 digits)"),
+  quantity: z.number().positive("quantity must be positive"),
+  chargedAmount: z.number().nonnegative("chargedAmount must be non-negative"),
+});
+
+const BillAuditRequestSchema = z.object({
+  lineItems: z.array(BillItemSchema).min(1, "lineItems must contain at least one item"),
+});
+
+describe("CPT code validation", () => {
+  it("accepts valid 5-digit CPT code", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Office visit",
+      cptCode: "99213",
+      quantity: 1,
+      chargedAmount: 130,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid J-code (J + 4 digits)", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Adrenaline injection",
+      cptCode: "J0170",
+      quantity: 1,
+      chargedAmount: 15,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-numeric CPT code", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Invalid code",
+      cptCode: "abc",
+      quantity: 1,
+      chargedAmount: 100,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("cptCode must be a valid CPT code");
+    }
+  });
+
+  it("rejects 4-digit code", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Too short",
+      cptCode: "9921",
+      quantity: 1,
+      chargedAmount: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects 6-digit code", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Too long",
+      cptCode: "992134",
+      quantity: 1,
+      chargedAmount: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects code with special characters", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Special chars",
+      cptCode: "99-213",
+      quantity: 1,
+      chargedAmount: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Empty code",
+      cptCode: "",
+      quantity: 1,
+      chargedAmount: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects J-code with wrong digit count", () => {
+    const result = BillItemSchema.safeParse({
+      description: "Wrong J-code",
+      cptCode: "J017",
+      quantity: 1,
+      chargedAmount: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates a complete bill audit request with valid codes", () => {
+    const result = BillAuditRequestSchema.safeParse({
+      lineItems: [
+        { description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: 130 },
+        { description: "Injection", cptCode: "J0170", quantity: 1, chargedAmount: 15 },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a bill audit request with invalid CPT code", () => {
+    const result = BillAuditRequestSchema.safeParse({
+      lineItems: [
+        { description: "Invalid", cptCode: "abc", quantity: 1, chargedAmount: 100 },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -22,6 +22,7 @@ import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
+import { sanitizeUserString } from "../../shared/sanitize.ts";
 
 const PORT = parseInt(process.env.BILL_AUDIT_API_PORT || "3002");
 const PAY_TO = process.env.BILL_PROVIDER_PUBLIC_KEY;
@@ -135,9 +136,11 @@ checkRatesFreshness();
 interface BillItem { description: string; cptCode: string; quantity: number; chargedAmount: number; }
 
 // Zod schema for validating bill items
+const CPT_CODE_PATTERN = /^(?:\d{5}|J\d{4})$/;
+
 const BillItemSchema = z.object({
   description: z.string().min(1, "description is required"),
-  cptCode: z.string().min(1, "cptCode is required"),
+  cptCode: z.string().regex(CPT_CODE_PATTERN, "cptCode must be a valid CPT code (5 digits or J followed by 4 digits)"),
   quantity: z.number().positive("quantity must be positive"),
   chargedAmount: z.number().nonnegative("chargedAmount must be non-negative"),
 });
@@ -236,7 +239,11 @@ applyX402Middleware(app, {
 app.post("/bill/audit", (req, res) => {
   try {
     const validatedData = BillAuditRequestSchema.parse(req.body);
-    res.json(auditBill(validatedData.lineItems));
+    const sanitizedLineItems = validatedData.lineItems.map(item => ({
+      ...item,
+      description: sanitizeUserString(item.description),
+    }));
+    res.json(auditBill(sanitizedLineItems));
   } catch (error) {
     if (error instanceof z.ZodError) {
       const issues = error.issues.map((issue, idx) => {

--- a/services/pharmacy-payment/__tests__/order-validation.test.ts
+++ b/services/pharmacy-payment/__tests__/order-validation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+const OrderAmountSchema = z.union([
+  z.number().min(0.01, "amount must be at least $0.01").max(10000, "amount must not exceed $10,000"),
+  z.string().transform((val, ctx) => {
+    const parsed = parseFloat(val);
+    if (!Number.isFinite(parsed)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be a valid number" });
+      return z.NEVER;
+    }
+    if (parsed < 0.01) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be at least $0.01" });
+      return z.NEVER;
+    }
+    if (parsed > 10000) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must not exceed $10,000" });
+      return z.NEVER;
+    }
+    return parsed;
+  }),
+]);
+
+describe("OrderAmountSchema", () => {
+  it("accepts valid number amounts", () => {
+    expect(OrderAmountSchema.parse(1.50)).toBe(1.50);
+    expect(OrderAmountSchema.parse(0.01)).toBe(0.01);
+    expect(OrderAmountSchema.parse(10000)).toBe(10000);
+  });
+
+  it("accepts valid string amounts", () => {
+    expect(OrderAmountSchema.parse("1.50")).toBe(1.50);
+    expect(OrderAmountSchema.parse("0.01")).toBe(0.01);
+    expect(OrderAmountSchema.parse("10000")).toBe(10000);
+  });
+
+  it("rejects amount below 0.01", () => {
+    expect(() => OrderAmountSchema.parse(0)).toThrow();
+    expect(() => OrderAmountSchema.parse(-1)).toThrow();
+    expect(() => OrderAmountSchema.parse("0")).toThrow();
+  });
+
+  it("rejects amount above 10000", () => {
+    expect(() => OrderAmountSchema.parse(10000.01)).toThrow();
+    expect(() => OrderAmountSchema.parse("9999999999.99")).toThrow();
+  });
+
+  it("rejects NaN", () => {
+    expect(() => OrderAmountSchema.parse("abc")).toThrow();
+    expect(() => OrderAmountSchema.parse("NaN")).toThrow();
+  });
+
+  it("rejects Infinity", () => {
+    expect(() => OrderAmountSchema.parse("Infinity")).toThrow();
+  });
+});

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -14,6 +14,7 @@ if (!process.stdout.isTTY) {
 
 import "dotenv/config";
 import express from "express";
+import { z } from "zod";
 import { Mppx, Store } from "mppx/server";
 import { stellar } from "@stellar/mpp/charge/server";
 import { USDC_SAC_TESTNET } from "@stellar/mpp";
@@ -22,6 +23,7 @@ import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
+import { sanitizeUserString } from "../../shared/sanitize.ts";
 
 const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005");
 const RECIPIENT = process.env.PHARMACY_1_PUBLIC_KEY;
@@ -114,6 +116,27 @@ const mppx = Mppx.create({
   ],
 });
 
+// Zod schema for amount validation
+const OrderAmountSchema = z.union([
+  z.number().min(0.01, "amount must be at least $0.01").max(10000, "amount must not exceed $10,000"),
+  z.string().transform((val, ctx) => {
+    const parsed = parseFloat(val);
+    if (!Number.isFinite(parsed)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be a valid number" });
+      return z.NEVER;
+    }
+    if (parsed < 0.01) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be at least $0.01" });
+      return z.NEVER;
+    }
+    if (parsed > 10000) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must not exceed $10,000" });
+      return z.NEVER;
+    }
+    return parsed;
+  }),
+]);
+
 // MPP-protected medication order endpoint
 app.post("/pharmacy/order", async (req, res) => {
   const { drug, pharmacy, amount } = req.body;
@@ -122,6 +145,15 @@ app.post("/pharmacy/order", async (req, res) => {
     res.status(400).json({ error: "Missing required fields: drug, pharmacy, amount" });
     return;
   }
+
+  const parsedAmount = OrderAmountSchema.safeParse(amount);
+  if (!parsedAmount.success) {
+    res.status(400).json({ error: "Invalid amount", details: parsedAmount.error.issues.map(i => i.message) });
+    return;
+  }
+
+  const safeDrug = sanitizeUserString(drug);
+  const safePharmacy = sanitizeUserString(pharmacy);
 
   // Convert Express request to Web Request for mppx
   const headers = new Headers();
@@ -141,8 +173,8 @@ app.post("/pharmacy/order", async (req, res) => {
 
   // Run MPP charge flow
   const result = await mppx.charge({
-    amount: parseFloat(amount).toFixed(2),
-    description: `Medication: ${drug} from ${pharmacy}`,
+    amount: parsedAmount.data.toFixed(2),
+    description: `Medication: ${safeDrug} from ${safePharmacy}`,
   })(webReq);
 
   // 402 = client needs to sign and pay
@@ -157,9 +189,9 @@ app.post("/pharmacy/order", async (req, res) => {
   // Payment verified and settled on Stellar — create order
   const order = {
     id: `order-${Date.now()}`,
-    drug,
-    pharmacy,
-    amount: parseFloat(amount),
+    drug: safeDrug,
+    pharmacy: safePharmacy,
+    amount: parsedAmount.data,
     status: "confirmed",
     timestamp: new Date().toISOString(),
     network: NETWORK,
@@ -172,7 +204,7 @@ app.post("/pharmacy/order", async (req, res) => {
     Response.json({
       success: true,
       order,
-      message: `Payment of $${amount} USDC settled on Stellar. ${drug} order from ${pharmacy} confirmed.`,
+      message: `Payment of $${parsedAmount.data} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
     })
   );
 

--- a/shared/__tests__/sanitize.test.ts
+++ b/shared/__tests__/sanitize.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeUserString } from "../sanitize.ts";
+
+describe("sanitizeUserString", () => {
+  it("passes through clean alphanumeric strings", () => {
+    expect(sanitizeUserString("Lisinopril")).toBe("Lisinopril");
+    expect(sanitizeUserString("CVS Pharmacy (Main St)")).toBe("CVS Pharmacy (Main St)");
+  });
+
+  it("strips newline characters", () => {
+    expect(sanitizeUserString("Drug\nName")).toBe("DrugName");
+    expect(sanitizeUserString("Drug\r\nName")).toBe("DrugName");
+  });
+
+  it("strips Unicode RTL marks", () => {
+    // U+200F RIGHT-TO-LEFT MARK, U+202B RIGHT-TO-LEFT EMBEDDING
+    expect(sanitizeUserString("Drug\u200FName")).toBe("DrugName");
+    expect(sanitizeUserString("Drug\u202BName")).toBe("DrugName");
+  });
+
+  it("strips null bytes and other control characters", () => {
+    expect(sanitizeUserString("Drug\x00Name")).toBe("DrugName");
+    expect(sanitizeUserString("Drug\x07Name")).toBe("DrugName");
+  });
+
+  it("strips characters outside the allowed set", () => {
+    expect(sanitizeUserString("Drug<Name>")).toBe("DrugName");
+    expect(sanitizeUserString("Drug{Name}")).toBe("DrugName");
+    expect(sanitizeUserString("Drug@Name!")).toBe("DrugName");
+  });
+
+  it("caps length to 80 characters", () => {
+    const long = "A".repeat(100);
+    expect(sanitizeUserString(long)).toHaveLength(80);
+  });
+
+  it("returns empty string for non-string input", () => {
+    expect(sanitizeUserString(null)).toBe("");
+    expect(sanitizeUserString(undefined)).toBe("");
+    expect(sanitizeUserString(123)).toBe("");
+  });
+
+  it("trims whitespace", () => {
+    expect(sanitizeUserString("  Drug  ")).toBe("Drug");
+  });
+
+  it("allows hyphens and parentheses", () => {
+    expect(sanitizeUserString("Drug-Name (10mg)")).toBe("Drug-Name (10mg)");
+  });
+});

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -78,6 +78,12 @@ export const agentTransactionsTotal = new Counter({
   registers: [registry],
 });
 
+export const agentLlmErrorTotal = new Counter({
+  name: "agent_llm_error_total",
+  help: "Total LLM API errors during agent runs",
+  registers: [registry],
+});
+
 export function metricsHandler(): RequestHandler {
   return async (req, res) => {
     const token = process.env.METRICS_TOKEN;

--- a/shared/sanitize.ts
+++ b/shared/sanitize.ts
@@ -1,0 +1,26 @@
+/**
+ * Input sanitizer for user-supplied strings crossing API boundaries.
+ *
+ * Strips control characters, enforces a maximum length, and restricts
+ * the character set to safe characters. Used to prevent injection of
+ * newlines, Unicode RTL marks, and other characters that can break
+ * downstream UI parsing (receipts, PDFs, TxLink displays).
+ */
+
+const MAX_LENGTH = 80;
+
+// Allowed: alphanumeric, space, hyphen, parentheses
+const SAFE_PATTERN = /[^a-zA-Z0-9 \-()]/g;
+
+export function sanitizeUserString(input: unknown): string {
+  if (typeof input !== "string") return "";
+  // Strip control characters (U+0000–U+001F, U+007F, U+0080–U+009F)
+  let s = input.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x80-\x9F]/g, "");
+  // Strip any remaining disallowed characters
+  s = s.replace(SAFE_PATTERN, "");
+  // Trim whitespace
+  s = s.trim();
+  // Cap length
+  if (s.length > MAX_LENGTH) s = s.slice(0, MAX_LENGTH);
+  return s;
+}


### PR DESCRIPTION
## Description 

closes  #184 
closes #182 
closes #175 
closes #166 