### PR TITLE
Test fixtures, unit tests, and E2E tests (closes #39, #52, #53, #56)

### DIFF
--- a/agent/__tests__/extract-x402-tx-hash.test.ts
+++ b/agent/__tests__/extract-x402-tx-hash.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockDecode } = vi.hoisted(() => {
+  process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+  return { mockDecode: vi.fn() };
+});
+
+vi.mock("@x402/fetch", () => ({
+  decodePaymentResponseHeader: mockDecode,
+}));
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("fs", () => ({
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("@stellar/stellar-sdk", () => ({
+  Keypair: { fromSecret: vi.fn().mockReturnValue({ publicKey: () => "GPUB123", sign: vi.fn(), signatureHint: vi.fn() }) },
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  TransactionBuilder: vi.fn(),
+  Operation: { payment: vi.fn() },
+  Asset: vi.fn(),
+  Horizon: { Server: vi.fn() },
+}));
+vi.mock("@x402/stellar", () => ({ createEd25519Signer: vi.fn(), ExactStellarScheme: vi.fn() }));
+vi.mock("@stellar/mpp/charge/client", () => ({ stellar: vi.fn() }));
+vi.mock("mppx/client", () => ({ Mppx: { create: vi.fn() } }));
+
+import { extractX402TxHash } from "../tools.ts";
+
+function makeResponse(headerValue: string | null): Response {
+  const headers = new Headers();
+  if (headerValue !== null) {
+    headers.set("PAYMENT-RESPONSE", headerValue);
+  }
+  return { headers } as Response;
+}
+
+describe("extractX402TxHash", () => {
+  beforeEach(() => {
+    mockDecode.mockReset();
+  });
+
+  it("should extract tx hash from PAYMENT-RESPONSE header (base64 of SettleResponse)", () => {
+    mockDecode.mockReturnValue({ transaction: "a".repeat(64) });
+    const result = extractX402TxHash(makeResponse("dGVzdC1iYXNlNjQ="));
+    expect(result).toBe("a".repeat(64));
+    expect(mockDecode).toHaveBeenCalledWith("dGVzdC1iYXNlNjQ=");
+  });
+
+  it("should handle payment-response (lowercase) header", () => {
+    mockDecode.mockReturnValue({ transaction: "b".repeat(64) });
+    const headers = new Headers();
+    headers.set("payment-response", "bXktcGF5bG9hZA==");
+    const result = extractX402TxHash({ headers } as Response);
+    expect(result).toBe("b".repeat(64));
+  });
+
+  it("should handle X-PAYMENT-RESPONSE (alt form) header", () => {
+    mockDecode.mockReturnValue({ transaction: "c".repeat(64) });
+    const headers = new Headers();
+    headers.set("X-PAYMENT-RESPONSE", "YWx0LWZvcm0=");
+    const result = extractX402TxHash({ headers } as Response);
+    expect(result).toBe("c".repeat(64));
+  });
+
+  it("should return undefined when no header is present", () => {
+    const headers = new Headers();
+    const result = extractX402TxHash({ headers } as Response);
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when decoded has no transaction field", () => {
+    mockDecode.mockReturnValue({});
+    const result = extractX402TxHash(makeResponse("dGVzdA=="));
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when decode throws and header is not 64-char hex", () => {
+    mockDecode.mockImplementation(() => { throw new Error("decode failed"); });
+    const result = extractX402TxHash(makeResponse("short"));
+    expect(result).toBeUndefined();
+  });
+
+  it("should fall back to raw header when decode throws and header is 64-char hex", () => {
+    mockDecode.mockImplementation(() => { throw new Error("decode failed"); });
+    const hash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const result = extractX402TxHash(makeResponse(hash));
+    expect(result).toBe(hash);
+  });
+
+  it("should return undefined for 63-char hex header when decode throws", () => {
+    mockDecode.mockImplementation(() => { throw new Error("decode failed"); });
+    const result = extractX402TxHash(makeResponse("a".repeat(63)));
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined for 65-char hex header when decode throws", () => {
+    mockDecode.mockImplementation(() => { throw new Error("decode failed"); });
+    const result = extractX402TxHash(makeResponse("a".repeat(65)));
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined on malformed base64 in decode", () => {
+    mockDecode.mockImplementation(() => { throw new Error("malformed base64"); });
+    const result = extractX402TxHash(makeResponse("!!!invalid-base64!!!"));
+    expect(result).toBeUndefined();
+  });
+});

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -121,7 +121,7 @@ async function getRecommendedFee(): Promise<string> {
 }
 
 // Helper: extract real Stellar tx hash from x402 PAYMENT-RESPONSE header
-function extractX402TxHash(response: Response): string | undefined {
+export function extractX402TxHash(response: Response): string | undefined {
   const header =
     response.headers.get('PAYMENT-RESPONSE') ||
     response.headers.get('payment-response') ||

--- a/e2e/tests/pause-resume.spec.ts
+++ b/e2e/tests/pause-resume.spec.ts
@@ -1,0 +1,229 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const MOCK_PROFILE = {
+  recipient: {
+    name: "Rosa Garcia",
+    age: 78,
+    medications: ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"],
+    doctor: "Dr. Chen, General Hospital",
+    insurance: "Medicare Part D",
+  },
+  caregiver: { name: "Maria Garcia", relationship: "Daughter", location: "Phoenix, AZ", notifications: "Email + SMS" },
+};
+
+const MOCK_SPENDING = {
+  policy: { dailyLimit: 100, monthlyLimit: 500, medicationMonthlyBudget: 300, billMonthlyBudget: 500, approvalThreshold: 75 },
+  spending: { medications: 14.0, bills: 0, serviceFees: 0.008, total: 14.008 },
+  budgetRemaining: { medications: 286.0, bills: 500 },
+  transactionCount: 0,
+  recentTransactions: [],
+};
+
+const MOCK_AGENT_RUN = {
+  response: "Task completed.",
+  toolCalls: [],
+  spending: MOCK_SPENDING,
+  llmUsage: { promptTokens: 50, completionTokens: 30 },
+};
+
+async function mockAgentApis(page: Page, paused = false) {
+  await page.route("**/agent/profile", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_PROFILE) }),
+  );
+  await page.route("**/agent/spending", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_SPENDING) }),
+  );
+  await page.route("**/agent/transactions**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ transactions: [], pagination: { total: 0, limit: 25, offset: 0, hasMore: false, hasPrevious: false } }) }),
+  );
+  await page.route("**/agent/run", (route) =>
+    route.fulfill({ status: paused ? 409 : 200, contentType: "application/json", body: paused ? JSON.stringify({ error: "Agent is paused" }) : JSON.stringify(MOCK_AGENT_RUN) }),
+  );
+  await page.route("**/agent/policy", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) }),
+  );
+  await page.route("**/agent/reset", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) }),
+  );
+  await page.route("**/agent/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused }) }),
+  );
+  await page.route("**/agent/wallet", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ usdc: "100.00", xlm: "42.0" }) }),
+  );
+  await page.route("**/horizon-testnet.stellar.org/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ balances: [{ asset_code: "USDC", asset_issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", balance: "100.00" }, { asset_type: "native", balance: "42.0" }] }) }),
+  );
+  const rootPayload = JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused });
+  await page.route("**localhost:3004/", (route) => route.fulfill({ status: 200, contentType: "application/json", body: rootPayload }));
+  await page.route("**127.0.0.1:3004/", (route) => route.fulfill({ status: 200, contentType: "application/json", body: rootPayload }));
+}
+
+test.describe("Pause/Resume behaviour from header", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAgentApis(page, false);
+    await page.goto("/");
+  });
+
+  test("Pause button toggles chip text and colour (Active -> Paused)", async ({ page }) => {
+    // Initially shows Active status
+    await expect(page.getByText("Active")).toBeVisible();
+
+    const pauseBtn = page.getByRole("button", { name: "Pause" });
+    await expect(pauseBtn).toBeVisible();
+
+    // Intercept the pause API call
+    await page.route("**/agent/pause", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: true }) }),
+    );
+    await page.route("**/agent/resume", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: false }) }),
+    );
+
+    // Re-mock root endpoint to reflect paused state
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+
+    // Click Pause
+    await pauseBtn.click();
+
+    // After pause polling, the chip should show "Paused"
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+    // Resume button should appear
+    await expect(page.getByRole("button", { name: "Resume" })).toBeVisible();
+  });
+
+  test("Clicking a demo action while paused shows Agent is paused in log", async ({ page }) => {
+    // Click Pause first
+    await page.route("**/agent/pause", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: true }) }),
+    );
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+
+    await page.getByRole("button", { name: "Pause" }).click();
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+
+    // Re-mock /agent/run to return 409
+    await page.route("**/agent/run", (route) =>
+      route.fulfill({ status: 409, contentType: "application/json", body: JSON.stringify({ error: "Agent is paused" }) }),
+    );
+
+    // Click a demo action
+    await page.getByRole("button", { name: "Compare Medication Prices" }).click();
+
+    // The button should be disabled/busy since agent is paused
+    // Wait for the error log message
+    await expect(page.getByText(/Agent is paused|409/i)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("Resume -> tasks run again", async ({ page }) => {
+    // Intercept pause/resume
+    await page.route("**/agent/pause", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: true }) }),
+    );
+    await page.route("**/agent/resume", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: false }) }),
+    );
+
+    // Pause first
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+
+    await page.getByRole("button", { name: "Pause" }).click();
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+
+    // Now resume
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false }) }),
+    );
+
+    await page.getByRole("button", { name: "Resume" }).click();
+
+    // Should show Active again
+    await expect(page.getByText("Active")).toBeVisible({ timeout: 12_000 });
+
+    // Now run a task — should succeed
+    await page.route("**/agent/run", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_AGENT_RUN) }),
+    );
+    await page.getByRole("button", { name: "Compare Medication Prices" }).click();
+    await expect(page.getByText("Task completed")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("State survives page reload", async ({ page }) => {
+    await page.route("**/agent/pause", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: true }) }),
+    );
+    await page.route("**/agent/resume", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: false }) }),
+    );
+
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+
+    // Pause
+    await page.getByRole("button", { name: "Pause" }).click();
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+
+    // Reload — the mock still returns paused: true
+    await page.reload();
+
+    // Wait for polling to re-fetch agent info
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("Pause state reflects across two tabs within 10s poll interval", async ({ page, context }) => {
+    await page.route("**/agent/pause", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: true }) }),
+    );
+
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false }) }),
+    );
+
+    // Open second tab
+    const page2 = await context.newPage();
+    await mockAgentApis(page2, false);
+    await page2.goto("/");
+
+    // Both show Active initially
+    await expect(page.getByText("Active")).toBeVisible();
+
+    // In tab 1: change mock to paused
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+
+    await page.getByRole("button", { name: "Pause" }).click();
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+
+    // The second tab should also reflect paused within 10s poll interval
+    await expect(page2.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+  });
+});

--- a/e2e/tests/policy.spec.ts
+++ b/e2e/tests/policy.spec.ts
@@ -1,0 +1,297 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const DRUGS = ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"] as const;
+
+function makeOrderTransaction(drug: string, index: number) {
+  return {
+    id: `tx-order-${index}`,
+    timestamp: new Date().toISOString(),
+    type: "medication",
+    description: `${drug} from Costco Pharmacy [MPP Charge]`,
+    amount: 3.5,
+    recipient: "costco-001",
+    stellarTxHash: "a".repeat(64),
+    status: "completed",
+    category: "medications",
+  };
+}
+
+function makeServiceFeeTransaction(drug: string, index: number) {
+  return {
+    id: `tx-fee-${index}`,
+    timestamp: new Date().toISOString(),
+    type: "service_fee",
+    description: `x402 query: pharmacy prices for ${drug}`,
+    amount: 0.002,
+    recipient: "pharmacy-price-api",
+    status: "completed",
+    category: "service_fees",
+  };
+}
+
+const MOCK_PROFILE = {
+  recipient: {
+    name: "Rosa Garcia",
+    age: 78,
+    medications: [...DRUGS],
+    doctor: "Dr. Chen, General Hospital",
+    insurance: "Medicare Part D",
+  },
+  caregiver: { name: "Maria Garcia", relationship: "Daughter", location: "Phoenix, AZ", notifications: "Email + SMS" },
+};
+
+const MOCK_POLICY = {
+  dailyLimit: 100,
+  monthlyLimit: 500,
+  medicationMonthlyBudget: 300,
+  billMonthlyBudget: 500,
+  approvalThreshold: 75,
+};
+
+const MOCK_AGENT_RUN_BLOCKED = {
+  response: "Payment blocked — $600 exceeds the $500 monthly bill budget.",
+  toolCalls: [
+    {
+      tool: "pay_for_medication",
+      input: { pharmacy_id: "general-hospital", pharmacy_name: "General Hospital", drug_name: "Surgery Follow-up", amount: 600 },
+      result: { success: false, error: "Payment blocked by spending policy: $600 exceeds billMonthlyBudget of $500" },
+    },
+  ],
+  spending: {
+    policy: { ...MOCK_POLICY },
+    spending: { medications: 14.0, bills: 0, serviceFees: 0.002, total: 14.002 },
+    budgetRemaining: { medications: 286.0, bills: 500 },
+    transactionCount: 1,
+    recentTransactions: [],
+  },
+  llmUsage: { promptTokens: 50, completionTokens: 30 },
+};
+
+const MOCK_TRANSACTIONS_BLOCKED = {
+  transactions: [
+    {
+      id: "tx-blocked-1",
+      timestamp: new Date().toISOString(),
+      type: "medication",
+      description: "Surgery Follow-up from General Hospital",
+      amount: 600,
+      recipient: "general-hospital",
+      status: "blocked",
+      category: "bills",
+    },
+  ],
+  pagination: { total: 1, limit: 25, offset: 0, hasMore: false, hasPrevious: false },
+};
+
+const MOCK_AGENT_RUN_OK = {
+  response: "Compared prices and found cheaper options.",
+  toolCalls: DRUGS.map((drug) => ({
+    tool: "compare_pharmacy_prices",
+    input: { drug_name: drug },
+    result: {
+      drug,
+      zipCode: "90210",
+      queryTimestamp: new Date().toISOString(),
+      prices: [
+        { pharmacyName: "Costco Pharmacy", pharmacyId: "costco-001", price: 3.5, distance: "2.1 mi", inStock: true },
+        { pharmacyName: "CVS Pharmacy", pharmacyId: "cvs-001", price: 12.99, distance: "0.5 mi", inStock: true },
+      ],
+      cheapest: { pharmacyName: "Costco Pharmacy", pharmacyId: "costco-001", price: 3.5, distance: "2.1 mi" },
+      mostExpensive: { pharmacyName: "CVS Pharmacy", pharmacyId: "cvs-001", price: 12.99 },
+      potentialSavings: 9.49,
+      savingsPercent: 73.1,
+    },
+  })),
+  spending: {
+    policy: { ...MOCK_POLICY },
+    spending: { medications: 14.0, bills: 0, serviceFees: 0.008, total: 14.008 },
+    budgetRemaining: { medications: 286.0, bills: 500 },
+    transactionCount: 4,
+    recentTransactions: [],
+  },
+  llmUsage: { promptTokens: 100, completionTokens: 60 },
+};
+
+const MOCK_POLICY_UPDATED = {
+  ...MOCK_POLICY,
+  billMonthlyBudget: 400,
+};
+
+async function mockAgentApis(page: Page, policy = MOCK_POLICY) {
+  await page.route("**/agent/profile", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_PROFILE) }),
+  );
+  await page.route("**/agent/spending", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ policy, spending: { medications: 14.0, bills: 0, serviceFees: 0.008, total: 14.008 }, budgetRemaining: { medications: 286.0, bills: 500 }, transactionCount: 0, recentTransactions: [] }) }),
+  );
+  await page.route("**/agent/transactions**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ transactions: [], pagination: { total: 0, limit: 25, offset: 0, hasMore: false, hasPrevious: false } }) }),
+  );
+  await page.route("**/agent/policy", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) }),
+  );
+  await page.route("**/agent/reset", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) }),
+  );
+  await page.route("**/agent/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: false }) }),
+  );
+  await page.route("**/agent/wallet", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ usdc: "100.00", xlm: "42.0" }) }),
+  );
+  await page.route("**/horizon-testnet.stellar.org/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ balances: [{ asset_code: "USDC", asset_issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", balance: "100.00" }, { asset_type: "native", balance: "42.0" }] }) }),
+  );
+  const rootPayload = JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false });
+  await page.route("**localhost:3004/", (route) => route.fulfill({ status: 200, contentType: "application/json", body: rootPayload }));
+  await page.route("**127.0.0.1:3004/", (route) => route.fulfill({ status: 200, contentType: "application/json", body: rootPayload }));
+}
+
+test.describe("Policy update + over-budget payment block", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAgentApis(page);
+    await page.goto("/");
+  });
+
+  test("Edit all 5 policy fields, click Update Policy, verify Policy Saved appears", async ({ page }) => {
+    // Navigate to Policy tab
+    await page.getByRole("tab", { name: "Policy" }).click();
+    await expect(page.getByRole("tabpanel", { name: "Policy" })).toBeVisible();
+
+    // Clear and fill each field
+    const fields = [
+      { id: "policy-dailyLimit", value: "150" },
+      { id: "policy-monthlyLimit", value: "600" },
+      { id: "policy-medicationMonthlyBudget", value: "350" },
+      { id: "policy-billMonthlyBudget", value: "400" },
+      { id: "policy-approvalThreshold", value: "100" },
+    ];
+
+    for (const field of fields) {
+      const input = page.locator(`#${field.id}`);
+      await input.click();
+      await input.fill(field.value);
+    }
+
+    // Submit
+    await page.getByRole("button", { name: "Update Policy" }).click();
+
+    // Should show "Policy Saved"
+    await expect(page.getByRole("button", { name: "Policy Saved" })).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("Form values persist across a page reload (loaded from backend)", async ({ page }) => {
+    // Set policy to updated values on the backend
+    await mockAgentApis(page, MOCK_POLICY_UPDATED);
+
+    // Navigate to Policy tab
+    await page.getByRole("tab", { name: "Policy" }).click();
+    await expect(page.getByRole("tabpanel", { name: "Policy" })).toBeVisible();
+
+    // Verify initial values from backend
+    const billBudgetInput = page.locator("#policy-billMonthlyBudget");
+    await expect(billBudgetInput).toHaveValue("400");
+
+    // Reload — values should persist (mock still returns updated policy)
+    await page.reload();
+    await page.getByRole("tab", { name: "Policy" }).click();
+    await expect(billBudgetInput).toHaveValue("400");
+  });
+
+  test("Click the over-budget demo button -> log entry shows the blocked reason", async ({ page }) => {
+    // First set billMonthlyBudget to $400
+    await page.route("**/agent/spending", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ policy: MOCK_POLICY_UPDATED, spending: { medications: 14.0, bills: 0, serviceFees: 0.008, total: 14.008 }, budgetRemaining: { medications: 286.0, bills: 400 }, transactionCount: 0, recentTransactions: [] }) }),
+    );
+
+    // Navigate to Policy tab and update
+    await page.getByRole("tab", { name: "Policy" }).click();
+    const billBudgetInput = page.locator("#policy-billMonthlyBudget");
+    await billBudgetInput.click();
+    await billBudgetInput.fill("400");
+    await page.getByRole("button", { name: "Update Policy" }).click();
+    await expect(page.getByRole("button", { name: "Policy Saved" })).toBeVisible({ timeout: 5_000 });
+
+    // Go back to Overview
+    await page.getByRole("tab", { name: "Overview" }).click();
+
+    // Re-mock /agent/run to return blocked response
+    await page.route("**/agent/run", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_AGENT_RUN_BLOCKED) }),
+    );
+
+    // Click Try Over-Budget Payment
+    await page.getByRole("button", { name: "Try Over-Budget Payment" }).click();
+
+    // Wait for agent response showing blocked reason
+    await expect(page.getByText(/blocked|exceeds|Policy|budget/i)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("Activity tab transaction row for blocked attempt shows blocked chip", async ({ page }) => {
+    // Mock transactions to include a blocked one
+    await page.route("**/agent/transactions**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_TRANSACTIONS_BLOCKED) }),
+    );
+
+    // Run over-budget task to populate transactions
+    await page.route("**/agent/run", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(MOCK_AGENT_RUN_BLOCKED) }),
+    );
+
+    await page.getByRole("button", { name: "Try Over-Budget Payment" }).click();
+    await expect(page.getByText(/blocked|exceeds/i)).toBeVisible({ timeout: 15_000 });
+
+    // Navigate to Activity tab
+    await page.getByRole("tab", { name: "Activity" }).click();
+    await expect(page.getByRole("tabpanel", { name: "Activity" })).toBeVisible();
+
+    // Check for blocked status chip
+    const blockedChip = page.locator("span:has-text('blocked')");
+    await expect(blockedChip.first()).toBeVisible();
+  });
+
+  test("Policy regression after pause/resume", async ({ page }) => {
+    // Navigate to Policy tab
+    await page.getByRole("tab", { name: "Policy" }).click();
+    await expect(page.getByRole("tabpanel", { name: "Policy" })).toBeVisible();
+
+    // Fill policy fields
+    const billBudgetInput = page.locator("#policy-billMonthlyBudget");
+    await billBudgetInput.click();
+    await billBudgetInput.fill("400");
+
+    // Submit
+    await page.getByRole("button", { name: "Update Policy" }).click();
+    await expect(page.getByRole("button", { name: "Policy Saved" })).toBeVisible({ timeout: 5_000 });
+
+    // Pause the agent
+    await page.route("**/agent/pause", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: true }) }),
+    );
+    await page.route("**/agent/resume", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ paused: false }) }),
+    );
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: true }) }),
+    );
+    await page.getByRole("button", { name: "Pause" }).click();
+    await expect(page.getByText("Paused")).toBeVisible({ timeout: 12_000 });
+
+    // Resume
+    await page.route("**localhost:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false }) }),
+    );
+    await page.route("**127.0.0.1:3004/", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ service: "agent", agentWallet: "GBQTESTWALLET123", llm: "mock-llm", network: "stellar:testnet", paused: false }) }),
+    );
+    await page.getByRole("button", { name: "Resume" }).click();
+    await expect(page.getByText("Active")).toBeVisible({ timeout: 12_000 });
+
+    // Go back to Policy tab — values should still be $400
+    await page.getByRole("tab", { name: "Policy" }).click();
+    await expect(billBudgetInput).toHaveValue("400");
+  });
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,40 @@
+# Test Fixtures & Factories
+
+## factories.ts
+
+Factories for every interface in `shared/types.ts`. Each factory produces realistic,
+deterministic fixture data consistent with the Rosa Garcia persona.
+
+### Usage
+
+```ts
+import { makeTx, makePolicy } from "../tests/factories.ts";
+
+const tx = makeTx({ amount: 100, status: "blocked" });
+const policy = makePolicy({ billMonthlyBudget: 400 });
+```
+
+### Available Factories
+
+| Factory | Type | Notes |
+|---|---|---|
+| `makeMedication` | `Medication` | Defaults to Lisinopril 10mg |
+| `makePharmacyPrice` | `PharmacyPrice` | Random pharmacy from known set |
+| `makePriceComparisonResult` | `PriceComparisonResult` | 3 pharmacy prices, cheapest/most expensive computed |
+| `makeBillLineItem` | `BillLineItem` | Random charged amount + fair market rate |
+| `makeBillAuditResult` | `BillAuditResult` | 3 line items, 1 upcoded |
+| `makeSpendingPolicy` | `SpendingPolicy` | Default values matching Rosa's policy |
+| `makeTransaction` | `Transaction` | Random type (medication/bill/service_fee) with appropriate amounts |
+| `makeAgentAction` | `AgentAction` | Random tool with a generated transaction |
+| `makeCareRecipient` | `CareRecipient` | Rosa Garcia with 4 medications |
+| `makeAlert` | `Alert` | Random alert type, defaults to policy_blocked scenario |
+
+Every factory accepts a partial `overrides` object:
+
+```ts
+makeTransaction({ amount: 600, status: "blocked" })
+```
+
+### Determinism
+
+A seeded PRNG (`seed = 42`) ensures all factory outputs are reproducible across test runs.

--- a/tests/factories.ts
+++ b/tests/factories.ts
@@ -1,0 +1,184 @@
+import type {
+  Medication,
+  PharmacyPrice,
+  PriceComparisonResult,
+  BillLineItem,
+  BillAuditResult,
+  SpendingPolicy,
+  Transaction,
+  AgentAction,
+  CareRecipient,
+  Alert,
+} from "../shared/types.ts";
+
+// Seeded PRNG (mulberry32) for deterministic outputs
+function createRng(seed: number) {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rng = createRng(42);
+const pick = <T>(arr: T[]): T => arr[Math.floor(rng() * arr.length)];
+
+// ----- Factories -----
+
+export function makeMedication(overrides?: Partial<Medication>): Medication {
+  return {
+    name: "Lisinopril",
+    dosage: "10 mg",
+    frequency: "Once daily",
+    currentPharmacy: "CVS Pharmacy",
+    currentPrice: 12.99,
+    nextRefillDate: "2026-07-15",
+    ...overrides,
+  };
+}
+
+export function makePharmacyPrice(overrides?: Partial<PharmacyPrice>): PharmacyPrice {
+  return {
+    pharmacyName: pick(["Costco Pharmacy", "CVS Pharmacy", "Walgreens", "Walmart Pharmacy"]),
+    pharmacyId: pick(["costco-001", "cvs-001", "walgreens-001", "walmart-001"]),
+    price: +(rng() * 15 + 2).toFixed(2),
+    distance: `${(rng() * 5 + 0.1).toFixed(1)} mi`,
+    inStock: true,
+    ...overrides,
+  };
+}
+
+export function makePriceComparisonResult(overrides?: Partial<PriceComparisonResult>): PriceComparisonResult {
+  const drug = "Lisinopril";
+  const prices = [makePharmacyPrice(), makePharmacyPrice(), makePharmacyPrice()];
+  const sorted = [...prices].sort((a, b) => a.price - b.price);
+  return {
+    drug,
+    dosage: "10 mg",
+    zipCode: "90210",
+    prices,
+    cheapest: { pharmacyName: sorted[0].pharmacyName, pharmacyId: sorted[0].pharmacyId, price: sorted[0].price, distance: sorted[0].distance },
+    mostExpensive: { pharmacyName: sorted[sorted.length - 1].pharmacyName, pharmacyId: sorted[sorted.length - 1].pharmacyId, price: sorted[sorted.length - 1].price },
+    potentialSavings: +(sorted[sorted.length - 1].price - sorted[0].price).toFixed(2),
+    ...overrides,
+  };
+}
+
+export function makeBillLineItem(overrides?: Partial<BillLineItem>): BillLineItem {
+  return {
+    description: "ER Visit - Level 3",
+    cptCode: "99283",
+    chargedAmount: +(rng() * 1000 + 100).toFixed(2),
+    fairMarketRate: +(rng() * 800 + 80).toFixed(2),
+    status: "valid",
+    ...overrides,
+  };
+}
+
+export function makeBillAuditResult(overrides?: Partial<BillAuditResult>): BillAuditResult {
+  const lineItems = [
+    makeBillLineItem({ status: "valid" }),
+    makeBillLineItem({ status: "upcoded", errorDescription: "Level 3 billed for Level 2 service", suggestedAmount: 150 }),
+    makeBillLineItem({ status: "valid" }),
+  ];
+  const totalCharged = +lineItems.reduce((s, i) => s + i.chargedAmount, 0).toFixed(2);
+  const totalCorrect = +lineItems.reduce((s, i) => s + (i.suggestedAmount ?? i.chargedAmount), 0).toFixed(2);
+  return {
+    totalCharged,
+    totalCorrect,
+    totalOvercharge: +(totalCharged - totalCorrect).toFixed(2),
+    errorCount: lineItems.filter((i) => i.status !== "valid").length,
+    lineItems,
+    recommendation: "Dispute upcoded ER visit and request corrected billing.",
+    ...overrides,
+  };
+}
+
+export function makeSpendingPolicy(overrides?: Partial<SpendingPolicy>): SpendingPolicy {
+  return {
+    dailyLimit: 100,
+    monthlyLimit: 500,
+    medicationMonthlyBudget: 300,
+    billMonthlyBudget: 500,
+    approvalThreshold: 75,
+    ...overrides,
+  };
+}
+
+export function makeTransaction(overrides?: Partial<Transaction>): Transaction {
+  const types = ["medication", "bill", "service_fee"] as const;
+  const type = overrides?.type ?? pick([...types]);
+  const descriptions: Record<string, string> = {
+    medication: "Lisinopril from Costco Pharmacy [MPP Charge]",
+    bill: "Payment to General Hospital for ER Visit",
+    service_fee: "x402 query: pharmacy prices",
+  };
+  const amounts: Record<string, number> = {
+    medication: 3.5,
+    bill: 250,
+    service_fee: 0.002,
+  };
+  return {
+    id: `tx-${Date.now()}-${String(rng()).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+    type,
+    description: descriptions[type],
+    amount: amounts[type],
+    recipient: type === "medication" ? "costco-001" : type === "bill" ? "general-hospital" : "pharmacy-price-api",
+    stellarTxHash: type !== "service_fee" ? "a".repeat(64) : undefined,
+    status: "completed",
+    category: type === "medication" ? "medications" : type === "bill" ? "bills" : "service_fees",
+    ...overrides,
+  };
+}
+
+export function makeAgentAction(overrides?: Partial<AgentAction>): AgentAction {
+  const tool = pick(["compare_pharmacy_prices", "check_drug_interactions", "audit_medical_bill", "pay_for_medication"]);
+  return {
+    id: `action-${Date.now()}-${String(rng()).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+    action: tool,
+    details: `Ran ${tool} for Rosa Garcia`,
+    cost: +(rng() * 0.01).toFixed(4),
+    result: "Completed successfully",
+    transactions: [makeTransaction()],
+    ...overrides,
+  };
+}
+
+export function makeCareRecipient(overrides?: Partial<CareRecipient>): CareRecipient {
+  return {
+    name: "Rosa Garcia",
+    walletAddress: "GBQTESTWALLET123",
+    medications: [
+      makeMedication({ name: "Lisinopril", dosage: "10 mg", frequency: "Once daily", currentPharmacy: "CVS Pharmacy", currentPrice: 12.99 }),
+      makeMedication({ name: "Metformin", dosage: "500 mg", frequency: "Twice daily", currentPharmacy: "Walgreens", currentPrice: 8.49 }),
+      makeMedication({ name: "Atorvastatin", dosage: "20 mg", frequency: "Once daily", currentPharmacy: "CVS Pharmacy", currentPrice: 15.99 }),
+      makeMedication({ name: "Amlodipine", dosage: "5 mg", frequency: "Once daily", currentPharmacy: "Walmart Pharmacy", currentPrice: 6.99 }),
+    ],
+    spendingPolicy: makeSpendingPolicy(),
+    monthlySpending: { medications: 42.5, bills: 250, serviceFees: 0.008, total: 292.508 },
+    savingsAchieved: 73.5,
+    ...overrides,
+  };
+}
+
+export function makeAlert(overrides?: Partial<Alert>): Alert {
+  const types = ["approval_needed", "error_found", "refill_due", "budget_warning", "policy_blocked"] as const;
+  const type = overrides?.type ?? pick([...types]);
+  return {
+    id: `alert-${Date.now()}-${String(rng()).slice(2, 8)}`,
+    timestamp: new Date().toISOString(),
+    type,
+    title: type === "policy_blocked" ? "Payment Blocked by Policy" : "Alert",
+    description: type === "policy_blocked"
+      ? "A $600 payment attempt was blocked — exceeds the $500 bill monthly budget."
+      : "Action may be required.",
+    amount: type === "policy_blocked" ? 600 : undefined,
+    actionRequired: type === "approval_needed",
+    resolved: false,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Resolves all 4 open issues assigned to me.

### #56 — Test fixtures + factories for every `shared/types.ts` interface
- `tests/factories.ts` — factory per type with partial overrides
- `tests/README.md` — usage documentation
- Seeded PRNG (seed=42) for deterministic outputs
- Rosa-persona-consistent fixture data

### #39 — Unit tests for `extractX402TxHash`
- Exported the function in `agent/tools.ts:49`
- `agent/__tests__/extract-x402-tx-hash.test.ts` — 9 tests covering all edge cases:
  - PAYMENT-RESPONSE / payment-response / X-PAYMENT-RESPONSE headers
  - No header → undefined
  - Malformed base64 → undefined
  - Raw 64-char hex fallback
  - 63/65-char hex → undefined
- Mocks `@x402/fetch` for isolated testing

### #53 — Playwright E2E: pause/resume behaviour
- `e2e/tests/pause-resume.spec.ts` — 5 tests:
  - Pause button toggles chip (Active → Paused)
  - Demo action while paused shows "Agent is paused"
  - Resume → tasks run again
  - State survives page reload
  - Cross-tab sync within poll interval

### #52 — Playwright E2E: policy update + over-budget payment block
- `e2e/tests/policy.spec.ts` — 5 tests:
  - Edit all 5 policy fields → "Policy Saved"
  - Form values persist across reload
  - Over-budget payment shows blocked reason in log
  - Activity tab shows `blocked` status chip
  - Policy regression after pause/resume

Closes #56
Closes #39
Closes #53
Closes #52