### PR TITLE
Add zod schemas for shared runtime types

### DIFF
--- a/shared/__tests__/types.test.ts
+++ b/shared/__tests__/types.test.ts
@@ -1,8 +1,28 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
 import {
+  AgentActionSchema,
+  AlertSchema,
+  BillAuditResultSchema,
+  BillLineItemSchema,
+  CareRecipientSchema,
+  MedicationSchema,
+  PharmacyPriceSchema,
+  PriceComparisonResultSchema,
+  SpendingPolicySchema,
   TRANSACTION_CATEGORY,
+  TransactionSchema,
   isTransactionCategory,
   normalizeTransactionCategory,
+  type AgentAction,
+  type Alert,
+  type BillAuditResult,
+  type BillLineItem,
+  type CareRecipient,
+  type Medication,
+  type PharmacyPrice,
+  type PriceComparisonResult,
+  type SpendingPolicy,
   type Transaction,
   type TransactionCategory,
 } from '../types.ts';
@@ -28,5 +48,223 @@ describe('Transaction category typing', () => {
     expect(normalizeTransactionCategory('surprise_bucket')).toBe(
       TRANSACTION_CATEGORY.SERVICE_FEES,
     );
+  });
+});
+
+const medicationFixture = {
+  name: 'Metformin',
+  dosage: '500mg',
+  frequency: 'twice daily',
+  currentPharmacy: 'CarePlus',
+  currentPrice: 8.25,
+  nextRefillDate: '2026-07-01',
+};
+
+const pharmacyPriceFixture = {
+  pharmacyName: 'CarePlus',
+  pharmacyId: 'careplus-1',
+  price: 8.25,
+  distance: '1.2 mi',
+  inStock: true,
+};
+
+const billLineItemFixture = {
+  description: 'Office visit',
+  cptCode: '99213',
+  chargedAmount: 130,
+  fairMarketRate: 95,
+  status: 'valid',
+  suggestedAmount: 95,
+};
+
+const billAuditResultFixture = {
+  totalCharged: 130,
+  totalCorrect: 95,
+  totalOvercharge: 35,
+  errorCount: 1,
+  lineItems: [billLineItemFixture],
+  recommendation: 'Request an itemized correction.',
+};
+
+const spendingPolicyFixture = {
+  dailyLimit: 100,
+  monthlyLimit: 800,
+  medicationMonthlyBudget: 300,
+  billMonthlyBudget: 500,
+  approvalThreshold: 75,
+  holdTimeSeconds: 0,
+  timezone: 'America/Phoenix',
+  toolFees: {
+    comparePharmacyPrices: 0.002,
+    auditBill: 0.01,
+  },
+  notifications: {
+    email: true,
+    sms: false,
+    emailAddress: 'caregiver@example.com',
+  },
+};
+
+const transactionFixture = {
+  id: 'tx-1',
+  timestamp: '2026-06-26T12:00:00.000Z',
+  type: 'bill',
+  description: 'Hospital visit',
+  amount: 50,
+  recipient: 'provider-1',
+  stellarTxHash: 'a'.repeat(64),
+  status: 'completed',
+  category: TRANSACTION_CATEGORY.BILLS,
+};
+
+const priceComparisonFixture = {
+  drug: 'Metformin',
+  dosage: '500mg',
+  zipCode: '90210',
+  prices: [pharmacyPriceFixture],
+  cheapest: pharmacyPriceFixture,
+  mostExpensive: pharmacyPriceFixture,
+  potentialSavings: 4.5,
+};
+
+const agentActionFixture = {
+  id: 'action-1',
+  timestamp: '2026-06-26T12:00:00.000Z',
+  action: 'pay_bill',
+  details: 'Paid hospital bill',
+  cost: 0.01,
+  result: 'completed',
+  transactions: [transactionFixture],
+};
+
+const careRecipientFixture = {
+  name: 'Rosa',
+  walletAddress: 'GBWEDYWFGPNPAWCYOKWMCRPTR4IMV4SNZ7CVOZHPUXGHVXXPJSCFKVXQ',
+  medications: [medicationFixture],
+  spendingPolicy: spendingPolicyFixture,
+  monthlySpending: {
+    medications: 10,
+    bills: 20,
+    serviceFees: 0.02,
+    total: 30.02,
+  },
+  savingsAchieved: 12.5,
+};
+
+const alertFixture = {
+  id: 'alert-1',
+  timestamp: '2026-06-26T12:00:00.000Z',
+  type: 'approval_needed',
+  title: 'Approval needed',
+  description: 'A payment needs caregiver approval.',
+  amount: 85,
+  actionRequired: true,
+  resolved: false,
+};
+
+const schemaCases: Array<{
+  name: string;
+  schema: z.ZodTypeAny;
+  valid: unknown;
+  invalid: unknown;
+}> = [
+  {
+    name: 'MedicationSchema',
+    schema: MedicationSchema,
+    valid: medicationFixture,
+    invalid: { ...medicationFixture, dosage: 500 },
+  },
+  {
+    name: 'PharmacyPriceSchema',
+    schema: PharmacyPriceSchema,
+    valid: pharmacyPriceFixture,
+    invalid: { ...pharmacyPriceFixture, inStock: 'yes' },
+  },
+  {
+    name: 'PriceComparisonResultSchema',
+    schema: PriceComparisonResultSchema,
+    valid: priceComparisonFixture,
+    invalid: { ...priceComparisonFixture, prices: [] as unknown[], cheapest: undefined },
+  },
+  {
+    name: 'BillLineItemSchema',
+    schema: BillLineItemSchema,
+    valid: billLineItemFixture,
+    invalid: { ...billLineItemFixture, status: 'review' },
+  },
+  {
+    name: 'BillAuditResultSchema',
+    schema: BillAuditResultSchema,
+    valid: billAuditResultFixture,
+    invalid: { ...billAuditResultFixture, lineItems: [{ ...billLineItemFixture, chargedAmount: '130' }] },
+  },
+  {
+    name: 'SpendingPolicySchema',
+    schema: SpendingPolicySchema,
+    valid: spendingPolicyFixture,
+    invalid: { ...spendingPolicyFixture, notifications: { email: 'yes', sms: false } },
+  },
+  {
+    name: 'TransactionSchema',
+    schema: TransactionSchema,
+    valid: transactionFixture,
+    invalid: { ...transactionFixture, stellarTxHash: 'not-a-hash' },
+  },
+  {
+    name: 'AgentActionSchema',
+    schema: AgentActionSchema,
+    valid: agentActionFixture,
+    invalid: { ...agentActionFixture, transactions: [{ ...transactionFixture, category: 'legacy' }] },
+  },
+  {
+    name: 'CareRecipientSchema',
+    schema: CareRecipientSchema,
+    valid: careRecipientFixture,
+    invalid: { ...careRecipientFixture, monthlySpending: { ...careRecipientFixture.monthlySpending, total: '30.02' } },
+  },
+  {
+    name: 'AlertSchema',
+    schema: AlertSchema,
+    valid: alertFixture,
+    invalid: { ...alertFixture, type: 'informational' },
+  },
+];
+
+describe('Runtime schemas', () => {
+  it.each(schemaCases)('$name accepts a canonical valid fixture', ({ schema, valid }) => {
+    expect(schema.safeParse(valid).success).toBe(true);
+  });
+
+  it.each(schemaCases)('$name rejects a malformed fixture', ({ schema, invalid }) => {
+    expect(schema.safeParse(invalid).success).toBe(false);
+  });
+
+  it('derives exported TypeScript types from their matching schemas', () => {
+    expectTypeOf<Medication>().toEqualTypeOf<z.infer<typeof MedicationSchema>>();
+    expectTypeOf<PharmacyPrice>().toEqualTypeOf<
+      z.infer<typeof PharmacyPriceSchema>
+    >();
+    expectTypeOf<PriceComparisonResult>().toEqualTypeOf<
+      z.infer<typeof PriceComparisonResultSchema>
+    >();
+    expectTypeOf<BillLineItem>().toEqualTypeOf<
+      z.infer<typeof BillLineItemSchema>
+    >();
+    expectTypeOf<BillAuditResult>().toEqualTypeOf<
+      z.infer<typeof BillAuditResultSchema>
+    >();
+    expectTypeOf<SpendingPolicy>().toEqualTypeOf<
+      z.infer<typeof SpendingPolicySchema>
+    >();
+    expectTypeOf<Transaction>().toEqualTypeOf<
+      z.infer<typeof TransactionSchema>
+    >();
+    expectTypeOf<AgentAction>().toEqualTypeOf<
+      z.infer<typeof AgentActionSchema>
+    >();
+    expectTypeOf<CareRecipient>().toEqualTypeOf<
+      z.infer<typeof CareRecipientSchema>
+    >();
+    expectTypeOf<Alert>().toEqualTypeOf<z.infer<typeof AlertSchema>>();
   });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,7 @@
 // CareGuard Shared Types
 
+import { z } from 'zod';
+
 /**
  * Drug Interaction Severity Convention
  * 
@@ -13,75 +15,106 @@
  * For interactions with equal severity, sort alphabetically by drug names.
  */
 
-export interface Medication {
-  name: string;
-  dosage: string;
-  frequency: string;
-  currentPharmacy?: string;
-  currentPrice?: number;
-  nextRefillDate?: string;
-}
+export const MedicationSchema = z
+  .object({
+    name: z.string(),
+    dosage: z.string(),
+    frequency: z.string(),
+    currentPharmacy: z.string().optional(),
+    currentPrice: z.number().optional(),
+    nextRefillDate: z.string().optional(),
+  })
+  .strict();
+export type Medication = z.infer<typeof MedicationSchema>;
 
-export interface PharmacyPrice {
-  pharmacyName: string;
-  pharmacyId: string;
-  price: number;
-  distance?: string;
-  inStock: boolean | 'unknown';
-}
+export const PharmacyPriceSchema = z
+  .object({
+    pharmacyName: z.string(),
+    pharmacyId: z.string(),
+    price: z.number(),
+    distance: z.string().optional(),
+    inStock: z.union([z.boolean(), z.literal('unknown')]),
+  })
+  .strict();
+export type PharmacyPrice = z.infer<typeof PharmacyPriceSchema>;
 
-export interface PriceComparisonResult {
-  drug: string;
-  dosage: string;
-  zipCode: string;
-  prices: PharmacyPrice[];
-  cheapest: PharmacyPrice;
-  mostExpensive: PharmacyPrice;
-  potentialSavings: number;
-}
+export const PriceComparisonResultSchema = z
+  .object({
+    drug: z.string(),
+    dosage: z.string(),
+    zipCode: z.string(),
+    prices: z.array(PharmacyPriceSchema),
+    cheapest: PharmacyPriceSchema,
+    mostExpensive: PharmacyPriceSchema,
+    potentialSavings: z.number(),
+  })
+  .strict();
+export type PriceComparisonResult = z.infer<
+  typeof PriceComparisonResultSchema
+>;
 
-export interface BillLineItem {
-  description: string;
-  cptCode?: string;
-  chargedAmount: number;
-  fairMarketRate?: number;
-  status: 'valid' | 'duplicate' | 'upcoded' | 'unbundled' | 'error';
-  errorDescription?: string;
-  suggestedAmount?: number;
-}
+export const BillLineItemStatusSchema = z.enum([
+  'valid',
+  'duplicate',
+  'upcoded',
+  'unbundled',
+  'error',
+]);
 
-export interface BillAuditResult {
-  totalCharged: number;
-  totalCorrect: number;
-  totalOvercharge: number;
-  errorCount: number;
-  lineItems: BillLineItem[];
-  recommendation: string;
-}
+export const BillLineItemSchema = z
+  .object({
+    description: z.string(),
+    cptCode: z.string().optional(),
+    chargedAmount: z.number(),
+    fairMarketRate: z.number().optional(),
+    status: BillLineItemStatusSchema,
+    errorDescription: z.string().optional(),
+    suggestedAmount: z.number().optional(),
+  })
+  .strict();
+export type BillLineItem = z.infer<typeof BillLineItemSchema>;
 
-export interface SpendingPolicy {
-  dailyLimit: number;
-  monthlyLimit: number;
-  medicationMonthlyBudget: number;
-  billMonthlyBudget: number;
-  approvalThreshold: number; // require caregiver approval above this amount
-  holdTimeSeconds: number; // time before pending approvals auto-approve
-  /**
-   * IANA timezone string for the caregiver's local day (Issue #207).
-   * Example: "America/Phoenix", "America/New_York", "Europe/London".
-   * When set, daily-limit checks use this timezone to determine "today"
-   * rather than UTC or the global SPENDING_TIMEZONE env var.
-   * Defaults to the SPENDING_TIMEZONE env var if omitted.
-   */
-  timezone?: string;
-  toolFees?: Record<string, number>; // per-tool query fees (e.g., comparePharmacyPrices: 0.002)
-  notifications?: {
-    email: boolean;
-    sms: boolean;
-    emailAddress?: string;
-    phoneNumber?: string;
-  };
-}
+export const BillAuditResultSchema = z
+  .object({
+    totalCharged: z.number(),
+    totalCorrect: z.number(),
+    totalOvercharge: z.number(),
+    errorCount: z.number(),
+    lineItems: z.array(BillLineItemSchema),
+    recommendation: z.string(),
+  })
+  .strict();
+export type BillAuditResult = z.infer<typeof BillAuditResultSchema>;
+
+export const SpendingPolicySchema = z
+  .object({
+    dailyLimit: z.number(),
+    monthlyLimit: z.number(),
+    medicationMonthlyBudget: z.number(),
+    billMonthlyBudget: z.number(),
+    approvalThreshold: z.number(), // require caregiver approval above this amount
+    holdTimeSeconds: z.number(), // time before pending approvals auto-approve
+    /**
+     * IANA timezone string for the caregiver's local day (Issue #207).
+     * Example: "America/Phoenix", "America/New_York", "Europe/London".
+     * When set, daily-limit checks use this timezone to determine "today"
+     * rather than UTC or the global SPENDING_TIMEZONE env var.
+     * Defaults to the SPENDING_TIMEZONE env var if omitted.
+     */
+    timezone: z.string().optional(),
+    toolFees: z.record(z.number()).optional(), // per-tool query fees (e.g., comparePharmacyPrices: 0.002)
+    notifications: z
+      .object({
+        email: z.boolean(),
+        sms: z.boolean(),
+        emailAddress: z.string().optional(),
+        phoneNumber: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+export type SpendingPolicy = z.infer<typeof SpendingPolicySchema>;
 
 // A confirmed Stellar transaction hash is always 64 lowercase/uppercase hex chars.
 export const STELLAR_TX_HASH_RE = /^[0-9a-f]{64}$/i;
@@ -98,7 +131,13 @@ export const TRANSACTION_CATEGORIES = [
   TRANSACTION_CATEGORY.SERVICE_FEES,
 ] as const;
 
-export type TransactionCategory = (typeof TRANSACTION_CATEGORIES)[number];
+export const TransactionCategorySchema = z.enum([
+  TRANSACTION_CATEGORY.MEDICATIONS,
+  TRANSACTION_CATEGORY.BILLS,
+  TRANSACTION_CATEGORY.SERVICE_FEES,
+]);
+
+export type TransactionCategory = z.infer<typeof TransactionCategorySchema>;
 
 export function isTransactionCategory(
   category: unknown,
@@ -117,66 +156,92 @@ export function normalizeTransactionCategory(
     : TRANSACTION_CATEGORY.SERVICE_FEES;
 }
 
-export interface Transaction {
-  id: string;
-  timestamp: string;
-  type: 'medication' | 'bill' | 'service_fee';
-  description: string;
-  amount: number;
-  recipient: string;
-  // Always a real 64-char hex Stellar tx hash, or undefined. Never a raw/base64
-  // payment receipt — the backend normalizes that before recording the transaction (#14).
-  stellarTxHash?: string;
-  mppOrderId?: string;
-  status:
-    | 'pending'
-    | 'approved'
-    | 'completed'
-    | 'blocked'
-    | 'disputed'
-    | 'cancelled'
-    | 'rejected';
-  category: TransactionCategory;
-  pendingUntil?: string;
-  submittedAt?: string;
-}
+export const TransactionTypeSchema = z.enum([
+  'medication',
+  'bill',
+  'service_fee',
+]);
 
-export interface AgentAction {
-  id: string;
-  timestamp: string;
-  action: string;
-  details: string;
-  cost: number; // agent service fee paid via x402
-  result: string;
-  transactions: Transaction[];
-}
+export const TransactionStatusSchema = z.enum([
+  'pending',
+  'approved',
+  'completed',
+  'blocked',
+  'disputed',
+  'cancelled',
+  'rejected',
+]);
 
-export interface CareRecipient {
-  name: string;
-  walletAddress: string;
-  medications: Medication[];
-  spendingPolicy: SpendingPolicy;
-  monthlySpending: {
-    medications: number;
-    bills: number;
-    serviceFees: number;
-    total: number;
-  };
-  savingsAchieved: number;
-}
+export const TransactionSchema = z
+  .object({
+    id: z.string(),
+    timestamp: z.string(),
+    type: TransactionTypeSchema,
+    description: z.string(),
+    amount: z.number(),
+    recipient: z.string(),
+    // Always a real 64-char hex Stellar tx hash, or undefined. Never a raw/base64
+    // payment receipt — the backend normalizes that before recording the transaction (#14).
+    stellarTxHash: z.string().regex(STELLAR_TX_HASH_RE).optional(),
+    mppOrderId: z.string().optional(),
+    status: TransactionStatusSchema,
+    category: TransactionCategorySchema,
+    pendingUntil: z.string().optional(),
+    submittedAt: z.string().optional(),
+  })
+  .strict();
+export type Transaction = z.infer<typeof TransactionSchema>;
 
-export interface Alert {
-  id: string;
-  timestamp: string;
-  type:
-    | 'approval_needed'
-    | 'error_found'
-    | 'refill_due'
-    | 'budget_warning'
-    | 'policy_blocked';
-  title: string;
-  description: string;
-  amount?: number;
-  actionRequired: boolean;
-  resolved: boolean;
-}
+export const AgentActionSchema = z
+  .object({
+    id: z.string(),
+    timestamp: z.string(),
+    action: z.string(),
+    details: z.string(),
+    cost: z.number(), // agent service fee paid via x402
+    result: z.string(),
+    transactions: z.array(TransactionSchema),
+  })
+  .strict();
+export type AgentAction = z.infer<typeof AgentActionSchema>;
+
+export const CareRecipientSchema = z
+  .object({
+    name: z.string(),
+    walletAddress: z.string(),
+    medications: z.array(MedicationSchema),
+    spendingPolicy: SpendingPolicySchema,
+    monthlySpending: z
+      .object({
+        medications: z.number(),
+        bills: z.number(),
+        serviceFees: z.number(),
+        total: z.number(),
+      })
+      .strict(),
+    savingsAchieved: z.number(),
+  })
+  .strict();
+export type CareRecipient = z.infer<typeof CareRecipientSchema>;
+
+export const AlertTypeSchema = z.enum([
+  'approval_needed',
+  'error_found',
+  'refill_due',
+  'budget_warning',
+  'policy_blocked',
+]);
+
+export const AlertSchema = z
+  .object({
+    id: z.string(),
+    timestamp: z.string(),
+    type: AlertTypeSchema,
+    title: z.string(),
+    description: z.string(),
+    amount: z.number().optional(),
+    actionRequired: z.boolean(),
+    resolved: z.boolean(),
+  })
+  .strict();
+export type Alert = z.infer<typeof AlertSchema>;


### PR DESCRIPTION
## Summary
- Add zod schemas for the shared runtime data shapes in `shared/types.ts`.
- Re-derive the exported TypeScript types from their corresponding schemas so validation and static types share one source of truth.
- Extend `shared/__tests__/types.test.ts` with valid and invalid fixtures for each shared schema.

## Validation
- `npm ci --legacy-peer-deps`
- `npm test -- shared/__tests__/types.test.ts`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types vitest/globals --allowImportingTsExtensions shared/types.ts shared/__tests__/types.test.ts`
- `git diff --check`

## Notes
- Closes #33.
- `npm run typecheck` still fails in existing unrelated areas, including dashboard missing Next/Playwright/Sentry type dependencies, `shared/rate-limit.ts`, and other pre-existing project-wide type errors. The new shared schema files pass the focused typecheck above.