### PR TITLE
Fix pharmacy persistence, validation caps, wallet seed recovery, and day-bound spending checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # --- Wallets ---
 # Generate all wallets with: npm run setup
 # The setup script outputs keys to paste here.
-# Optional deterministic setup seed. If unset, npm run setup asks before writing .dev-seed.
+# Optional deterministic setup seed. Prefer a BIP-39 mnemonic.
+# If unset, npm run setup asks before writing a new mnemonic to .dev-seed.
 # DEV_WALLET_SEED=
 
 # Agent wallet (the AI agent's wallet — fund with testnet USDC)
@@ -38,9 +39,13 @@ BILL_PROVIDER_PUBLIC_KEY=G...
 OZ_FACILITATOR_API_KEY=
 X402_FACILITATOR_URL=https://channels.openzeppelin.com/x402/testnet
 
-# --- Pharmacy Pricing Provider ---
-# Options: static (default, 5 drugs), goodrx (500+ drugs), costco (500+ drugs)
-PHARMACY_PRICING_PROVIDER=static
+# --- Pharmacy Pricing Store ---
+# Optional override for the on-disk SQLite file used by the pharmacy API.
+# PHARMACY_DB_PATH=./data/pharmacy-pricing.sqlite
+
+# Optional Bearer token for admin pharmacy CRUD and price updates.
+# When unset in unified mode, CAREGIVER_TOKEN is used as the fallback admin token.
+# PHARMACY_ADMIN_TOKEN=
 
 # --- MPP (Machine Payments Protocol) ---
 # Shared secret for MPP credential signing. Generate with: openssl rand -hex 32

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ dist/
 data/audit.log.jsonl
 data/spending.json
 data/orders.json
+data/pharmacy-pricing.sqlite
+data/pharmacy-pricing.sqlite-*
+data/pharmacy-pricing.sqlite-shm
+data/pharmacy-pricing.sqlite-wal
 data/adherence.jsonl
 data/recipients/*/*.json
 !data/recipients/*/

--- a/agent/__tests__/timezone.test.ts
+++ b/agent/__tests__/timezone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { getLocalDateStr } from "../tz.ts";
+import { getLocalDateStr, getLocalDayBounds } from "../tz.ts";
 
 // Isolated module — no external deps, no mocking needed.
 
@@ -76,5 +76,25 @@ describe("getLocalDateStr (Issue #19 — timezone-aware daily limit)", () => {
     // UTC 2024-03-15T03:00:00Z = Eastern 2024-03-14T23:00:00 (11 pm March 14, EST = UTC-5)
     const d = getLocalDateStr("America/New_York", new Date("2024-03-15T03:00:00Z"));
     expect(d).toBe("2024-03-14");
+  });
+
+  it("returns exact UTC day bounds for UTC timezones", () => {
+    const { dayStart, dayEnd } = getLocalDayBounds(
+      "UTC",
+      new Date("2026-04-10T12:00:00.000Z"),
+    );
+
+    expect(dayStart.toISOString()).toBe("2026-04-10T00:00:00.000Z");
+    expect(dayEnd.toISOString()).toBe("2026-04-11T00:00:00.000Z");
+  });
+
+  it("returns timezone-aware day bounds for Phoenix", () => {
+    const { dayStart, dayEnd } = getLocalDayBounds(
+      "America/Phoenix",
+      new Date("2024-06-16T12:00:00.000Z"),
+    );
+
+    expect(dayStart.toISOString()).toBe("2024-06-16T07:00:00.000Z");
+    expect(dayEnd.toISOString()).toBe("2024-06-17T07:00:00.000Z");
   });
 });

--- a/agent/__tests__/tools.test.ts
+++ b/agent/__tests__/tools.test.ts
@@ -2,6 +2,7 @@
 const { mockMppFetch, onProgressHolder, MOCK_HINT } = vi.hoisted(() => {
   process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
   process.env.MOCK_NETWORK = "1";
+  process.env.SPENDING_TIMEZONE = "UTC";
   const onProgressHolder: { fn?: (event: any) => void } = {};
   return {
     mockMppFetch: vi.fn(),
@@ -136,6 +137,51 @@ describe("Spending Policy", () => {
   it("should allow valid amounts within policy", () => {
     const policy = checkSpendingPolicy(50, "medications");
     expect(policy.allowed).toBe(true);
+  });
+
+  it("counts transactions at midnight and 1ms past midnight in the current day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-10T12:00:00.000Z"));
+
+    const tracker = loadSpending("rosa");
+    tracker.transactions = [
+      {
+        id: "tx-midnight",
+        timestamp: "2026-04-10T00:00:00.000Z",
+        type: "payment",
+        description: "Midnight medication",
+        amount: 40,
+        recipient: "pharmacy-1",
+        status: "completed",
+        category: "medications",
+      },
+      {
+        id: "tx-midnight-plus-1ms",
+        timestamp: "2026-04-10T00:00:00.001Z",
+        type: "payment",
+        description: "Midnight medication +1ms",
+        amount: 40,
+        recipient: "pharmacy-1",
+        status: "completed",
+        category: "medications",
+      },
+      {
+        id: "tx-previous-day",
+        timestamp: "2026-04-09T23:59:59.999Z",
+        type: "payment",
+        description: "Previous day medication",
+        amount: 10,
+        recipient: "pharmacy-1",
+        status: "completed",
+        category: "medications",
+      },
+    ] as any;
+
+    const policy = checkSpendingPolicy(30, "medications");
+    expect(policy.allowed).toBe(false);
+    expect(policy.reason).toContain("Already spent today: $80.00");
+
+    vi.useRealTimers();
   });
 });
 

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -47,8 +47,8 @@ import {
   type SpendingPolicy,
   type Transaction,
 } from '../shared/types.ts';
-import { SPENDING_TIMEZONE, getLocalDateStr } from './tz.ts';
-export { SPENDING_TIMEZONE, getLocalDateStr };
+import { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds } from './tz.ts';
+export { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds };
 import { appendAuditEntry } from '../shared/audit-log.ts';
 import { notify } from '../shared/notifications.ts';
 import {
@@ -1035,12 +1035,20 @@ export function checkSpendingPolicy(
     };
   }
 
-  const today = getLocalDateStr(SPENDING_TIMEZONE);
+  const { dayStart, dayEnd } = getLocalDayBounds(SPENDING_TIMEZONE);
+  const dayStartMs = dayStart.getTime();
+  const dayEndMs = dayEnd.getTime();
   const totalToday = spendingTracker.transactions
     .filter(
-      (t) =>
-        getLocalDateStr(SPENDING_TIMEZONE, new Date(t.timestamp)) === today &&
-        t.category === category,
+      (t) => {
+        const txTimestamp = new Date(t.timestamp).getTime();
+        return (
+          Number.isFinite(txTimestamp) &&
+          txTimestamp >= dayStartMs &&
+          txTimestamp < dayEndMs &&
+          t.category === category
+        );
+      },
     )
     .reduce((sum, t) => sum + t.amount, 0);
 

--- a/agent/tz.ts
+++ b/agent/tz.ts
@@ -17,3 +17,69 @@ export function getLocalDateStr(tz: string, date: Date = new Date()): string {
     day: "2-digit",
   }).format(date);
 }
+
+function getDatePart(
+  tz: string,
+  date: Date,
+  field: "year" | "month" | "day" | "hour" | "minute" | "second",
+) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+  const part = formatter
+    .formatToParts(date)
+    .find((entry) => entry.type === field);
+
+  if (!part) {
+    throw new Error(`Unable to resolve ${field} for timezone ${tz}`);
+  }
+
+  return parseInt(part.value, 10);
+}
+
+function getTimeZoneOffsetMs(tz: string, date: Date) {
+  const year = getDatePart(tz, date, "year");
+  const month = getDatePart(tz, date, "month");
+  const day = getDatePart(tz, date, "day");
+  const hour = getDatePart(tz, date, "hour");
+  const minute = getDatePart(tz, date, "minute");
+  const second = getDatePart(tz, date, "second");
+  const asUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+  return asUtc - date.getTime();
+}
+
+function getLocalMidnightUtc(
+  tz: string,
+  year: number,
+  month: number,
+  day: number,
+) {
+  const utcMidnight = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
+  let candidate = new Date(utcMidnight);
+
+  // Iterate to converge on the UTC instant that renders as local midnight.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const offsetMs = getTimeZoneOffsetMs(tz, candidate);
+    candidate = new Date(utcMidnight - offsetMs);
+  }
+
+  return candidate;
+}
+
+export function getLocalDayBounds(tz: string, date: Date = new Date()) {
+  const year = getDatePart(tz, date, "year");
+  const month = getDatePart(tz, date, "month");
+  const day = getDatePart(tz, date, "day");
+
+  return {
+    dayStart: getLocalMidnightUtc(tz, year, month, day),
+    dayEnd: getLocalMidnightUtc(tz, year, month, day + 1),
+  };
+}

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1,0 +1,237 @@
+openapi: '3.1.0'
+info:
+  title: 'CareGuard API'
+  version: '1.0.0'
+  description: 'OpenAPI spec for CareGuard services: agent spending, pharmacy, bill audit, drug interactions, and payments.'
+servers:
+  - url: 'http://localhost:3000'
+    description: 'Development server'
+  - url: 'https://api.careguard.xyz'
+    description: 'Production server'
+security:
+  - X402Auth:
+[]
+components:
+  securitySchemes:
+    X402Auth:
+      type: 'http'
+      scheme: 'bearer'
+      description: 'x402 payment protocol. Include X-PAYMENT header with payment proof on protected routes.'
+  schemas:
+    Error:
+      type: 'object'
+      properties:
+        error:
+          type: 'string'
+        code:
+          type: 'string'
+        details:
+          type: 'object'
+paths:
+  /agent/spending:
+    get:
+      summary: 'Get agent spending summary'
+      tags:
+        - 'Agent'
+      responses:
+        200:
+          description: 'Spending summary'
+          content:
+            application/json:
+              schema:
+                type: 'object'
+                properties:
+                  totalSpent:
+                    type: 'number'
+                  categories:
+                    type: 'object'
+  /pharmacy/compare:
+    get:
+      summary: 'Compare pharmacy prices for a drug'
+      tags:
+        - 'Pharmacy'
+      security:
+        - X402Auth:
+[]
+      parameters:
+        - in: 'query'
+          name: 'drug'
+          required: true
+          schema:
+            type: 'string'
+            minLength: 1
+            maxLength: 80
+          description: 'Drug name. Maximum length: 80 characters.'
+        - in: 'query'
+          name: 'dosage'
+          required: false
+          schema:
+            type: 'string'
+            minLength: 1
+            maxLength: 80
+          description: 'Optional dosage string. Maximum length: 80 characters.'
+        - in: 'query'
+          name: 'zip'
+          required: false
+          schema:
+            type: 'string'
+            pattern: '^\d{5}$'
+          description: '5-digit ZIP code used for distance adjustments.'
+      responses:
+        200:
+          description: 'Pharmacy query results'
+        400:
+          description: 'Invalid request'
+  /pharmacy/prices:
+    post:
+      summary: 'Admin upsert for a drug price at a pharmacy'
+      tags:
+        - 'Pharmacy'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                drug:
+                  type: 'string'
+                  minLength: 1
+                  maxLength: 80
+                pharmacyId:
+                  type: 'string'
+                  minLength: 1
+                  maxLength: 80
+                price:
+                  type: 'number'
+                  exclusiveMinimum: 0
+                  maximum: 10000
+              required:
+                - 'drug'
+                - 'pharmacyId'
+                - 'price'
+      responses:
+        200:
+          description: 'Price created or updated'
+        400:
+          description: 'Validation error'
+  /bill/audit:
+    post:
+      summary: 'Audit medical bills'
+      tags:
+        - 'Bill Audit'
+      security:
+        - X402Auth:
+[]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                lineItems:
+                  type: 'array'
+                  items:
+                    type: 'object'
+                    properties:
+                      cptCode:
+                        type: 'string'
+                      quantity:
+                        type: 'integer'
+                        minimum: 1
+                        maximum: 999
+                      chargedAmount:
+                        type: 'number'
+                        minimum: 0
+                        maximum: 1000000
+                      description:
+                        type: 'string'
+                        minLength: 1
+                        maxLength: 80
+                    required:
+                      - 'cptCode'
+                      - 'quantity'
+                      - 'chargedAmount'
+                      - 'description'
+              required:
+                - 'lineItems'
+      responses:
+        200:
+          description: 'Audit results'
+        400:
+          description: 'Validation error'
+          content:
+            application/json:
+              schema:
+                type: 'object'
+                properties:
+                  errors:
+                    type: 'array'
+  /drug/interactions:
+    get:
+      summary: 'Check drug interactions for a medication list'
+      tags:
+        - 'Drug Interactions'
+      security:
+        - X402Auth:
+[]
+      parameters:
+        - in: 'query'
+          name: 'meds'
+          required: true
+          schema:
+            type: 'string'
+            minLength: 1
+            maxLength: 1619
+          description: 'Comma-separated medication names. Each medication name is limited to 80 characters.'
+      responses:
+        200:
+          description: 'Drug interaction results'
+        400:
+          description: 'Validation error'
+  /pharmacy/order:
+    post:
+      summary: 'Submit a paid pharmacy order'
+      tags:
+        - 'Pharmacy Payments'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: 'object'
+              properties:
+                drug:
+                  type: 'string'
+                  minLength: 1
+                  maxLength: 80
+                pharmacy:
+                  type: 'string'
+                  minLength: 1
+                  maxLength: 80
+                amount:
+                  oneOf:
+                    - type: 'number'
+                      minimum: 0.01
+                      maximum: 10000
+                    - type: 'string'
+              required:
+                - 'drug'
+                - 'pharmacy'
+                - 'amount'
+      responses:
+        200:
+          description: 'Order confirmed'
+        400:
+          description: 'Validation error'
+        402:
+          description: 'Payment required'
+  /docs:
+    get:
+      summary: 'API documentation UI'
+      tags:
+        - 'Documentation'
+      responses:
+        200:
+          description: 'Scalar UI serving this OpenAPI spec'

--- a/docs/scripts/setup-wallets.md
+++ b/docs/scripts/setup-wallets.md
@@ -1,0 +1,38 @@
+# Wallet Setup Recovery
+
+`npm run setup` now derives wallet keypairs from a deterministic seed.
+
+## Recommended flow
+
+1. Run `npm run setup`.
+2. Approve writing `.dev-seed` on the first run.
+3. Store the `.dev-seed` mnemonic somewhere safe.
+4. Re-run `npm run setup` whenever you need the same test wallets again.
+
+## Using your own seed
+
+Pass a BIP-39 mnemonic directly:
+
+```bash
+npm run setup -- --seed="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+```
+
+The script derives Stellar keys with SLIP-0010 on the path `m/44'/148'/index'`, where `index` maps to the wallet role order in `scripts/setup-wallets.ts`.
+
+## Recovery
+
+If you lose the generated `.env` output but still have `.dev-seed`, run:
+
+```bash
+npm run setup
+```
+
+If you backed up the mnemonic elsewhere, you can also recover with:
+
+```bash
+npm run setup -- --seed="your mnemonic here"
+```
+
+## Legacy seeds
+
+Older `.dev-seed` files may contain non-mnemonic raw strings. Those are still supported so existing dev wallets remain reproducible, but they do not provide BIP-39 recovery semantics. Replace them with a mnemonic when practical.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc -b",
     "build": "tsc --noEmit",
     "lint": "tsc --noEmit",
+    "gen-openapi": "node --import tsx scripts/gen-openapi.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "load": "k6 run load/agent-run.js",

--- a/scripts/__tests__/setup-wallets.test.ts
+++ b/scripts/__tests__/setup-wallets.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   deriveWalletsFromSeed,
   DEV_SEED_FILE,
+  isMnemonicSeed,
   resolveSetupSeed,
 } from "../setup-wallets.ts";
 
@@ -24,6 +25,17 @@ function tempDir() {
 }
 
 describe("setup-wallets seed handling", () => {
+  it("derives the same six wallets from the same BIP-39 mnemonic", () => {
+    const mnemonic =
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const first = deriveWalletsFromSeed(mnemonic);
+    const second = deriveWalletsFromSeed(mnemonic);
+
+    expect(first).toEqual(second);
+    expect(first).toHaveLength(6);
+    expect(new Set(first.map((wallet) => wallet.publicKey)).size).toBe(6);
+  });
+
   it("derives the same six wallets from the same seed", () => {
     const first = deriveWalletsFromSeed("repeatable-dev-seed");
     const second = deriveWalletsFromSeed("repeatable-dev-seed");
@@ -56,6 +68,7 @@ describe("setup-wallets seed handling", () => {
     expect(first.source).toBe("generated");
     expect(second.source).toBe("file");
     expect(second.seed).toBe(first.seed);
+    expect(isMnemonicSeed(first.seed)).toBe(true);
     expect(readFileSync(path.join(cwd, DEV_SEED_FILE), "utf-8").trim()).toBe(first.seed);
   });
 

--- a/scripts/gen-openapi.ts
+++ b/scripts/gen-openapi.ts
@@ -10,6 +10,10 @@ import { z } from "zod";
 import { writeFileSync, mkdirSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import {
+  MAX_FREE_TEXT_LENGTH,
+  MAX_FREE_TEXT_LIST_LENGTH,
+} from "../shared/free-text.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const docsDir = path.resolve(__dirname, "../docs");
@@ -24,6 +28,7 @@ interface OpenAPIPath {
   [method: string]: {
     summary?: string;
     tags?: string[];
+    parameters?: Array<Record<string, unknown>>;
     requestBody?: {
       required: boolean;
       content: {
@@ -144,25 +149,45 @@ function generateSpec(): OpenAPISpec {
           },
         },
       },
-      "/pharmacy": {
-        post: {
-          summary: "Query pharmacy API",
+      "/pharmacy/compare": {
+        get: {
+          summary: "Compare pharmacy prices for a drug",
           tags: ["Pharmacy"],
           security: [{ X402Auth: [] }],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    query: { type: "string" },
-                  },
-                  required: ["query"],
-                },
+          parameters: [
+            {
+              in: "query",
+              name: "drug",
+              required: true,
+              schema: {
+                type: "string",
+                minLength: 1,
+                maxLength: MAX_FREE_TEXT_LENGTH,
               },
+              description: "Drug name. Maximum length: 80 characters.",
             },
-          },
+            {
+              in: "query",
+              name: "dosage",
+              required: false,
+              schema: {
+                type: "string",
+                minLength: 1,
+                maxLength: MAX_FREE_TEXT_LENGTH,
+              },
+              description: "Optional dosage string. Maximum length: 80 characters.",
+            },
+            {
+              in: "query",
+              name: "zip",
+              required: false,
+              schema: {
+                type: "string",
+                pattern: "^\\d{5}$",
+              },
+              description: "5-digit ZIP code used for distance adjustments.",
+            },
+          ],
           responses: {
             "200": {
               description: "Pharmacy query results",
@@ -173,7 +198,49 @@ function generateSpec(): OpenAPISpec {
           },
         },
       },
-      "/bill-audit": {
+      "/pharmacy/prices": {
+        post: {
+          summary: "Admin upsert for a drug price at a pharmacy",
+          tags: ["Pharmacy"],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    drug: {
+                      type: "string",
+                      minLength: 1,
+                      maxLength: MAX_FREE_TEXT_LENGTH,
+                    },
+                    pharmacyId: {
+                      type: "string",
+                      minLength: 1,
+                      maxLength: MAX_FREE_TEXT_LENGTH,
+                    },
+                    price: {
+                      type: "number",
+                      exclusiveMinimum: 0,
+                      maximum: 10000,
+                    },
+                  },
+                  required: ["drug", "pharmacyId", "price"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Price created or updated",
+            },
+            "400": {
+              description: "Validation error",
+            },
+          },
+        },
+      },
+      "/bill/audit": {
         post: {
           summary: "Audit medical bills",
           tags: ["Bill Audit"],
@@ -185,7 +252,7 @@ function generateSpec(): OpenAPISpec {
                 schema: {
                   type: "object",
                   properties: {
-                    items: {
+                    lineItems: {
                       type: "array",
                       items: {
                         type: "object",
@@ -197,7 +264,11 @@ function generateSpec(): OpenAPISpec {
                             minimum: 0,
                             maximum: 1000000,
                           },
-                          description: { type: "string", minLength: 1 },
+                          description: {
+                            type: "string",
+                            minLength: 1,
+                            maxLength: MAX_FREE_TEXT_LENGTH,
+                          },
                         },
                         required: [
                           "cptCode",
@@ -208,7 +279,7 @@ function generateSpec(): OpenAPISpec {
                       },
                     },
                   },
-                  required: ["items"],
+                  required: ["lineItems"],
                 },
               },
             },
@@ -229,6 +300,81 @@ function generateSpec(): OpenAPISpec {
                   },
                 },
               },
+            },
+          },
+        },
+      },
+      "/drug/interactions": {
+        get: {
+          summary: "Check drug interactions for a medication list",
+          tags: ["Drug Interactions"],
+          security: [{ X402Auth: [] }],
+          parameters: [
+            {
+              in: "query",
+              name: "meds",
+              required: true,
+              schema: {
+                type: "string",
+                minLength: 1,
+                maxLength: MAX_FREE_TEXT_LIST_LENGTH,
+              },
+              description:
+                "Comma-separated medication names. Each medication name is limited to 80 characters.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Drug interaction results",
+            },
+            "400": {
+              description: "Validation error",
+            },
+          },
+        },
+      },
+      "/pharmacy/order": {
+        post: {
+          summary: "Submit a paid pharmacy order",
+          tags: ["Pharmacy Payments"],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    drug: {
+                      type: "string",
+                      minLength: 1,
+                      maxLength: MAX_FREE_TEXT_LENGTH,
+                    },
+                    pharmacy: {
+                      type: "string",
+                      minLength: 1,
+                      maxLength: MAX_FREE_TEXT_LENGTH,
+                    },
+                    amount: {
+                      oneOf: [
+                        { type: "number", minimum: 0.01, maximum: 10000 },
+                        { type: "string" },
+                      ],
+                    },
+                  },
+                  required: ["drug", "pharmacy", "amount"],
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Order confirmed",
+            },
+            "400": {
+              description: "Validation error",
+            },
+            "402": {
+              description: "Payment required",
             },
           },
         },

--- a/scripts/setup-wallets.ts
+++ b/scripts/setup-wallets.ts
@@ -6,10 +6,12 @@
  */
 
 import { Keypair, Networks, TransactionBuilder, Operation, Asset, Horizon } from "@stellar/stellar-sdk";
-import { createHash, randomBytes } from "crypto";
+import { createHash, createHmac } from "crypto";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { pathToFileURL } from "url";
+import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
+import { wordlist as englishWordlist } from "@scure/bip39/wordlists/english";
 import { logger } from "../shared/logger.ts";
 
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
@@ -24,6 +26,9 @@ export const WALLET_NAMES = [
   "PHARMACY_3",
   "BILL_PROVIDER",
 ] as const;
+const HARDENED_OFFSET = 0x80000000;
+const STELLAR_DERIVATION_PATH = [44, 148] as const;
+const GENERATED_MNEMONIC_STRENGTH = 256;
 
 export interface WalletInfo {
   name: string;
@@ -31,7 +36,15 @@ export interface WalletInfo {
   secretKey: string;
 }
 
-export function deriveWalletsFromSeed(seedMaterial: string): WalletInfo[] {
+function normalizeSeedMaterial(seedMaterial: string) {
+  return seedMaterial.trim().normalize("NFKD").split(/\s+/).join(" ");
+}
+
+export function isMnemonicSeed(seedMaterial: string) {
+  return validateMnemonic(normalizeSeedMaterial(seedMaterial), englishWordlist);
+}
+
+function deriveLegacyWalletsFromSeed(seedMaterial: string): WalletInfo[] {
   return WALLET_NAMES.map((name, index) => {
     const rawSeed = createHash("sha256")
       .update(seedMaterial)
@@ -47,6 +60,62 @@ export function deriveWalletsFromSeed(seedMaterial: string): WalletInfo[] {
       secretKey: keypair.secret(),
     };
   });
+}
+
+function hardenedIndex(index: number) {
+  return index + HARDENED_OFFSET;
+}
+
+function serializeIndex(index: number) {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32BE(index);
+  return buffer;
+}
+
+function deriveSlip10Seed(masterSeed: Uint8Array, index: number) {
+  let hmac = createHmac("sha512", "ed25519 seed");
+  hmac.update(masterSeed);
+  let result = hmac.digest();
+  let privateKey = result.subarray(0, 32);
+  let chainCode = result.subarray(32);
+
+  for (const segment of [...STELLAR_DERIVATION_PATH, index]) {
+    const data = Buffer.concat([
+      Buffer.from([0]),
+      privateKey,
+      serializeIndex(hardenedIndex(segment)),
+    ]);
+    hmac = createHmac("sha512", chainCode);
+    hmac.update(data);
+    result = hmac.digest();
+    privateKey = result.subarray(0, 32);
+    chainCode = result.subarray(32);
+  }
+
+  return privateKey;
+}
+
+function deriveWalletsFromMnemonic(mnemonic: string): WalletInfo[] {
+  const normalizedMnemonic = normalizeSeedMaterial(mnemonic);
+  const masterSeed = mnemonicToSeedSync(normalizedMnemonic);
+
+  return WALLET_NAMES.map((name, index) => {
+    const rawSeed = deriveSlip10Seed(masterSeed, index);
+    const keypair = Keypair.fromRawEd25519Seed(rawSeed);
+    return {
+      name,
+      publicKey: keypair.publicKey(),
+      secretKey: keypair.secret(),
+    };
+  });
+}
+
+export function deriveWalletsFromSeed(seedMaterial: string): WalletInfo[] {
+  if (isMnemonicSeed(seedMaterial)) {
+    return deriveWalletsFromMnemonic(seedMaterial);
+  }
+
+  return deriveLegacyWalletsFromSeed(seedMaterial);
 }
 
 async function confirmDevSeedGeneration(): Promise<boolean> {
@@ -88,7 +157,7 @@ export async function resolveSetupSeed(options: {
     );
   }
 
-  const seed = randomBytes(32).toString("hex");
+  const seed = generateMnemonic(englishWordlist, GENERATED_MNEMONIC_STRENGTH);
   writeFileSync(seedPath, `${seed}\n`, { mode: 0o600 });
   return { seed, source: "generated", path: seedPath };
 }
@@ -146,6 +215,12 @@ async function main() {
     logger.info({ path: seed.path }, "generated setup seed");
   } else {
     logger.info({ source: seed.source }, "using setup seed");
+  }
+
+  if (!isMnemonicSeed(seed.seed)) {
+    logger.warn(
+      "using legacy non-mnemonic setup seed; recovery via BIP-39 mnemonic is unavailable until you replace .dev-seed or pass --seed",
+    );
   }
 
   const wallets = deriveWalletsFromSeed(seed.seed);

--- a/server.ts
+++ b/server.ts
@@ -26,6 +26,11 @@ import { applySecurityMiddleware } from "./shared/security-middleware.ts";
 import { logger } from "./shared/logger.ts";
 import { validateTask, getSuspiciousTaskCount } from "./shared/task-validation.ts";
 import { buildScrubSession, scrubText } from "./shared/prompt-scrub.ts";
+import {
+  BillAuditValidationError,
+  validateBillAuditRequest,
+} from "./shared/bill-audit.ts";
+import { sanitizeUserString } from "./shared/sanitize.ts";
 
 // Sentry (gated by SENTRY_DSN)
 import { initSentry } from "./shared/sentry.ts";
@@ -69,6 +74,30 @@ import {
   TOOL_DEFINITIONS,
   validateToolInput,
 } from "./agent/tools.ts";
+import { resolveRequestedDosage } from "./services/pharmacy-api/dosage.ts";
+import { createPharmacyPricingStore } from "./services/pharmacy-api/db.ts";
+import {
+  buildCompareResponse,
+  DrugRecordSchema,
+  PharmacyCompareQuerySchema,
+  PharmacyPriceSchema,
+  PharmacyRecordSchema,
+} from "./services/pharmacy-api/logic.ts";
+import type {
+  DrugRecordInput,
+  PharmacyCompareQuery,
+  PharmacyPriceInput,
+  PharmacyRecordInput,
+} from "./services/pharmacy-api/logic.ts";
+import {
+  checkInteractions as checkDrugInteractionsInService,
+  DrugInteractionsQuerySchema,
+} from "./services/drug-interaction-api/logic.ts";
+import type { DrugInteractionsQuery } from "./services/drug-interaction-api/logic.ts";
+import {
+  MedicationOrderSchema,
+  type MedicationOrderInput,
+} from "./services/pharmacy-payment/validation.ts";
 
 // --- Environment ---
 const envSchema = z.object({
@@ -265,174 +294,162 @@ app.patch("/agent/profile", (req, res) => {
 // PHARMACY PRICE API (was port 3001)
 // ============================================================
 
-const PRICING_DATABASE: Record<
-  string,
-  Array<{ pharmacy: string; id: string; price: number; distance: string }>
-> = {
-  lisinopril: [
-    {
-      pharmacy: "Costco Pharmacy",
-      id: "costco-001",
-      price: 3.5,
-      distance: "2.1 mi",
-    },
-    {
-      pharmacy: "Walmart Pharmacy",
-      id: "walmart-001",
-      price: 4.0,
-      distance: "1.8 mi",
-    },
-    {
-      pharmacy: "CVS Pharmacy",
-      id: "cvs-001",
-      price: 12.99,
-      distance: "0.5 mi",
-    },
-    {
-      pharmacy: "Walgreens",
-      id: "walgreens-001",
-      price: 15.49,
-      distance: "0.8 mi",
-    },
-    {
-      pharmacy: "Rite Aid",
-      id: "riteaid-001",
-      price: 18.99,
-      distance: "3.2 mi",
-    },
-  ],
-  metformin: [
-    {
-      pharmacy: "Costco Pharmacy",
-      id: "costco-001",
-      price: 4.0,
-      distance: "2.1 mi",
-    },
-    {
-      pharmacy: "Walmart Pharmacy",
-      id: "walmart-001",
-      price: 4.0,
-      distance: "1.8 mi",
-    },
-    {
-      pharmacy: "CVS Pharmacy",
-      id: "cvs-001",
-      price: 11.99,
-      distance: "0.5 mi",
-    },
-    {
-      pharmacy: "Walgreens",
-      id: "walgreens-001",
-      price: 13.49,
-      distance: "0.8 mi",
-    },
-    {
-      pharmacy: "Rite Aid",
-      id: "riteaid-001",
-      price: 16.79,
-      distance: "3.2 mi",
-    },
-  ],
-  atorvastatin: [
-    {
-      pharmacy: "Costco Pharmacy",
-      id: "costco-001",
-      price: 6.5,
-      distance: "2.1 mi",
-    },
-    {
-      pharmacy: "Walmart Pharmacy",
-      id: "walmart-001",
-      price: 9.0,
-      distance: "1.8 mi",
-    },
-    {
-      pharmacy: "CVS Pharmacy",
-      id: "cvs-001",
-      price: 24.99,
-      distance: "0.5 mi",
-    },
-    {
-      pharmacy: "Walgreens",
-      id: "walgreens-001",
-      price: 28.49,
-      distance: "0.8 mi",
-    },
-    {
-      pharmacy: "Rite Aid",
-      id: "riteaid-001",
-      price: 31.99,
-      distance: "3.2 mi",
-    },
-  ],
-  amlodipine: [
-    {
-      pharmacy: "Costco Pharmacy",
-      id: "costco-001",
-      price: 4.2,
-      distance: "2.1 mi",
-    },
-    {
-      pharmacy: "Walmart Pharmacy",
-      id: "walmart-001",
-      price: 4.0,
-      distance: "1.8 mi",
-    },
-    {
-      pharmacy: "CVS Pharmacy",
-      id: "cvs-001",
-      price: 14.99,
-      distance: "0.5 mi",
-    },
-    {
-      pharmacy: "Walgreens",
-      id: "walgreens-001",
-      price: 17.49,
-      distance: "0.8 mi",
-    },
-    {
-      pharmacy: "Rite Aid",
-      id: "riteaid-001",
-      price: 19.99,
-      distance: "3.2 mi",
-    },
-  ],
-  omeprazole: [
-    {
-      pharmacy: "Costco Pharmacy",
-      id: "costco-001",
-      price: 5.8,
-      distance: "2.1 mi",
-    },
-    {
-      pharmacy: "Walmart Pharmacy",
-      id: "walmart-001",
-      price: 8.5,
-      distance: "1.8 mi",
-    },
-    {
-      pharmacy: "CVS Pharmacy",
-      id: "cvs-001",
-      price: 22.99,
-      distance: "0.5 mi",
-    },
-    {
-      pharmacy: "Walgreens",
-      id: "walgreens-001",
-      price: 25.49,
-      distance: "0.8 mi",
-    },
-    {
-      pharmacy: "Rite Aid",
-      id: "riteaid-001",
-      price: 27.99,
-      distance: "3.2 mi",
-    },
-  ],
-};
+const PHARMACY_ADMIN_TOKEN = process.env.PHARMACY_ADMIN_TOKEN || CAREGIVER_TOKEN;
+const pharmacyStore = createPharmacyPricingStore();
+
+function requirePharmacyAdmin(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+) {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer ")) {
+    res
+      .status(401)
+      .setHeader("WWW-Authenticate", "Bearer")
+      .json({ error: "Missing admin token" });
+    return;
+  }
+
+  if (auth.slice("Bearer ".length) !== PHARMACY_ADMIN_TOKEN) {
+    res.status(403).json({ error: "Invalid admin token" });
+    return;
+  }
+
+  next();
+}
 
 app.get("/pharmacy/drugs", (_req, res) => {
-  res.json({ drugs: Object.keys(PRICING_DATABASE) });
+  const drugs = pharmacyStore.listDrugs();
+  res.json({ count: drugs.length, drugs, provider: "sqlite" });
+});
+
+app.get("/pharmacy/pharmacies", (_req, res) => {
+  res.json({ pharmacies: pharmacyStore.listPharmacies() });
+});
+
+app.post("/pharmacy/drugs", requirePharmacyAdmin, (req, res) => {
+  const parsedBody = DrugRecordSchema.safeParse(req.body);
+  if (!parsedBody.success) {
+    res.status(400).json({
+      error: parsedBody.error.issues[0]?.message ?? "Invalid drug payload",
+    });
+    return;
+  }
+
+  res.status(201).json({
+    drug: pharmacyStore.upsertDrug(parsedBody.data as DrugRecordInput),
+  });
+});
+
+app.put("/pharmacy/drugs/:drugName", requirePharmacyAdmin, (req, res) => {
+  const drugName = Array.isArray(req.params.drugName)
+    ? req.params.drugName[0]
+    : req.params.drugName;
+  const parsedBody = DrugRecordSchema.safeParse({
+    ...req.body,
+    name: drugName,
+  });
+  if (!parsedBody.success) {
+    res.status(400).json({
+      error: parsedBody.error.issues[0]?.message ?? "Invalid drug payload",
+    });
+    return;
+  }
+
+  res.json({ drug: pharmacyStore.upsertDrug(parsedBody.data as DrugRecordInput) });
+});
+
+app.delete("/pharmacy/drugs/:drugName", requirePharmacyAdmin, (req, res) => {
+  const drugName = Array.isArray(req.params.drugName)
+    ? req.params.drugName[0]
+    : req.params.drugName;
+  if (!pharmacyStore.deleteDrug(drugName)) {
+    res.status(404).json({ error: `Drug not found: ${drugName}` });
+    return;
+  }
+
+  res.status(204).send();
+});
+
+app.post("/pharmacy/pharmacies", requirePharmacyAdmin, (req, res) => {
+  const parsedBody = PharmacyRecordSchema.safeParse(req.body);
+  if (!parsedBody.success) {
+    res.status(400).json({
+      error: parsedBody.error.issues[0]?.message ?? "Invalid pharmacy payload",
+    });
+    return;
+  }
+
+  res.status(201).json({
+    pharmacy: pharmacyStore.upsertPharmacy(parsedBody.data as PharmacyRecordInput),
+  });
+});
+
+app.put(
+  "/pharmacy/pharmacies/:pharmacyId",
+  requirePharmacyAdmin,
+  (req, res) => {
+    const pharmacyId = Array.isArray(req.params.pharmacyId)
+      ? req.params.pharmacyId[0]
+      : req.params.pharmacyId;
+    const parsedBody = PharmacyRecordSchema.safeParse({
+      ...req.body,
+      id: pharmacyId,
+    });
+    if (!parsedBody.success) {
+      res.status(400).json({
+        error:
+          parsedBody.error.issues[0]?.message ?? "Invalid pharmacy payload",
+      });
+      return;
+    }
+
+    res.json({
+      pharmacy: pharmacyStore.upsertPharmacy(
+        parsedBody.data as PharmacyRecordInput,
+      ),
+    });
+  },
+);
+
+app.delete(
+  "/pharmacy/pharmacies/:pharmacyId",
+  requirePharmacyAdmin,
+  (req, res) => {
+    const pharmacyId = Array.isArray(req.params.pharmacyId)
+      ? req.params.pharmacyId[0]
+      : req.params.pharmacyId;
+    if (!pharmacyStore.deletePharmacy(pharmacyId)) {
+      res.status(404).json({
+        error: `Pharmacy not found: ${pharmacyId}`,
+      });
+      return;
+    }
+
+    res.status(204).send();
+  },
+);
+
+app.post("/pharmacy/prices", requirePharmacyAdmin, (req, res) => {
+  const parsedBody = PharmacyPriceSchema.safeParse(req.body);
+  if (!parsedBody.success) {
+    res.status(400).json({
+      error:
+        parsedBody.error.issues[0]?.message ?? "Invalid pharmacy price payload",
+    });
+    return;
+  }
+
+  try {
+    res.json({
+      price: pharmacyStore.upsertPrice(parsedBody.data as PharmacyPriceInput),
+    });
+  } catch (error) {
+    res.status(404).json({
+      error: error instanceof Error ? error.message : "Unable to upsert price",
+    });
+  }
 });
 
 // x402 for pharmacy compare
@@ -457,50 +474,43 @@ applyX402Middleware(
 );
 
 app.get("/pharmacy/compare", (req, res) => {
-  const drug = ((req.query.drug as string) || "").toLowerCase().trim();
-  if (!drug) {
-    res.status(400).json({ error: "Missing: drug" });
-    return;
-  }
-  const prices = PRICING_DATABASE[drug];
-  if (!prices) {
-    res.status(404).json({ error: `Drug "${drug}" not found` });
-    return;
-  }
-  const sorted = [...prices].sort((a, b) => a.price - b.price);
-  const cheapest = sorted[0],
-    most = sorted[sorted.length - 1];
-  res.json({
-    drug: drug.charAt(0).toUpperCase() + drug.slice(1),
-    zipCode: req.query.zip || "90210",
-    queryTimestamp: new Date().toISOString(),
-    protocol: {
-      name: "x402",
-      network: NETWORK,
-      price: "$0.002",
-      payTo: process.env.PHARMACY_1_PUBLIC_KEY,
-    },
-    prices: sorted.map((p) => ({
-      pharmacyName: p.pharmacy,
-      pharmacyId: p.id,
-      price: p.price,
-      distance: p.distance,
-      inStock: 'unknown',
-    })),
-    cheapest: {
-      pharmacyName: cheapest.pharmacy,
-      pharmacyId: cheapest.id,
-      price: cheapest.price,
-      distance: cheapest.distance,
-    },
-    mostExpensive: {
-      pharmacyName: most.pharmacy,
-      pharmacyId: most.id,
-      price: most.price,
-    },
-    potentialSavings: +(most.price - cheapest.price).toFixed(2),
-    savingsPercent: +((1 - cheapest.price / most.price) * 100).toFixed(1),
+  const parsedQuery = PharmacyCompareQuerySchema.safeParse({
+    drug: req.query.drug,
+    dosage: req.query.dosage,
+    zip: req.query.zip,
   });
+  if (!parsedQuery.success) {
+    res.status(400).json({
+      error:
+        parsedQuery.error.issues[0]?.message ??
+        "Invalid pharmacy query parameters",
+    });
+    return;
+  }
+
+  const query = parsedQuery.data as PharmacyCompareQuery;
+  const drug = query.drug.trim().toLowerCase();
+  const dosage = resolveRequestedDosage(drug, query.dosage);
+
+  try {
+    const prices = pharmacyStore.getPrices(drug);
+    res.json(
+      buildCompareResponse({
+        drug,
+        dosage,
+        zip: query.zip,
+        payTo: env.data.PHARMACY_1_PUBLIC_KEY,
+        network: NETWORK,
+        prices,
+      }),
+    );
+  } catch (error) {
+    res.status(404).json({
+      error: error instanceof Error ? error.message : `Drug "${drug}" not found`,
+      provider: "sqlite",
+      drugCount: pharmacyStore.getDrugCount(),
+    });
+  }
 });
 
 // ============================================================
@@ -687,68 +697,32 @@ applyX402Middleware(app, {
 });
 
 app.post("/bill/audit", (req, res) => {
-  const { lineItems } = req.body;
-  if (!lineItems?.length) {
-    res.status(400).json({ error: "Missing lineItems" });
-    return;
+  try {
+    const validatedBody = validateBillAuditRequest(req.body);
+    const sanitizedLineItems = validatedBody.lineItems.map((lineItem) => ({
+      ...lineItem,
+      description: sanitizeUserString(lineItem.description),
+    }));
+    res.json(runBillAudit(sanitizedLineItems));
+  } catch (error) {
+    if (error instanceof BillAuditValidationError) {
+      const validationError = error as BillAuditValidationError;
+      res.status(400).json({
+        ok: false,
+        reason: validationError.code,
+        message: validationError.message,
+        issues: validationError.issues,
+      });
+      return;
+    }
+
+    res.status(400).json({ ok: false, reason: "INVALID_REQUEST_BODY" });
   }
-  res.json(runBillAudit(lineItems));
 });
 
 // ============================================================
 // DRUG INTERACTION API (was port 3003)
 // ============================================================
-
-const INTERACTIONS = [
-  {
-    drugs: ["lisinopril", "potassium"] as [string, string],
-    severity: "severe" as const,
-    description: "ACE inhibitors + potassium = hyperkalemia risk",
-    recommendation: "Monitor potassium levels",
-  },
-  {
-    drugs: ["metformin", "alcohol"] as [string, string],
-    severity: "severe" as const,
-    description: "Alcohol + metformin = lactic acidosis risk",
-    recommendation: "Limit alcohol",
-  },
-  {
-    drugs: ["atorvastatin", "grapefruit"] as [string, string],
-    severity: "moderate" as const,
-    description: "Grapefruit increases atorvastatin levels",
-    recommendation: "Avoid grapefruit juice",
-  },
-  {
-    drugs: ["lisinopril", "ibuprofen"] as [string, string],
-    severity: "moderate" as const,
-    description: "NSAIDs reduce lisinopril effectiveness",
-    recommendation: "Use acetaminophen instead",
-  },
-  {
-    drugs: ["amlodipine", "atorvastatin"] as [string, string],
-    severity: "mild" as const,
-    description: "Amlodipine slightly increases atorvastatin levels",
-    recommendation: "Safe at standard doses",
-  },
-  {
-    drugs: ["metformin", "atorvastatin"] as [string, string],
-    severity: "mild" as const,
-    description: "Statins may slightly increase blood sugar",
-    recommendation: "Monitor blood sugar",
-  },
-  {
-    drugs: ["omeprazole", "metformin"] as [string, string],
-    severity: "mild" as const,
-    description: "Long-term omeprazole may reduce B12 absorption",
-    recommendation: "Monitor B12",
-  },
-  {
-    drugs: ["lisinopril", "amlodipine"] as [string, string],
-    severity: "mild" as const,
-    description: "Common BP combo, generally safe",
-    recommendation: "Monitor for low BP",
-  },
-];
 
 // x402 for drug interactions
 applyX402Middleware(app, {
@@ -765,62 +739,25 @@ applyX402Middleware(app, {
 });
 
 app.get("/drug/interactions", (req, res) => {
-  const medsParam = req.query.meds as string;
-  if (!medsParam) {
-    res.status(400).json({ error: "Missing: meds" });
+  const parsedQuery = DrugInteractionsQuerySchema.safeParse({
+    meds: req.query.meds,
+  });
+  if (!parsedQuery.success) {
+    res.status(400).json({
+      error:
+        parsedQuery.error.issues[0]?.message ??
+        "Invalid meds query parameter",
+    });
     return;
   }
-  const medications = medsParam
-    .split(",")
-    .map((m) => m.trim())
-    .filter(Boolean);
-  if (medications.length < 2) {
-    res.status(400).json({ error: "Need 2+ medications" });
-    return;
-  }
-  const meds = medications.map((m) => m.toLowerCase());
-  const found: any[] = [];
-  for (let i = 0; i < meds.length; i++) {
-    for (let j = i + 1; j < meds.length; j++) {
-      for (const ix of INTERACTIONS) {
-        if (
-          (meds[i] === ix.drugs[0] && meds[j] === ix.drugs[1]) ||
-          (meds[i] === ix.drugs[1] && meds[j] === ix.drugs[0])
-        ) {
-          found.push({
-            drug1: medications[i],
-            drug2: medications[j],
-            severity: ix.severity,
-            description: ix.description,
-            recommendation: ix.recommendation,
-          });
-        }
-      }
-    }
-  }
-  const severe = found.filter((f) => f.severity === "severe").length;
-  const moderate = found.filter((f) => f.severity === "moderate").length;
+
+  const result = checkDrugInteractionsInService(
+    (parsedQuery.data as DrugInteractionsQuery).medications,
+  );
   res.json({
     checkTimestamp: new Date().toISOString(),
     protocol: { name: "x402", network: NETWORK, price: "$0.001" },
-    medications,
-    interactionCount: found.length,
-    severeCount: severe,
-    moderateCount: moderate,
-    mildCount: found.length - severe - moderate,
-    interactions: found,
-    overallRisk:
-      severe > 0
-        ? "high"
-        : moderate > 0
-          ? "moderate"
-          : found.length > 0
-            ? "low"
-            : "none",
-    summary:
-      found.length === 0
-        ? "No known interactions found."
-        : `Found ${found.length} interaction(s): ${severe} severe, ${moderate} moderate, ${found.length - severe - moderate} mild.`,
+    ...result,
   });
 });
 
@@ -848,7 +785,10 @@ const mppx = Mppx.create({
     stellar.charge({
       recipient: process.env.PHARMACY_1_PUBLIC_KEY!,
       currency: USDC_SAC_TESTNET,
-      network: NETWORK,
+      network:
+        env.data.STELLAR_NETWORK === "public"
+          ? "stellar:pubnet"
+          : "stellar:testnet",
       store: Store.memory(),
     }),
   ],
@@ -859,11 +799,18 @@ app.get("/pharmacy/orders", (_req, res) => {
 });
 
 app.post("/pharmacy/order", async (req, res) => {
-  const { drug, pharmacy, amount } = req.body;
-  if (!drug || !pharmacy || !amount) {
-    res.status(400).json({ error: "Missing: drug, pharmacy, amount" });
+  const parsedOrder = MedicationOrderSchema.safeParse(req.body);
+  if (!parsedOrder.success) {
+    res.status(400).json({
+      error: "Invalid order request",
+      details: parsedOrder.error.issues.map((issue) => issue.message),
+    });
     return;
   }
+
+  const order = parsedOrder.data as MedicationOrderInput;
+  const safeDrug = sanitizeUserString(order.drug);
+  const safePharmacy = sanitizeUserString(order.pharmacy);
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
     if (value == null) continue;
@@ -878,8 +825,8 @@ app.post("/pharmacy/order", async (req, res) => {
     headers,
   });
   const result = await mppx.charge({
-    amount: parseFloat(amount).toFixed(2),
-    description: `Medication: ${drug} from ${pharmacy}`,
+    amount: order.amount.toFixed(2),
+    description: `Medication: ${safeDrug} from ${safePharmacy}`,
   })(webReq);
   if (result.status === 402) {
     result.challenge.headers.forEach((v: string, k: string) =>
@@ -890,9 +837,9 @@ app.post("/pharmacy/order", async (req, res) => {
   }
   const order = {
     id: `order-${Date.now()}`,
-    drug,
-    pharmacy,
-    amount: parseFloat(amount),
+    drug: safeDrug,
+    pharmacy: safePharmacy,
+    amount: order.amount,
     status: "confirmed",
     timestamp: new Date().toISOString(),
     network: NETWORK,
@@ -903,7 +850,7 @@ app.post("/pharmacy/order", async (req, res) => {
     Response.json({
       success: true,
       order,
-      message: `Payment settled. ${drug} from ${pharmacy} confirmed.`,
+      message: `Payment settled. ${safeDrug} from ${safePharmacy} confirmed.`,
     }),
   );
   response.headers.forEach((v: string, k: string) => res.setHeader(k, v));

--- a/server.ts
+++ b/server.ts
@@ -808,9 +808,9 @@ app.post("/pharmacy/order", async (req, res) => {
     return;
   }
 
-  const order = parsedOrder.data as MedicationOrderInput;
-  const safeDrug = sanitizeUserString(order.drug);
-  const safePharmacy = sanitizeUserString(order.pharmacy);
+  const parsedOrderData = parsedOrder.data as MedicationOrderInput;
+  const safeDrug = sanitizeUserString(parsedOrderData.drug);
+  const safePharmacy = sanitizeUserString(parsedOrderData.pharmacy);
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
     if (value == null) continue;
@@ -825,7 +825,7 @@ app.post("/pharmacy/order", async (req, res) => {
     headers,
   });
   const result = await mppx.charge({
-    amount: order.amount.toFixed(2),
+    amount: parsedOrderData.amount.toFixed(2),
     description: `Medication: ${safeDrug} from ${safePharmacy}`,
   })(webReq);
   if (result.status === 402) {
@@ -839,7 +839,7 @@ app.post("/pharmacy/order", async (req, res) => {
     id: `order-${Date.now()}`,
     drug: safeDrug,
     pharmacy: safePharmacy,
-    amount: order.amount,
+    amount: parsedOrderData.amount,
     status: "confirmed",
     timestamp: new Date().toISOString(),
     network: NETWORK,

--- a/services/bill-audit-api/__tests__/validation.test.ts
+++ b/services/bill-audit-api/__tests__/validation.test.ts
@@ -7,6 +7,7 @@ describe("bill audit line item validation", () => {
     ["zero qty", [{ description: "Office visit", cptCode: "99213", quantity: 0, chargedAmount: 130 }]],
     ["negative amount", [{ description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: -1 }]],
     ["malformed cpt", [{ description: "Office visit", cptCode: "AB123", quantity: 1, chargedAmount: 130 }]],
+    ["too long description", [{ description: "x".repeat(81), cptCode: "99213", quantity: 1, chargedAmount: 130 }]],
   ])("rejects %s", (_label, lineItems) => {
     try {
       validateLineItems(lineItems as any);

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -139,20 +139,6 @@ checkRatesFreshness();
 
 interface BillItem { description: string; cptCode: string; quantity: number; chargedAmount: number; }
 
-// Zod schema for validating bill items
-const CPT_CODE_PATTERN = /^(?:\d{5}|J\d{4})$/;
-
-const BillItemSchema = z.object({
-  description: z.string().min(1, "description is required"),
-  cptCode: z.string().regex(CPT_CODE_PATTERN, "cptCode must be a valid CPT code (5 digits or J followed by 4 digits)"),
-  quantity: z.number().positive("quantity must be positive"),
-  chargedAmount: z.number().nonnegative("chargedAmount must be non-negative"),
-});
-
-const BillAuditRequestSchema = z.object({
-  lineItems: z.array(BillItemSchema).min(1, "lineItems must contain at least one item"),
-});
-
 function auditBill(lineItems: BillItem[]) {
   const results: any[] = [];
   let totalCharged = 0, totalCorrect = 0, errorCount = 0;
@@ -242,19 +228,20 @@ applyX402Middleware(app, {
 
 app.post("/bill/audit", (req, res) => {
   try {
-    const validatedData = BillAuditRequestSchema.parse(req.body);
-    const sanitizedLineItems = validatedData.lineItems.map(item => ({
+    const validatedData = validateBillAuditRequest(req.body);
+    const sanitizedLineItems = validatedData.lineItems.map((item) => ({
       ...item,
       description: sanitizeUserString(item.description),
     }));
     res.json(auditBill(sanitizedLineItems));
   } catch (error) {
     if (error instanceof BillAuditValidationError) {
+      const validationError = error as BillAuditValidationError;
       res.status(400).json({
         ok: false,
-        reason: error.code,
-        message: error.message,
-        issues: error.issues,
+        reason: validationError.code,
+        message: validationError.message,
+        issues: validationError.issues,
       });
     } else {
       res.status(400).json({ ok: false, reason: "INVALID_REQUEST_BODY" });

--- a/services/drug-interaction-api/logic.ts
+++ b/services/drug-interaction-api/logic.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+import { delimitedFreeTextListSchema } from "../../shared/free-text.ts";
+
+export interface Interaction {
+  drugs: [string, string];
+  severity: "mild" | "moderate" | "severe";
+  description: string;
+  recommendation: string;
+}
+
+export const INTERACTIONS: Interaction[] = [
+  {
+    drugs: ["lisinopril", "potassium"],
+    severity: "severe",
+    description:
+      "Lisinopril can increase potassium levels. Taking potassium supplements with ACE inhibitors may cause dangerously high potassium (hyperkalemia).",
+    recommendation:
+      "Monitor potassium levels regularly. Avoid potassium supplements unless directed by physician.",
+  },
+  {
+    drugs: ["metformin", "alcohol"],
+    severity: "severe",
+    description:
+      "Alcohol with metformin increases risk of lactic acidosis, a rare but life-threatening condition.",
+    recommendation:
+      "Limit alcohol consumption. Seek immediate medical attention if experiencing unusual muscle pain.",
+  },
+  {
+    drugs: ["atorvastatin", "grapefruit"],
+    severity: "moderate",
+    description:
+      "Grapefruit can increase atorvastatin blood levels, raising the risk of muscle damage (rhabdomyolysis).",
+    recommendation:
+      "Avoid grapefruit and grapefruit juice while taking atorvastatin.",
+  },
+  {
+    drugs: ["lisinopril", "ibuprofen"],
+    severity: "moderate",
+    description:
+      "NSAIDs like ibuprofen can reduce lisinopril's effectiveness and may increase kidney damage risk.",
+    recommendation:
+      "Use acetaminophen (Tylenol) instead of ibuprofen for pain relief.",
+  },
+  {
+    drugs: ["amlodipine", "atorvastatin"],
+    severity: "mild",
+    description:
+      "Amlodipine can slightly increase atorvastatin blood levels. Generally safe at standard doses.",
+    recommendation:
+      "No action needed at standard doses. Monitor for muscle pain if atorvastatin dose exceeds 20mg.",
+  },
+  {
+    drugs: ["metformin", "atorvastatin"],
+    severity: "mild",
+    description:
+      "Some studies suggest statins may slightly increase blood sugar levels. Very common in diabetic patients.",
+    recommendation:
+      "Monitor blood sugar levels as usual. Benefits of statin therapy generally outweigh this small risk.",
+  },
+  {
+    drugs: ["omeprazole", "metformin"],
+    severity: "mild",
+    description:
+      "Long-term omeprazole use may reduce vitamin B12 absorption, compounding metformin's known B12 effect.",
+    recommendation:
+      "Consider periodic B12 level monitoring, especially after 2+ years of concurrent use.",
+  },
+  {
+    drugs: ["lisinopril", "amlodipine"],
+    severity: "mild",
+    description:
+      "Common intentional combination for blood pressure management. Both lower BP through different mechanisms.",
+    recommendation:
+      "Monitor for excessive blood pressure lowering (dizziness, lightheadedness).",
+  },
+];
+
+export const NORMALIZED_INTERACTIONS = INTERACTIONS.map((interaction) => ({
+  ...interaction,
+  drugs: [
+    interaction.drugs[0].toLowerCase(),
+    interaction.drugs[1].toLowerCase(),
+  ] as [string, string],
+}));
+
+export const DrugInteractionsQuerySchema = z
+  .object({
+    meds: delimitedFreeTextListSchema("meds"),
+  })
+  .strict()
+  .refine(
+    ({ meds }) => meds.length >= 2,
+    "Need at least 2 medications",
+  )
+  .transform(({ meds }) => ({ medications: meds }));
+
+export type DrugInteractionsQuery = z.infer<typeof DrugInteractionsQuerySchema>;
+
+function sortPairsBySeverity(pairs: any[]) {
+  const severityOrder: Record<string, number> = {
+    severe: 0,
+    moderate: 1,
+    mild: 2,
+  };
+
+  return pairs.sort((left, right) => {
+    const severityDiff =
+      (severityOrder[left.severity] ?? 3) - (severityOrder[right.severity] ?? 3);
+    if (severityDiff !== 0) {
+      return severityDiff;
+    }
+
+    const leftKey = [left.drug1, left.drug2].sort().join("|");
+    const rightKey = [right.drug1, right.drug2].sort().join("|");
+    return leftKey.localeCompare(rightKey);
+  });
+}
+
+export function checkInteractions(medications: string[]) {
+  const normalizedMedications = medications.map((medication) =>
+    medication.toLowerCase().trim(),
+  );
+  const found: Array<{
+    drug1: string;
+    drug2: string;
+    severity: Interaction["severity"];
+    description: string;
+    recommendation: string;
+  }> = [];
+
+  for (let left = 0; left < normalizedMedications.length; left++) {
+    for (let right = left + 1; right < normalizedMedications.length; right++) {
+      for (const interaction of NORMALIZED_INTERACTIONS) {
+        const [first, second] = interaction.drugs;
+        if (
+          (normalizedMedications[left] === first &&
+            normalizedMedications[right] === second) ||
+          (normalizedMedications[left] === second &&
+            normalizedMedications[right] === first)
+        ) {
+          found.push({
+            drug1: medications[left],
+            drug2: medications[right],
+            severity: interaction.severity,
+            description: interaction.description,
+            recommendation: interaction.recommendation,
+          });
+        }
+      }
+    }
+  }
+
+  const severeCount = found.filter(
+    (interaction) => interaction.severity === "severe",
+  ).length;
+  const moderateCount = found.filter(
+    (interaction) => interaction.severity === "moderate",
+  ).length;
+
+  return {
+    medications,
+    interactionCount: found.length,
+    severeCount,
+    moderateCount,
+    mildCount: found.length - severeCount - moderateCount,
+    interactions: sortPairsBySeverity(found),
+    overallRisk:
+      severeCount > 0
+        ? "high"
+        : moderateCount > 0
+          ? "moderate"
+          : found.length > 0
+            ? "low"
+            : "none",
+    summary:
+      found.length === 0
+        ? "No known interactions found."
+        : `Found ${found.length} interaction(s): ${severeCount} severe, ${moderateCount} moderate, ${found.length - severeCount - moderateCount} mild.`,
+  };
+}

--- a/services/drug-interaction-api/server.ts
+++ b/services/drug-interaction-api/server.ts
@@ -20,77 +20,16 @@ import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
+import {
+  checkInteractions,
+  DrugInteractionsQuerySchema,
+} from "./logic.ts";
+import type { DrugInteractionsQuery } from "./logic.ts";
 
 const PORT = parseInt(process.env.DRUG_INTERACTION_API_PORT || "3003");
 const PAY_TO = process.env.PHARMACY_2_PUBLIC_KEY;
 
 if (!PAY_TO) throw new Error("PHARMACY_2_PUBLIC_KEY required in .env");
-
-interface Interaction { drugs: [string, string]; severity: "mild" | "moderate" | "severe"; description: string; recommendation: string; }
-
-const INTERACTIONS: Interaction[] = [
-  { drugs: ["lisinopril", "potassium"], severity: "severe", description: "Lisinopril can increase potassium levels. Taking potassium supplements with ACE inhibitors may cause dangerously high potassium (hyperkalemia).", recommendation: "Monitor potassium levels regularly. Avoid potassium supplements unless directed by physician." },
-  { drugs: ["metformin", "alcohol"], severity: "severe", description: "Alcohol with metformin increases risk of lactic acidosis, a rare but life-threatening condition.", recommendation: "Limit alcohol consumption. Seek immediate medical attention if experiencing unusual muscle pain." },
-  { drugs: ["atorvastatin", "grapefruit"], severity: "moderate", description: "Grapefruit can increase atorvastatin blood levels, raising the risk of muscle damage (rhabdomyolysis).", recommendation: "Avoid grapefruit and grapefruit juice while taking atorvastatin." },
-  { drugs: ["lisinopril", "ibuprofen"], severity: "moderate", description: "NSAIDs like ibuprofen can reduce lisinopril's effectiveness and may increase kidney damage risk.", recommendation: "Use acetaminophen (Tylenol) instead of ibuprofen for pain relief." },
-  { drugs: ["amlodipine", "atorvastatin"], severity: "mild", description: "Amlodipine can slightly increase atorvastatin blood levels. Generally safe at standard doses.", recommendation: "No action needed at standard doses. Monitor for muscle pain if atorvastatin dose exceeds 20mg." },
-  { drugs: ["metformin", "atorvastatin"], severity: "mild", description: "Some studies suggest statins may slightly increase blood sugar levels. Very common in diabetic patients.", recommendation: "Monitor blood sugar levels as usual. Benefits of statin therapy generally outweigh this small risk." },
-  { drugs: ["omeprazole", "metformin"], severity: "mild", description: "Long-term omeprazole use may reduce vitamin B12 absorption, compounding metformin's known B12 effect.", recommendation: "Consider periodic B12 level monitoring, especially after 2+ years of concurrent use." },
-  { drugs: ["lisinopril", "amlodipine"], severity: "mild", description: "Common intentional combination for blood pressure management. Both lower BP through different mechanisms.", recommendation: "Monitor for excessive blood pressure lowering (dizziness, lightheadedness)." },
-];
-
-// Normalize drug names to lowercase at startup — defense-in-depth even though
-// checkInteractions() already lowercases input, the source data should be clean too.
-const NORMALIZED_INTERACTIONS = INTERACTIONS.map(ix => ({
-  ...ix,
-  drugs: [ix.drugs[0].toLowerCase(), ix.drugs[1].toLowerCase()] as [string, string],
-}));
-
-/**
- * Sort drug interaction pairs by severity (severe > moderate > mild)
- * and alphabetically by drug name for equal severities.
- * Severity order: severe (0) > moderate (1) > mild (2)
- */
-function sortPairsBySeverity(pairs: any[]): any[] {
-  const severityOrder: Record<string, number> = { severe: 0, moderate: 1, mild: 2 };
-  return pairs.sort((a, b) => {
-    const severityDiff = (severityOrder[a.severity] ?? 3) - (severityOrder[b.severity] ?? 3);
-    if (severityDiff !== 0) return severityDiff;
-    // Equal severity: sort alphabetically by drug names
-    const aKey = [a.drug1, a.drug2].sort().join('|');
-    const bKey = [b.drug1, b.drug2].sort().join('|');
-    return aKey.localeCompare(bKey);
-  });
-}
-
-function checkInteractions(medications: string[]) {
-  const meds = medications.map(m => m.toLowerCase().trim());
-  const found: any[] = [];
-
-  for (let i = 0; i < meds.length; i++) {
-    for (let j = i + 1; j < meds.length; j++) {
-      for (const ix of NORMALIZED_INTERACTIONS) {
-        const [a, b] = ix.drugs;
-        if ((meds[i] === a && meds[j] === b) || (meds[i] === b && meds[j] === a)) {
-          found.push({ drug1: medications[i], drug2: medications[j], severity: ix.severity, description: ix.description, recommendation: ix.recommendation });
-        }
-      }
-    }
-  }
-
-  const severe = found.filter(f => f.severity === "severe").length;
-  const moderate = found.filter(f => f.severity === "moderate").length;
-
-  return {
-    checkTimestamp: new Date().toISOString(),
-    protocol: { name: "x402", network: NETWORK, price: "$0.001", payTo: PAY_TO },
-    medications, interactionCount: found.length, severeCount: severe, moderateCount: moderate,
-    mildCount: found.length - severe - moderate,
-    interactions: sortPairsBySeverity(found),
-    overallRisk: severe > 0 ? "high" : moderate > 0 ? "moderate" : found.length > 0 ? "low" : "none",
-    summary: found.length === 0 ? "No known interactions found." : `Found ${found.length} interaction(s): ${severe} severe, ${moderate} moderate, ${found.length - severe - moderate} mild.`,
-  };
-}
 
 const app = express();
 applySecurityMiddleware(app);
@@ -112,11 +51,24 @@ applyX402Middleware(app, {
 });
 
 app.get("/drug/interactions", (req, res) => {
-  const medsParam = req.query.meds as string;
-  if (!medsParam) { res.status(400).json({ error: "Missing: meds (comma-separated)" }); return; }
-  const medications = medsParam.split(",").map(m => m.trim()).filter(Boolean);
-  if (medications.length < 2) { res.status(400).json({ error: "Need at least 2 medications" }); return; }
-  res.json(checkInteractions(medications));
+  const parsedQuery = DrugInteractionsQuerySchema.safeParse({
+    meds: req.query.meds,
+  });
+  if (!parsedQuery.success) {
+    res.status(400).json({
+      error: parsedQuery.error.issues[0]?.message ?? "Invalid meds query parameter",
+    });
+    return;
+  }
+
+  const result = checkInteractions(
+    (parsedQuery.data as DrugInteractionsQuery).medications,
+  );
+  res.json({
+    checkTimestamp: new Date().toISOString(),
+    protocol: { name: "x402", network: NETWORK, price: "$0.001", payTo: PAY_TO },
+    ...result,
+  });
 });
 
 app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/services/pharmacy-api/__tests__/server.test.ts
+++ b/services/pharmacy-api/__tests__/server.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("../../../shared/x402-middleware.ts", () => ({
+  applyX402Middleware: vi.fn(),
+  NETWORK: "stellar:testnet",
+  OZ_FACILITATOR_URL: "https://example.test/x402",
+}));
+
+process.env.PHARMACY_1_PUBLIC_KEY = "GBQTESTPHARMACY1";
+process.env.PHARMACY_ADMIN_TOKEN = "admin-secret";
+
+const { createPharmacyPricingStore } = await import("../db.ts");
+const { PharmacyCompareQuerySchema } = await import("../logic.ts");
+const { createPharmacyApp } = await import("../server.ts");
+
+describe("pharmacy API persistence", () => {
+  let tempDir: string;
+  let app: ReturnType<typeof createPharmacyApp>["app"];
+  let pricingStore: ReturnType<typeof createPharmacyApp>["pricingStore"];
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "careguard-pharmacy-"));
+    const store = createPharmacyPricingStore({
+      dbPath: path.join(tempDir, "pricing.sqlite"),
+    });
+    pricingStore = store;
+    app = createPharmacyApp({
+      payTo: "GBQTESTPHARMACY1",
+      adminToken: "admin-secret",
+      pricingStore: store,
+      enablePayments: false,
+    }).app;
+  });
+
+  afterEach(() => {
+    pricingStore.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("covers seed -> query -> update -> query with persisted prices", async () => {
+    const initialQuery = await request(app)
+      .get("/pharmacy/compare")
+      .query({ drug: "Lisinopril", zip: "90210" });
+
+    expect(initialQuery.status).toBe(200);
+    expect(initialQuery.body.cheapest.pharmacyId).toBe("costco-001");
+    expect(initialQuery.body.cheapest.price).toBe(3.5);
+
+    const updatePrice = await request(app)
+      .post("/pharmacy/prices")
+      .set("Authorization", "Bearer admin-secret")
+      .send({ drug: "lisinopril", pharmacyId: "cvs-001", price: 1.99 });
+
+    expect(updatePrice.status).toBe(200);
+    expect(updatePrice.body.price.price).toBe(1.99);
+
+    const updatedQuery = await request(app)
+      .get("/pharmacy/compare")
+      .query({ drug: "Lisinopril", zip: "90210" });
+
+    expect(updatedQuery.status).toBe(200);
+    expect(updatedQuery.body.cheapest.pharmacyId).toBe("cvs-001");
+    expect(updatedQuery.body.cheapest.price).toBe(1.99);
+  });
+
+  it("supports CRUD for drugs and pharmacies through admin endpoints", async () => {
+    const createDrug = await request(app)
+      .post("/pharmacy/drugs")
+      .set("Authorization", "Bearer admin-secret")
+      .send({ name: "losartan", displayName: "Losartan", defaultDosage: "50mg" });
+    expect(createDrug.status).toBe(201);
+
+    const createPharmacy = await request(app)
+      .post("/pharmacy/pharmacies")
+      .set("Authorization", "Bearer admin-secret")
+      .send({
+        id: "independent-001",
+        name: "Independent Pharmacy",
+        distanceMiles: 1.4,
+      });
+    expect(createPharmacy.status).toBe(201);
+
+    const setPrice = await request(app)
+      .post("/pharmacy/prices")
+      .set("Authorization", "Bearer admin-secret")
+      .send({ drug: "losartan", pharmacyId: "independent-001", price: 7.25 });
+    expect(setPrice.status).toBe(200);
+
+    const compare = await request(app)
+      .get("/pharmacy/compare")
+      .query({ drug: "losartan", dosage: "50mg", zip: "94105" });
+    expect(compare.status).toBe(200);
+    expect(compare.body.drug).toBe("Losartan");
+    expect(compare.body.cheapest.pharmacyId).toBe("independent-001");
+
+    const deleteDrug = await request(app)
+      .delete("/pharmacy/drugs/losartan")
+      .set("Authorization", "Bearer admin-secret");
+    expect(deleteDrug.status).toBe(204);
+
+    const deletePharmacy = await request(app)
+      .delete("/pharmacy/pharmacies/independent-001")
+      .set("Authorization", "Bearer admin-secret");
+    expect(deletePharmacy.status).toBe(204);
+  });
+
+  it("returns 400 for a 100KB drug query string", async () => {
+    const schemaResult = PharmacyCompareQuerySchema.safeParse({
+      drug: "x".repeat(100_000),
+      zip: "90210",
+    });
+
+    expect(schemaResult.success).toBe(false);
+
+    const response = await request(app)
+      .get("/pharmacy/compare")
+      .query({ drug: "x".repeat(81), zip: "90210" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain("80 characters");
+  });
+});

--- a/services/pharmacy-api/db.ts
+++ b/services/pharmacy-api/db.ts
@@ -1,0 +1,360 @@
+import { mkdirSync } from "fs";
+import { createRequire } from "module";
+import path from "path";
+import { logger } from "../../shared/logger.ts";
+import { PHARMACY_SEED_DATA, type PharmacySeedData } from "./seed.ts";
+
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite") as typeof import("node:sqlite");
+
+export interface PharmacyRecord {
+  id: string;
+  name: string;
+  distanceMiles: number;
+}
+
+export interface DrugRecord {
+  name: string;
+  displayName: string;
+  defaultDosage: string | null;
+}
+
+export interface PharmacyPriceRecord {
+  drug: string;
+  displayName: string;
+  pharmacyId: string;
+  pharmacy: string;
+  price: number;
+  distanceMiles: number;
+}
+
+export interface PharmacyPricingStoreOptions {
+  dbPath?: string;
+  seedData?: PharmacySeedData;
+}
+
+function normalizeDrugName(drugName: string) {
+  return drugName.trim().toLowerCase();
+}
+
+function normalizePharmacyId(pharmacyId: string) {
+  return pharmacyId.trim().toLowerCase();
+}
+
+function defaultDbPath() {
+  if (process.env.PHARMACY_DB_PATH) {
+    return path.resolve(process.cwd(), process.env.PHARMACY_DB_PATH);
+  }
+
+  if (process.env.NODE_ENV === "test") {
+    return ":memory:";
+  }
+
+  return new URL("../../data/pharmacy-pricing.sqlite", import.meta.url).pathname;
+}
+
+export class PharmacyPricingStore {
+  private readonly db: DatabaseSync;
+
+  constructor(options: PharmacyPricingStoreOptions = {}) {
+    const dbPath = options.dbPath ?? defaultDbPath();
+    if (dbPath !== ":memory:") {
+      mkdirSync(path.dirname(dbPath), { recursive: true });
+    }
+
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec("PRAGMA foreign_keys = ON");
+    this.migrate();
+    this.seedIfEmpty(options.seedData ?? PHARMACY_SEED_DATA);
+  }
+
+  private migrate() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS pharmacies (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        distance_miles REAL NOT NULL CHECK (distance_miles >= 0)
+      );
+
+      CREATE TABLE IF NOT EXISTS drugs (
+        name TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL,
+        default_dosage TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS prices (
+        drug_name TEXT NOT NULL REFERENCES drugs(name) ON DELETE CASCADE,
+        pharmacy_id TEXT NOT NULL REFERENCES pharmacies(id) ON DELETE CASCADE,
+        price REAL NOT NULL CHECK (price > 0),
+        PRIMARY KEY (drug_name, pharmacy_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_prices_drug_name ON prices(drug_name);
+      CREATE INDEX IF NOT EXISTS idx_prices_pharmacy_id ON prices(pharmacy_id);
+    `);
+  }
+
+  private seedIfEmpty(seedData: PharmacySeedData) {
+    const existing = this.db
+      .prepare("SELECT COUNT(*) AS count FROM drugs")
+      .get() as { count: number };
+
+    if (Number(existing.count) > 0) {
+      return;
+    }
+
+    this.db.exec("BEGIN");
+
+    try {
+      const insertPharmacy = this.db.prepare(`
+        INSERT INTO pharmacies (id, name, distance_miles)
+        VALUES (?, ?, ?)
+      `);
+      const insertDrug = this.db.prepare(`
+        INSERT INTO drugs (name, display_name, default_dosage)
+        VALUES (?, ?, ?)
+      `);
+      const insertPrice = this.db.prepare(`
+        INSERT INTO prices (drug_name, pharmacy_id, price)
+        VALUES (?, ?, ?)
+      `);
+
+      for (const pharmacy of seedData.pharmacies) {
+        insertPharmacy.run(
+          normalizePharmacyId(pharmacy.id),
+          pharmacy.name.trim(),
+          pharmacy.distanceMiles,
+        );
+      }
+
+      for (const drug of seedData.drugs) {
+        insertDrug.run(
+          normalizeDrugName(drug.name),
+          drug.displayName.trim(),
+          drug.defaultDosage?.trim() || null,
+        );
+      }
+
+      for (const price of seedData.prices) {
+        insertPrice.run(
+          normalizeDrugName(price.drug),
+          normalizePharmacyId(price.pharmacyId),
+          price.price,
+        );
+      }
+
+      this.db.exec("COMMIT");
+      logger.info(
+        {
+          drugCount: seedData.drugs.length,
+          pharmacyCount: seedData.pharmacies.length,
+        },
+        "Seeded pharmacy pricing database",
+      );
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  close() {
+    this.db.close();
+  }
+
+  getDrugCount() {
+    const result = this.db
+      .prepare("SELECT COUNT(*) AS count FROM drugs")
+      .get() as { count: number };
+
+    return Number(result.count);
+  }
+
+  listDrugs(): DrugRecord[] {
+    return this.db
+      .prepare(`
+        SELECT
+          name,
+          display_name AS displayName,
+          default_dosage AS defaultDosage
+        FROM drugs
+        ORDER BY display_name ASC
+      `)
+      .all() as unknown as DrugRecord[];
+  }
+
+  upsertDrug(input: {
+    name: string;
+    displayName?: string;
+    defaultDosage?: string | null;
+  }): DrugRecord {
+    const name = normalizeDrugName(input.name);
+    const displayName = input.displayName?.trim() || toDisplayName(name);
+    const defaultDosage = input.defaultDosage?.trim() || null;
+
+    this.db
+      .prepare(`
+        INSERT INTO drugs (name, display_name, default_dosage)
+        VALUES (?, ?, ?)
+        ON CONFLICT(name) DO UPDATE SET
+          display_name = excluded.display_name,
+          default_dosage = excluded.default_dosage
+      `)
+      .run(name, displayName, defaultDosage);
+
+    return {
+      name,
+      displayName,
+      defaultDosage,
+    };
+  }
+
+  deleteDrug(name: string) {
+    const result = this.db
+      .prepare("DELETE FROM drugs WHERE name = ?")
+      .run(normalizeDrugName(name));
+
+    return Number(result.changes) > 0;
+  }
+
+  listPharmacies(): PharmacyRecord[] {
+    return this.db
+      .prepare(`
+        SELECT
+          id,
+          name,
+          distance_miles AS distanceMiles
+        FROM pharmacies
+        ORDER BY name ASC
+      `)
+      .all() as unknown as PharmacyRecord[];
+  }
+
+  upsertPharmacy(input: PharmacyRecord): PharmacyRecord {
+    const id = normalizePharmacyId(input.id);
+    const name = input.name.trim();
+    const distanceMiles = input.distanceMiles;
+
+    this.db
+      .prepare(`
+        INSERT INTO pharmacies (id, name, distance_miles)
+        VALUES (?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          name = excluded.name,
+          distance_miles = excluded.distance_miles
+      `)
+      .run(id, name, distanceMiles);
+
+    return {
+      id,
+      name,
+      distanceMiles,
+    };
+  }
+
+  deletePharmacy(pharmacyId: string) {
+    const result = this.db
+      .prepare("DELETE FROM pharmacies WHERE id = ?")
+      .run(normalizePharmacyId(pharmacyId));
+
+    return Number(result.changes) > 0;
+  }
+
+  getPrices(drugName: string): PharmacyPriceRecord[] {
+    const normalizedDrugName = normalizeDrugName(drugName);
+    const rows = this.db
+      .prepare(`
+        SELECT
+          d.name AS drug,
+          d.display_name AS displayName,
+          p.id AS pharmacyId,
+          p.name AS pharmacy,
+          p.distance_miles AS distanceMiles,
+          pr.price AS price
+        FROM prices pr
+        INNER JOIN drugs d ON d.name = pr.drug_name
+        INNER JOIN pharmacies p ON p.id = pr.pharmacy_id
+        WHERE d.name = ?
+        ORDER BY pr.price ASC, p.name ASC
+      `)
+      .all(normalizedDrugName) as unknown as PharmacyPriceRecord[];
+
+    if (rows.length === 0) {
+      throw new Error(`Drug not found: ${drugName}`);
+    }
+
+    return rows.map((row) => ({
+      drug: row.drug,
+      displayName: row.displayName,
+      pharmacyId: row.pharmacyId,
+      pharmacy: row.pharmacy,
+      price: Number(row.price),
+      distanceMiles: Number(row.distanceMiles),
+    }));
+  }
+
+  upsertPrice(input: {
+    drug: string;
+    pharmacyId: string;
+    price: number;
+  }): PharmacyPriceRecord {
+    const drug = normalizeDrugName(input.drug);
+    const pharmacyId = normalizePharmacyId(input.pharmacyId);
+
+    const drugExists = this.db
+      .prepare("SELECT 1 AS found FROM drugs WHERE name = ?")
+      .get(drug) as { found?: number } | undefined;
+    if (!drugExists?.found) {
+      throw new Error(`Drug not found: ${input.drug}`);
+    }
+
+    const pharmacyExists = this.db
+      .prepare("SELECT 1 AS found FROM pharmacies WHERE id = ?")
+      .get(pharmacyId) as { found?: number } | undefined;
+    if (!pharmacyExists?.found) {
+      throw new Error(`Pharmacy not found: ${input.pharmacyId}`);
+    }
+
+    this.db
+      .prepare(`
+        INSERT INTO prices (drug_name, pharmacy_id, price)
+        VALUES (?, ?, ?)
+        ON CONFLICT(drug_name, pharmacy_id) DO UPDATE SET
+          price = excluded.price
+      `)
+      .run(drug, pharmacyId, input.price);
+
+    return this.db
+      .prepare(`
+        SELECT
+          d.name AS drug,
+          d.display_name AS displayName,
+          p.id AS pharmacyId,
+          p.name AS pharmacy,
+          p.distance_miles AS distanceMiles,
+          pr.price AS price
+        FROM prices pr
+        INNER JOIN drugs d ON d.name = pr.drug_name
+        INNER JOIN pharmacies p ON p.id = pr.pharmacy_id
+        WHERE pr.drug_name = ? AND pr.pharmacy_id = ?
+      `)
+      .get(drug, pharmacyId) as unknown as PharmacyPriceRecord;
+  }
+}
+
+export function createPharmacyPricingStore(
+  options?: PharmacyPricingStoreOptions,
+) {
+  return new PharmacyPricingStore(options);
+}
+
+export function toDisplayName(value: string) {
+  return value
+    .trim()
+    .split(/\s+/)
+    .map((word) =>
+      word.length === 0
+        ? word
+        : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join(" ");
+}

--- a/services/pharmacy-api/logic.ts
+++ b/services/pharmacy-api/logic.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import {
+  freeTextSchema,
+  optionalFreeTextSchema,
+  zipCodeSchema,
+} from "../../shared/free-text.ts";
+import {
+  type PharmacyPriceRecord,
+  toDisplayName,
+} from "./db.ts";
+
+export const PharmacyCompareQuerySchema = z
+  .object({
+    drug: freeTextSchema("drug"),
+    dosage: optionalFreeTextSchema("dosage"),
+    zip: zipCodeSchema.optional().default("90210"),
+  })
+  .strict();
+export type PharmacyCompareQuery = z.infer<typeof PharmacyCompareQuerySchema>;
+
+export const PharmacyRecordSchema = z
+  .object({
+    id: freeTextSchema("id"),
+    name: freeTextSchema("name"),
+    distanceMiles: z.coerce
+      .number()
+      .min(0, "distanceMiles must be at least 0")
+      .max(500, "distanceMiles must be at most 500"),
+  })
+  .strict();
+export type PharmacyRecordInput = z.infer<typeof PharmacyRecordSchema>;
+
+export const DrugRecordSchema = z
+  .object({
+    name: freeTextSchema("name"),
+    displayName: optionalFreeTextSchema("displayName"),
+    defaultDosage: optionalFreeTextSchema("defaultDosage"),
+  })
+  .strict();
+export type DrugRecordInput = z.infer<typeof DrugRecordSchema>;
+
+export const PharmacyPriceSchema = z
+  .object({
+    drug: freeTextSchema("drug"),
+    pharmacyId: freeTextSchema("pharmacyId"),
+    price: z.coerce
+      .number()
+      .positive("price must be greater than 0")
+      .max(10000, "price must be at most 10000"),
+  })
+  .strict();
+export type PharmacyPriceInput = z.infer<typeof PharmacyPriceSchema>;
+
+export function buildCompareResponse(options: {
+  drug: string;
+  dosage: string;
+  zip: string;
+  payTo: string;
+  network: string;
+  prices: PharmacyPriceRecord[];
+  protocolPrice?: string;
+}) {
+  const zipVariance = parseInt(options.zip.slice(-2), 10) % 10;
+  const adjustedPrices = options.prices.map((price, index) => ({
+    ...price,
+    adjustedDistanceMiles:
+      price.distanceMiles + zipVariance * 0.5 + index * 0.3,
+  }));
+
+  const sorted = [...adjustedPrices].sort((left, right) => left.price - right.price);
+  const cheapest = sorted[0];
+  const mostExpensive = sorted[sorted.length - 1];
+
+  return {
+    drug:
+      sorted[0]?.displayName ||
+      toDisplayName(options.drug.trim().toLowerCase()),
+    dosage: options.dosage,
+    zipCode: options.zip,
+    usedZipCode: true,
+    queryTimestamp: new Date().toISOString(),
+    protocol: {
+      name: "x402",
+      network: options.network,
+      price: options.protocolPrice ?? "$0.002",
+      payTo: options.payTo,
+    },
+    prices: sorted.map((price) => ({
+      pharmacyName: price.pharmacy,
+      pharmacyId: price.pharmacyId,
+      price: price.price,
+      distance: +price.adjustedDistanceMiles.toFixed(1),
+      inStock: true,
+    })),
+    cheapest: {
+      pharmacyName: cheapest.pharmacy,
+      pharmacyId: cheapest.pharmacyId,
+      price: cheapest.price,
+      distance: +cheapest.adjustedDistanceMiles.toFixed(1),
+    },
+    mostExpensive: {
+      pharmacyName: mostExpensive.pharmacy,
+      pharmacyId: mostExpensive.pharmacyId,
+      price: mostExpensive.price,
+      distance: +mostExpensive.adjustedDistanceMiles.toFixed(1),
+    },
+    potentialSavings: +(mostExpensive.price - cheapest.price).toFixed(2),
+    savingsPercent: +(
+      (1 - cheapest.price / mostExpensive.price) *
+      100
+    ).toFixed(1),
+  };
+}

--- a/services/pharmacy-api/seed.ts
+++ b/services/pharmacy-api/seed.ts
@@ -1,0 +1,61 @@
+export interface PharmacySeedData {
+  pharmacies: Array<{
+    id: string;
+    name: string;
+    distanceMiles: number;
+  }>;
+  drugs: Array<{
+    name: string;
+    displayName: string;
+    defaultDosage?: string;
+  }>;
+  prices: Array<{
+    drug: string;
+    pharmacyId: string;
+    price: number;
+  }>;
+}
+
+export const PHARMACY_SEED_DATA: PharmacySeedData = {
+  pharmacies: [
+    { id: "costco-001", name: "Costco Pharmacy", distanceMiles: 2.1 },
+    { id: "walmart-001", name: "Walmart Pharmacy", distanceMiles: 1.8 },
+    { id: "cvs-001", name: "CVS Pharmacy", distanceMiles: 0.5 },
+    { id: "walgreens-001", name: "Walgreens", distanceMiles: 0.8 },
+    { id: "riteaid-001", name: "Rite Aid", distanceMiles: 3.2 },
+  ],
+  drugs: [
+    { name: "lisinopril", displayName: "Lisinopril" },
+    { name: "metformin", displayName: "Metformin" },
+    { name: "atorvastatin", displayName: "Atorvastatin" },
+    { name: "amlodipine", displayName: "Amlodipine" },
+    { name: "omeprazole", displayName: "Omeprazole" },
+  ],
+  prices: [
+    { drug: "lisinopril", pharmacyId: "costco-001", price: 3.5 },
+    { drug: "lisinopril", pharmacyId: "walmart-001", price: 4.0 },
+    { drug: "lisinopril", pharmacyId: "cvs-001", price: 12.99 },
+    { drug: "lisinopril", pharmacyId: "walgreens-001", price: 15.49 },
+    { drug: "lisinopril", pharmacyId: "riteaid-001", price: 18.99 },
+    { drug: "metformin", pharmacyId: "costco-001", price: 4.0 },
+    { drug: "metformin", pharmacyId: "walmart-001", price: 4.0 },
+    { drug: "metformin", pharmacyId: "cvs-001", price: 11.99 },
+    { drug: "metformin", pharmacyId: "walgreens-001", price: 13.49 },
+    { drug: "metformin", pharmacyId: "riteaid-001", price: 16.79 },
+    { drug: "atorvastatin", pharmacyId: "costco-001", price: 6.5 },
+    { drug: "atorvastatin", pharmacyId: "walmart-001", price: 9.0 },
+    { drug: "atorvastatin", pharmacyId: "cvs-001", price: 24.99 },
+    { drug: "atorvastatin", pharmacyId: "walgreens-001", price: 28.49 },
+    { drug: "atorvastatin", pharmacyId: "riteaid-001", price: 31.99 },
+    { drug: "amlodipine", pharmacyId: "costco-001", price: 4.2 },
+    { drug: "amlodipine", pharmacyId: "walmart-001", price: 4.0 },
+    { drug: "amlodipine", pharmacyId: "cvs-001", price: 14.99 },
+    { drug: "amlodipine", pharmacyId: "walgreens-001", price: 17.49 },
+    { drug: "amlodipine", pharmacyId: "riteaid-001", price: 19.99 },
+    { drug: "omeprazole", pharmacyId: "costco-001", price: 5.8 },
+    { drug: "omeprazole", pharmacyId: "walmart-001", price: 8.5 },
+    { drug: "omeprazole", pharmacyId: "cvs-001", price: 22.99 },
+    { drug: "omeprazole", pharmacyId: "walgreens-001", price: 25.49 },
+    { drug: "omeprazole", pharmacyId: "riteaid-001", price: 27.99 },
+  ],
+};

--- a/services/pharmacy-api/server.ts
+++ b/services/pharmacy-api/server.ts
@@ -13,146 +13,346 @@ if (!process.stdout.isTTY) {
 }
 
 import "dotenv/config";
+import path from "path";
 import express from "express";
+import { pathToFileURL } from "url";
 import { applyX402Middleware, NETWORK, OZ_FACILITATOR_URL } from "../../shared/x402-middleware.ts";
-import { createPricingProvider } from "../../shared/pricing-sources.ts";
 import { createCorsMiddleware } from "../../shared/cors.ts";
 import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
+import type { PharmacyPricingStore } from "./db.ts";
+import { createPharmacyPricingStore } from "./db.ts";
 import { resolveRequestedDosage } from "./dosage.ts";
+import {
+  buildCompareResponse,
+  DrugRecordSchema,
+  PharmacyCompareQuerySchema,
+  PharmacyPriceSchema,
+  PharmacyRecordSchema,
+} from "./logic.ts";
+import type {
+  DrugRecordInput,
+  PharmacyCompareQuery,
+  PharmacyPriceInput,
+  PharmacyRecordInput,
+} from "./logic.ts";
 
 const PORT = parseInt(process.env.PHARMACY_API_PORT || "3001");
 const PAY_TO = process.env.PHARMACY_1_PUBLIC_KEY;
 
-if (!PAY_TO) throw new Error("PHARMACY_1_PUBLIC_KEY required in .env");
+export interface PharmacyAppOptions {
+  payTo: string;
+  pricingStore?: PharmacyPricingStore;
+  adminToken?: string;
+  enablePayments?: boolean;
+}
 
-// Initialize pricing provider (configurable via PHARMACY_PRICING_PROVIDER env var)
-const pricingProvider = createPricingProvider();
+function createAdminMiddleware(adminToken?: string) {
+  return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!adminToken) {
+      res.status(503).json({ error: "PHARMACY_ADMIN_TOKEN not configured" });
+      return;
+    }
 
-const app = express();
-applySecurityMiddleware(app);
-app.use(createCorsMiddleware());
-app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
-app.use(requestContextMiddleware());
-app.use(requestLoggerMiddleware());
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith("Bearer ")) {
+      res
+        .status(401)
+        .setHeader("WWW-Authenticate", "Bearer")
+        .json({ error: "Missing admin token" });
+      return;
+    }
 
-// Unprotected endpoints
-app.get("/", async (_req, res) => {
-  const drugCount = await pricingProvider.getDrugCount();
-  res.json({
-    service: "CareGuard Pharmacy Price Comparison API",
-    version: "1.0.0",
-    protocol: "x402 on Stellar",
-    network: NETWORK,
-    facilitator: OZ_FACILITATOR_URL,
-    payTo: PAY_TO,
-    price: "$0.002 per query",
-    pricingProvider: pricingProvider.name,
-    drugCount,
-  });
-});
+    if (auth.slice("Bearer ".length) !== adminToken) {
+      res.status(403).json({ error: "Invalid admin token" });
+      return;
+    }
 
-app.get("/pharmacy/drugs", async (_req, res) => {
-  const drugCount = await pricingProvider.getDrugCount();
-  res.json({ 
-    provider: pricingProvider.name,
-    count: drugCount,
-    message: "Use GET /pharmacy/compare?drug=<name>&zip=<code> to query prices"
-  });
-});
+    next();
+  };
+}
 
-// x402 payment middleware
-applyX402Middleware(app, {
-  "GET /pharmacy/compare": {
-    accepts: { scheme: "exact", network: NETWORK, payTo: PAY_TO, price: "$0.002" },
-    description: "Pharmacy price comparison query — $0.002 USDC",
-  },
-});
+function sendCrudNotFound(res: express.Response, message: string) {
+  res.status(404).json({ error: message });
+}
 
-// x402-protected endpoint
-app.get("/pharmacy/compare", async (req, res) => {
-  const drug = (req.query.drug as string || "").toLowerCase().trim();
-  const dosage = resolveRequestedDosage(drug, req.query.dosage as string | undefined);
-  const zip = req.query.zip as string || "90210";
+export function createPharmacyApp(options: PharmacyAppOptions) {
+  const pricingStore = options.pricingStore ?? createPharmacyPricingStore();
+  const adminToken = options.adminToken ?? process.env.PHARMACY_ADMIN_TOKEN;
+  const app = express();
+  let isDraining = false;
 
-  if (!drug) { res.status(400).json({ error: "Missing required parameter: drug" }); return; }
+  applySecurityMiddleware(app);
+  app.use(createCorsMiddleware());
+  app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
+  app.use(requestContextMiddleware());
+  app.use(requestLoggerMiddleware());
 
-  try {
-    const prices = await pricingProvider.getPrices(drug, zip);
-    
-    // Calculate distance based on zip code (mock implementation uses zip-based variance)
-    const zipVariance = parseInt(zip.slice(-2)) % 10; // Use last 2 digits for variance
-    const adjustedPrices = prices.map((p, idx) => {
-      const distance =
-        typeof p.distance === "number" ? p.distance : parseFloat(p.distance);
-      return {
-        ...p,
-        distance: distance + (zipVariance * 0.5) + (idx * 0.3), // Vary distance by zip
-      };
-    });
-    
-    const sorted = [...adjustedPrices].sort((a, b) => a.price - b.price);
-    const cheapest = sorted[0];
-    const mostExpensive = sorted[sorted.length - 1];
-
+  app.get("/", (_req, res) => {
     res.json({
-      drug: drug.charAt(0).toUpperCase() + drug.slice(1),
-      dosage,
-      zipCode: zip,
-      usedZipCode: true, // Indicates zip was actually used in calculations
-      queryTimestamp: new Date().toISOString(),
-      protocol: { name: "x402", network: NETWORK, price: "$0.002", payTo: PAY_TO },
-      provider: pricingProvider.name,
-      prices: sorted.map((p) => ({
-        pharmacyName: p.pharmacy, pharmacyId: p.id, price: p.price, distance: +p.distance.toFixed(1), inStock: true,
-      })),
-      cheapest: { pharmacyName: cheapest.pharmacy, pharmacyId: cheapest.id, price: cheapest.price, distance: +cheapest.distance.toFixed(1) },
-      mostExpensive: { pharmacyName: mostExpensive.pharmacy, pharmacyId: mostExpensive.id, price: mostExpensive.price },
-      potentialSavings: +(mostExpensive.price - cheapest.price).toFixed(2),
-      savingsPercent: +((1 - cheapest.price / mostExpensive.price) * 100).toFixed(1),
+      service: "CareGuard Pharmacy Price Comparison API",
+      version: "1.0.0",
+      protocol: "x402 on Stellar",
+      network: NETWORK,
+      facilitator: OZ_FACILITATOR_URL,
+      payTo: options.payTo,
+      price: "$0.002 per query",
+      pricingProvider: "sqlite",
+      drugCount: pricingStore.getDrugCount(),
     });
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
-    res.status(404).json({ 
-      error: errorMessage,
-      provider: pricingProvider.name,
-      drugCount: await pricingProvider.getDrugCount()
-    });
-  }
-});
-
-app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
-  if (err.type === "entity.too.large") {
-    return res.status(413).json({ error: "Request body too large", limit: err.limit });
-  }
-  next(err);
-});
-
-let isDraining = false;
-app.get("/ready", (_req, res) => {
-  if (isDraining) {
-    res.status(503).send("Service Unavailable");
-    return;
-  }
-  res.send("OK");
-});
-
-const server = app.listen(PORT, async () => {
-  const drugCount = await pricingProvider.getDrugCount();
-  logger.info({ port: PORT, network: NETWORK, facilitator: OZ_FACILITATOR_URL, payTo: PAY_TO, provider: pricingProvider.name, drugCount }, "Pharmacy Price API started");
-});
-
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM received. Draining server...");
-  isDraining = true;
-  server.close(() => {
-    logger.info("Server closed. Exiting process.");
-    process.exit(0);
   });
-  setTimeout(() => {
-    logger.error("Graceful shutdown timeout. Forcing exit.");
-    process.exit(1);
-  }, 30000);
-});
+
+  app.get("/pharmacy/drugs", (_req, res) => {
+    const drugs = pricingStore.listDrugs();
+    res.json({
+      provider: "sqlite",
+      count: drugs.length,
+      drugs,
+      message:
+        "Use GET /pharmacy/compare?drug=<name>&zip=<code> to query prices",
+    });
+  });
+
+  app.get("/pharmacy/pharmacies", (_req, res) => {
+    res.json({ pharmacies: pricingStore.listPharmacies() });
+  });
+
+  if (options.enablePayments !== false) {
+    applyX402Middleware(app, {
+      "GET /pharmacy/compare": {
+        accepts: {
+          scheme: "exact",
+          network: NETWORK,
+          payTo: options.payTo,
+          price: "$0.002",
+        },
+        description: "Pharmacy price comparison query — $0.002 USDC",
+      },
+    });
+  }
+
+  const requireAdmin = createAdminMiddleware(adminToken);
+
+  app.post("/pharmacy/drugs", requireAdmin, (req, res) => {
+    const parsedBody = DrugRecordSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      res.status(400).json({
+        error: parsedBody.error.issues[0]?.message ?? "Invalid drug payload",
+      });
+      return;
+    }
+
+    const drug = pricingStore.upsertDrug(parsedBody.data as DrugRecordInput);
+    res.status(201).json({ drug });
+  });
+
+  app.put("/pharmacy/drugs/:drugName", requireAdmin, (req, res) => {
+    const drugName = Array.isArray(req.params.drugName)
+      ? req.params.drugName[0]
+      : req.params.drugName;
+    const parsedBody = DrugRecordSchema.safeParse({
+      ...req.body,
+      name: drugName,
+    });
+    if (!parsedBody.success) {
+      res.status(400).json({
+        error: parsedBody.error.issues[0]?.message ?? "Invalid drug payload",
+      });
+      return;
+    }
+
+    const drug = pricingStore.upsertDrug(parsedBody.data as DrugRecordInput);
+    res.json({ drug });
+  });
+
+  app.delete("/pharmacy/drugs/:drugName", requireAdmin, (req, res) => {
+    const drugName = Array.isArray(req.params.drugName)
+      ? req.params.drugName[0]
+      : req.params.drugName;
+    if (!pricingStore.deleteDrug(drugName)) {
+      sendCrudNotFound(res, `Drug not found: ${drugName}`);
+      return;
+    }
+
+    res.status(204).send();
+  });
+
+  app.post("/pharmacy/pharmacies", requireAdmin, (req, res) => {
+    const parsedBody = PharmacyRecordSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      res.status(400).json({
+        error:
+          parsedBody.error.issues[0]?.message ?? "Invalid pharmacy payload",
+      });
+      return;
+    }
+
+    const pharmacy = pricingStore.upsertPharmacy(
+      parsedBody.data as PharmacyRecordInput,
+    );
+    res.status(201).json({ pharmacy });
+  });
+
+  app.put("/pharmacy/pharmacies/:pharmacyId", requireAdmin, (req, res) => {
+    const pharmacyId = Array.isArray(req.params.pharmacyId)
+      ? req.params.pharmacyId[0]
+      : req.params.pharmacyId;
+    const parsedBody = PharmacyRecordSchema.safeParse({
+      ...req.body,
+      id: pharmacyId,
+    });
+    if (!parsedBody.success) {
+      res.status(400).json({
+        error:
+          parsedBody.error.issues[0]?.message ?? "Invalid pharmacy payload",
+      });
+      return;
+    }
+
+    const pharmacy = pricingStore.upsertPharmacy(
+      parsedBody.data as PharmacyRecordInput,
+    );
+    res.json({ pharmacy });
+  });
+
+  app.delete("/pharmacy/pharmacies/:pharmacyId", requireAdmin, (req, res) => {
+    const pharmacyId = Array.isArray(req.params.pharmacyId)
+      ? req.params.pharmacyId[0]
+      : req.params.pharmacyId;
+    if (!pricingStore.deletePharmacy(pharmacyId)) {
+      sendCrudNotFound(res, `Pharmacy not found: ${pharmacyId}`);
+      return;
+    }
+
+    res.status(204).send();
+  });
+
+  app.post("/pharmacy/prices", requireAdmin, (req, res) => {
+    const parsedBody = PharmacyPriceSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      res.status(400).json({
+        error:
+          parsedBody.error.issues[0]?.message ?? "Invalid pharmacy price payload",
+      });
+      return;
+    }
+
+    try {
+      const price = pricingStore.upsertPrice(
+        parsedBody.data as PharmacyPriceInput,
+      );
+      res.json({ price });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to upsert price";
+      res.status(404).json({ error: message });
+    }
+  });
+
+  app.get("/pharmacy/compare", (req, res) => {
+    const parsedQuery = PharmacyCompareQuerySchema.safeParse({
+      drug: req.query.drug,
+      dosage: req.query.dosage,
+      zip: req.query.zip,
+    });
+    if (!parsedQuery.success) {
+      res.status(400).json({
+        error:
+          parsedQuery.error.issues[0]?.message ?? "Invalid pharmacy query parameters",
+      });
+      return;
+    }
+
+    const query = parsedQuery.data as PharmacyCompareQuery;
+    const drug = query.drug.trim().toLowerCase();
+    const dosage = resolveRequestedDosage(drug, query.dosage);
+
+    try {
+      const prices = pricingStore.getPrices(drug);
+      res.json(
+        buildCompareResponse({
+          drug,
+          dosage,
+          zip: query.zip,
+          payTo: options.payTo,
+          network: NETWORK,
+          prices,
+        }),
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      res.status(404).json({
+        error: errorMessage,
+        provider: "sqlite",
+        drugCount: pricingStore.getDrugCount(),
+      });
+    }
+  });
+
+  app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (err.type === "entity.too.large") {
+      return res.status(413).json({ error: "Request body too large", limit: err.limit });
+    }
+    next(err);
+  });
+
+  app.get("/ready", (_req, res) => {
+    if (isDraining) {
+      res.status(503).send("Service Unavailable");
+      return;
+    }
+    res.send("OK");
+  });
+
+  return {
+    app,
+    pricingStore,
+    setDraining(draining: boolean) {
+      isDraining = draining;
+    },
+  };
+}
+
+export const defaultPharmacyApp = PAY_TO
+  ? createPharmacyApp({ payTo: PAY_TO })
+  : undefined;
+
+const entrypointUrl = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+
+if (import.meta.url === entrypointUrl) {
+  if (!PAY_TO) {
+    throw new Error("PHARMACY_1_PUBLIC_KEY required in .env");
+  }
+
+  const startedApp = defaultPharmacyApp ?? createPharmacyApp({ payTo: PAY_TO });
+  const server = startedApp.app.listen(PORT, () => {
+    logger.info(
+      {
+        port: PORT,
+        network: NETWORK,
+        facilitator: OZ_FACILITATOR_URL,
+        payTo: PAY_TO,
+        provider: "sqlite",
+        drugCount: startedApp.pricingStore.getDrugCount(),
+      },
+      "Pharmacy Price API started",
+    );
+  });
+
+  process.on("SIGTERM", () => {
+    logger.info("SIGTERM received. Draining server...");
+    startedApp.setDraining(true);
+    server.close(() => {
+      logger.info("Server closed. Exiting process.");
+      process.exit(0);
+    });
+    setTimeout(() => {
+      logger.error("Graceful shutdown timeout. Forcing exit.");
+      process.exit(1);
+    }, 30000);
+  });
+}

--- a/services/pharmacy-payment/__tests__/order-validation.test.ts
+++ b/services/pharmacy-payment/__tests__/order-validation.test.ts
@@ -1,25 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { z } from "zod";
-
-const OrderAmountSchema = z.union([
-  z.number().min(0.01, "amount must be at least $0.01").max(10000, "amount must not exceed $10,000"),
-  z.string().transform((val, ctx) => {
-    const parsed = parseFloat(val);
-    if (!Number.isFinite(parsed)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be a valid number" });
-      return z.NEVER;
-    }
-    if (parsed < 0.01) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be at least $0.01" });
-      return z.NEVER;
-    }
-    if (parsed > 10000) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must not exceed $10,000" });
-      return z.NEVER;
-    }
-    return parsed;
-  }),
-]);
+import {
+  MedicationOrderSchema,
+  OrderAmountSchema,
+} from "../validation.ts";
 
 describe("OrderAmountSchema", () => {
   it("accepts valid number amounts", () => {
@@ -52,5 +35,15 @@ describe("OrderAmountSchema", () => {
 
   it("rejects Infinity", () => {
     expect(() => OrderAmountSchema.parse("Infinity")).toThrow();
+  });
+
+  it("rejects overlong drug names", () => {
+    expect(() =>
+      MedicationOrderSchema.parse({
+        drug: "x".repeat(81),
+        pharmacy: "Costco",
+        amount: 10,
+      }),
+    ).toThrow();
   });
 });

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -14,7 +14,6 @@ if (!process.stdout.isTTY) {
 
 import "dotenv/config";
 import express from "express";
-import { z } from "zod";
 import { Mppx, Store } from "mppx/server";
 import { stellar } from "@stellar/mpp/charge/server";
 import { USDC_SAC_TESTNET } from "@stellar/mpp";
@@ -24,6 +23,10 @@ import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
 import { sanitizeUserString } from "../../shared/sanitize.ts";
+import {
+  MedicationOrderSchema,
+  type MedicationOrderInput,
+} from "./validation.ts";
 
 const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005");
 const RECIPIENT = process.env.PHARMACY_1_PUBLIC_KEY;
@@ -116,44 +119,20 @@ const mppx = Mppx.create({
   ],
 });
 
-// Zod schema for amount validation
-const OrderAmountSchema = z.union([
-  z.number().min(0.01, "amount must be at least $0.01").max(10000, "amount must not exceed $10,000"),
-  z.string().transform((val, ctx) => {
-    const parsed = parseFloat(val);
-    if (!Number.isFinite(parsed)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be a valid number" });
-      return z.NEVER;
-    }
-    if (parsed < 0.01) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must be at least $0.01" });
-      return z.NEVER;
-    }
-    if (parsed > 10000) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "amount must not exceed $10,000" });
-      return z.NEVER;
-    }
-    return parsed;
-  }),
-]);
-
 // MPP-protected medication order endpoint
 app.post("/pharmacy/order", async (req, res) => {
-  const { drug, pharmacy, amount } = req.body;
-
-  if (!drug || !pharmacy || !amount) {
-    res.status(400).json({ error: "Missing required fields: drug, pharmacy, amount" });
+  const parsedOrder = MedicationOrderSchema.safeParse(req.body);
+  if (!parsedOrder.success) {
+    res.status(400).json({
+      error: "Invalid order request",
+      details: parsedOrder.error.issues.map((issue) => issue.message),
+    });
     return;
   }
 
-  const parsedAmount = OrderAmountSchema.safeParse(amount);
-  if (!parsedAmount.success) {
-    res.status(400).json({ error: "Invalid amount", details: parsedAmount.error.issues.map(i => i.message) });
-    return;
-  }
-
-  const safeDrug = sanitizeUserString(drug);
-  const safePharmacy = sanitizeUserString(pharmacy);
+  const order = parsedOrder.data as MedicationOrderInput;
+  const safeDrug = sanitizeUserString(order.drug);
+  const safePharmacy = sanitizeUserString(order.pharmacy);
 
   // Convert Express request to Web Request for mppx
   const headers = new Headers();
@@ -173,7 +152,7 @@ app.post("/pharmacy/order", async (req, res) => {
 
   // Run MPP charge flow
   const result = await mppx.charge({
-    amount: parsedAmount.data.toFixed(2),
+    amount: order.amount.toFixed(2),
     description: `Medication: ${safeDrug} from ${safePharmacy}`,
   })(webReq);
 
@@ -191,7 +170,7 @@ app.post("/pharmacy/order", async (req, res) => {
     id: `order-${Date.now()}`,
     drug: safeDrug,
     pharmacy: safePharmacy,
-    amount: parsedAmount.data,
+    amount: order.amount,
     status: "confirmed",
     timestamp: new Date().toISOString(),
     network: NETWORK,
@@ -204,7 +183,7 @@ app.post("/pharmacy/order", async (req, res) => {
     Response.json({
       success: true,
       order,
-      message: `Payment of $${parsedAmount.data} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
+      message: `Payment of $${order.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
     })
   );
 

--- a/services/pharmacy-payment/validation.ts
+++ b/services/pharmacy-payment/validation.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { freeTextSchema } from "../../shared/free-text.ts";
+
+export const OrderAmountSchema = z
+  .union([z.number(), z.string()])
+  .transform<number>((value, ctx) => {
+    const parsed =
+      typeof value === "number" ? value : parseFloat(value);
+    if (!Number.isFinite(parsed)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "amount must be a valid number",
+      });
+      return z.NEVER;
+    }
+    if (parsed < 0.01) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "amount must be at least $0.01",
+      });
+      return z.NEVER;
+    }
+    if (parsed > 10000) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "amount must not exceed $10,000",
+      });
+      return z.NEVER;
+    }
+    return parsed;
+  });
+
+export const MedicationOrderSchema = z
+  .object({
+    drug: freeTextSchema("drug"),
+    pharmacy: freeTextSchema("pharmacy"),
+    amount: OrderAmountSchema,
+  })
+  .strict();
+
+export type MedicationOrderInput = z.infer<typeof MedicationOrderSchema>;

--- a/shared/bill-audit.ts
+++ b/shared/bill-audit.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
+import { freeTextSchema } from "./free-text.ts";
 
 export const LineItemSchema = z
   .object({
-    description: z.string().min(1, "description is required"),
+    description: freeTextSchema("description"),
     cptCode: z
       .string()
       .regex(/^(?:\d{5}|J\d{4})$/, "cptCode must match /^(?:\\d{5}|J\\d{4})$/"),

--- a/shared/free-text.ts
+++ b/shared/free-text.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+export const MAX_FREE_TEXT_LENGTH = 80;
+export const MAX_TEXT_LIST_ITEMS = 20;
+export const MAX_FREE_TEXT_LIST_LENGTH =
+  MAX_TEXT_LIST_ITEMS * MAX_FREE_TEXT_LENGTH + (MAX_TEXT_LIST_ITEMS - 1);
+
+export function freeTextSchema(fieldName: string) {
+  return z
+    .string({ required_error: `${fieldName} is required` })
+    .trim()
+    .min(1, `${fieldName} is required`)
+    .max(
+      MAX_FREE_TEXT_LENGTH,
+      `${fieldName} must be at most ${MAX_FREE_TEXT_LENGTH} characters`,
+    );
+}
+
+export function optionalFreeTextSchema(fieldName: string) {
+  return freeTextSchema(fieldName).optional();
+}
+
+export const zipCodeSchema = z
+  .string({ required_error: "zip is required" })
+  .trim()
+  .regex(/^\d{5}$/, "zip must be a 5-digit ZIP code");
+
+export function delimitedFreeTextListSchema(
+  fieldName: string,
+  delimiter = ",",
+) {
+  return z
+    .string({ required_error: `${fieldName} is required` })
+    .trim()
+    .min(1, `${fieldName} is required`)
+    .max(
+      MAX_FREE_TEXT_LIST_LENGTH,
+      `${fieldName} must be at most ${MAX_FREE_TEXT_LIST_LENGTH} characters`,
+    )
+    .transform<string[]>((value, ctx) => {
+      const entries = value
+        .split(delimiter)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+
+      if (entries.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${fieldName} must contain at least one value`,
+        });
+        return z.NEVER;
+      }
+
+      if (entries.length > MAX_TEXT_LIST_ITEMS) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${fieldName} must contain at most ${MAX_TEXT_LIST_ITEMS} values`,
+        });
+        return z.NEVER;
+      }
+
+      for (const entry of entries) {
+        if (entry.length > MAX_FREE_TEXT_LENGTH) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `each ${fieldName} value must be at most ${MAX_FREE_TEXT_LENGTH} characters`,
+          });
+          return z.NEVER;
+        }
+      }
+
+      return entries;
+    });
+}


### PR DESCRIPTION
Closes #174
Closes #270
Closes #281
Closes #286

## Summary
- move pharmacy pricing to a seeded SQLite-backed store with admin CRUD endpoints and price upserts
- enforce 80-character free-text caps across pharmacy, bill-audit, drug-interaction, and pharmacy-payment inputs and document them in OpenAPI
- derive setup wallets deterministically from BIP-39 mnemonics via SLIP-0010 and document recovery via .dev-seed
- replace daily spending string matching with timezone-aware day-start/day-end comparisons

## Validation
- npm run gen-openapi
- targeted Vitest regression suite for the four issue areas passed:
  - services/pharmacy-api/__tests__/server.test.ts
  - scripts/__tests__/setup-wallets.test.ts
  - agent/__tests__/tools.test.ts
  - agent/__tests__/timezone.test.ts
  - services/pharmacy-payment/__tests__/order-validation.test.ts
  - services/bill-audit-api/__tests__/validation.test.ts
- note: the repo still has unrelated pre-existing failures in the global npm run build / npm test paths outside this change set