### PR TITLE
Add pharmacy payment server tests

### DIFF
--- a/services/pharmacy-payment/__tests__/server.test.ts
+++ b/services/pharmacy-payment/__tests__/server.test.ts
@@ -1,0 +1,322 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createPharmacyPaymentApp,
+  loadOrders,
+  startPharmacyPaymentServer,
+  type MppChargeServer,
+  type PharmacyOrderRecord,
+} from "../server.ts";
+
+const validOrder = {
+  drug: "Atorvastatin",
+  pharmacy: "CarePlus",
+  amount: 12.34,
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+  vi.clearAllMocks();
+});
+
+function setupApp(mppx: MppChargeServer) {
+  const ordersFile = createTempOrdersPath();
+  const app = createPharmacyPaymentApp({
+    mppx,
+    ordersFile,
+    recipient: "GTESTRECIPIENT",
+    port: 3305,
+  });
+
+  return { app, ordersFile };
+}
+
+function createTempOrdersPath() {
+  const dir = mkdtempSync(path.join(tmpdir(), "careguard-pharmacy-payment-"));
+  tempDirs.push(dir);
+  return path.join(dir, "orders.json");
+}
+
+function readOrders(ordersFile: string): PharmacyOrderRecord[] {
+  return JSON.parse(readFileSync(ordersFile, "utf-8"));
+}
+
+function createChallengeMppx() {
+  const charge = vi.fn((input: { amount: string; description: string }) => {
+    return vi.fn(async (_request: Request) => ({
+      status: 402,
+      challenge: new Response(JSON.stringify({ challenge: "sign-this-payment" }), {
+        status: 402,
+        headers: {
+          "www-authenticate": "MPP challenge=sign-this-payment",
+          "x-mpp-challenge": "sign-this-payment",
+        },
+      }),
+      input,
+    }));
+  });
+
+  return { charge } as unknown as MppChargeServer & { charge: typeof charge };
+}
+
+function createSuccessMppx(receipt = "stellar-receipt-abc") {
+  const charge = vi.fn((_input: { amount: string; description: string }) => {
+    return vi.fn(async (_request: Request) => ({
+      status: 200,
+      withReceipt(response: Response) {
+        response.headers.set("PAYMENT-RESPONSE", receipt);
+        response.headers.set("x-mpp-receipt", "settled");
+        return response;
+      },
+    }));
+  });
+
+  return { charge } as unknown as MppChargeServer & { charge: typeof charge };
+}
+
+describe("pharmacy payment server", () => {
+  it("returns the MPP 402 challenge body and headers before payment", async () => {
+    const mppx = createChallengeMppx();
+    const { app } = setupApp(mppx);
+
+    const response = await request(app).post("/pharmacy/order").send(validOrder);
+
+    expect(response.status).toBe(402);
+    expect(response.text).toBe(JSON.stringify({ challenge: "sign-this-payment" }));
+    expect(response.headers["www-authenticate"]).toBe("MPP challenge=sign-this-payment");
+    expect(response.headers["x-mpp-challenge"]).toBe("sign-this-payment");
+    expect(mppx.charge).toHaveBeenCalledWith({
+      amount: "12.34",
+      description: "Medication: Atorvastatin from CarePlus",
+    });
+  });
+
+  it("persists a confirmed order and echoes receipt headers after valid payment", async () => {
+    const mppx = createSuccessMppx("stellar-receipt-success");
+    const { app, ordersFile } = setupApp(mppx);
+
+    const response = await request(app).post("/pharmacy/order").send({
+      drug: "Metformin",
+      pharmacy: "Health Hub",
+      amount: "20.50",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers["payment-response"]).toBe("stellar-receipt-success");
+    expect(response.headers["x-mpp-receipt"]).toBe("settled");
+    expect(response.body).toMatchObject({
+      success: true,
+      order: {
+        drug: "Metformin",
+        pharmacy: "Health Hub",
+        amount: 20.5,
+        status: "confirmed",
+        network: "stellar:testnet",
+        protocol: "MPP Charge",
+      },
+    });
+
+    const orders = readOrders(ordersFile);
+    expect(orders).toHaveLength(1);
+    expect(orders[0]).toMatchObject(response.body.order);
+  });
+
+  it.each([
+    ["drug", { pharmacy: "CarePlus", amount: 12.34 }],
+    ["pharmacy", { drug: "Atorvastatin", amount: 12.34 }],
+    ["amount", { drug: "Atorvastatin", pharmacy: "CarePlus" }],
+  ])("returns 400 when %s is missing", async (_field, body) => {
+    const mppx = createSuccessMppx();
+    const { app } = setupApp(mppx);
+
+    const response = await request(app).post("/pharmacy/order").send(body);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid order request");
+    expect(response.body.details.length).toBeGreaterThan(0);
+    expect(mppx.charge).not.toHaveBeenCalled();
+  });
+
+  it("persists all orders from 50 parallel successful payment requests", async () => {
+    const mppx = createSuccessMppx();
+    const { app, ordersFile } = setupApp(mppx);
+
+    const responses = await Promise.all(
+      Array.from({ length: 50 }, (_value, index) =>
+        request(app)
+          .post("/pharmacy/order")
+          .send({
+            drug: `Drug ${index}`,
+            pharmacy: `Pharmacy ${index % 5}`,
+            amount: 1 + index / 100,
+          }),
+      ),
+    );
+
+    expect(responses.map((response) => response.status)).toEqual(Array(50).fill(200));
+
+    const orders = readOrders(ordersFile);
+    expect(orders).toHaveLength(50);
+    expect(new Set(orders.map((order) => order.id)).size).toBe(50);
+    expect(orders.map((order) => order.amount).sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 50 }, (_value, index) => 1 + index / 100),
+    );
+  }, 30000);
+
+  it("returns the persisted order list", async () => {
+    const mppx = createSuccessMppx();
+    const { app, ordersFile } = setupApp(mppx);
+    const seedOrders: PharmacyOrderRecord[] = [
+      {
+        id: "order-seed",
+        drug: "Lisinopril",
+        pharmacy: "CarePlus",
+        amount: 7.25,
+        status: "confirmed",
+        timestamp: "2026-06-26T00:00:00.000Z",
+        network: "stellar:testnet",
+        protocol: "MPP Charge",
+      },
+    ];
+    writeFileSync(ordersFile, JSON.stringify(seedOrders));
+
+    const response = await request(app).get("/pharmacy/orders");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ orders: seedOrders });
+  });
+
+  it("returns an empty order list for missing and empty order files", () => {
+    const ordersFile = createTempOrdersPath();
+
+    expect(loadOrders(ordersFile)).toEqual([]);
+
+    writeFileSync(ordersFile, "");
+
+    expect(loadOrders(ordersFile)).toEqual([]);
+  });
+
+  it("returns 413 when the JSON body exceeds the configured limit", async () => {
+    const originalLimit = process.env.JSON_BODY_LIMIT;
+    process.env.JSON_BODY_LIMIT = "8b";
+
+    try {
+      const mppx = createSuccessMppx();
+      const { app } = setupApp(mppx);
+
+      const response = await request(app).post("/pharmacy/order").send(validOrder);
+
+      expect(response.status).toBe(413);
+      expect(response.body.error).toBe("Request body too large");
+      expect(mppx.charge).not.toHaveBeenCalled();
+    } finally {
+      if (originalLimit === undefined) {
+        delete process.env.JSON_BODY_LIMIT;
+      } else {
+        process.env.JSON_BODY_LIMIT = originalLimit;
+      }
+    }
+  });
+
+  it("passes unexpected payment errors to Express error handling", async () => {
+    const charge = vi.fn(() => {
+      return vi.fn(async () => ({
+        status: 402,
+      }));
+    });
+    const { app } = setupApp({ charge } as unknown as MppChargeServer);
+
+    const response = await request(app).post("/pharmacy/order").send(validOrder);
+
+    expect(response.status).toBe(500);
+    expect(charge).toHaveBeenCalledOnce();
+  });
+
+  it("requires Stellar MPP environment variables when no payment server is injected", () => {
+    const originalRecipient = process.env.PHARMACY_1_PUBLIC_KEY;
+    const originalSecret = process.env.MPP_SECRET_KEY;
+    delete process.env.PHARMACY_1_PUBLIC_KEY;
+    delete process.env.MPP_SECRET_KEY;
+
+    try {
+      expect(() => createPharmacyPaymentApp()).toThrow("PHARMACY_1_PUBLIC_KEY required in .env");
+    } finally {
+      if (originalRecipient === undefined) {
+        delete process.env.PHARMACY_1_PUBLIC_KEY;
+      } else {
+        process.env.PHARMACY_1_PUBLIC_KEY = originalRecipient;
+      }
+
+      if (originalSecret === undefined) {
+        delete process.env.MPP_SECRET_KEY;
+      } else {
+        process.env.MPP_SECRET_KEY = originalSecret;
+      }
+    }
+  });
+
+  it("starts and closes an HTTP server with injected payment dependencies", async () => {
+    const server = startPharmacyPaymentServer({
+      mppx: createSuccessMppx(),
+      ordersFile: createTempOrdersPath(),
+      recipient: "GTESTRECIPIENT",
+      port: 0,
+    });
+
+    await new Promise<void>((resolve) => {
+      if (server.listening) {
+        resolve();
+        return;
+      }
+      server.once("listening", resolve);
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const address = server.address();
+    expect(address).toBeTruthy();
+    expect(typeof address === "object" && address !== null ? address.port : undefined).toBeGreaterThan(0);
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+  it("serves metadata and readiness for the isolated test app", async () => {
+    const mppx = createSuccessMppx();
+    const { app } = setupApp(mppx);
+
+    await expect(request(app).get("/")).resolves.toMatchObject({
+      status: 200,
+      body: {
+        service: "CareGuard Pharmacy Payment Service",
+        protocol: "MPP Charge on Stellar",
+        recipient: "GTESTRECIPIENT",
+      },
+    });
+
+    await expect(request(app).get("/ready")).resolves.toMatchObject({
+      status: 200,
+      text: "OK",
+    });
+
+    app.locals.startDraining();
+
+    await expect(request(app).get("/ready")).resolves.toMatchObject({
+      status: 503,
+      text: "Service Unavailable",
+    });
+  });
+});

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -1,11 +1,13 @@
 /**
- * Pharmacy Payment Service — MPP Charge on Stellar
+ * Pharmacy Payment Service - MPP Charge on Stellar
  *
  * Accepts real medication order payments via MPP (Machine Payments Protocol) charge mode.
  * Every payment settles as a real USDC transfer on Stellar testnet.
  *
- * Flow: Client POST → 402 challenge → Client signs Soroban auth entry → Server broadcasts → Order confirmed
+ * Flow: Client POST -> 402 challenge -> Client signs Soroban auth entry -> Server broadcasts -> Order confirmed
  */
+
+/// <reference path="../../types/proper-lockfile.d.ts" />
 
 if (!process.stdout.isTTY) {
   process.env.NO_COLOR ??= "1";
@@ -13,10 +15,17 @@ if (!process.stdout.isTTY) {
 }
 
 import "dotenv/config";
+import { randomUUID } from "crypto";
 import express from "express";
-import { Mppx, Store } from "mppx/server";
-import { stellar } from "@stellar/mpp/charge/server";
+import type { Application } from "express";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import type { Server } from "http";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
 import { USDC_SAC_TESTNET } from "@stellar/mpp";
+import { stellar } from "@stellar/mpp/charge/server";
+import { Mppx, Store } from "mppx/server";
+import lock from "proper-lockfile";
 import { createCorsMiddleware } from "../../shared/cors.ts";
 import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
@@ -28,199 +37,308 @@ import {
   type MedicationOrderInput,
 } from "./validation.ts";
 
-const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005");
-const RECIPIENT = process.env.PHARMACY_1_PUBLIC_KEY;
-const MPP_SECRET_KEY = process.env.MPP_SECRET_KEY;
-const NETWORK = "stellar:testnet";
+const DEFAULT_PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005", 10);
+type StellarMppNetwork = "stellar:testnet" | "stellar:pubnet";
 
-if (!RECIPIENT) throw new Error("PHARMACY_1_PUBLIC_KEY required in .env");
-if (!MPP_SECRET_KEY) throw new Error("MPP_SECRET_KEY required in .env");
+const NETWORK: StellarMppNetwork = "stellar:testnet";
+const DEFAULT_DATA_DIR = fileURLToPath(new URL("../../data/", import.meta.url));
+const DEFAULT_ORDERS_FILE = path.join(DEFAULT_DATA_DIR, "orders.json");
+const orderSaveQueues = new Map<string, Promise<void>>();
 
-// Order storage (persisted to file)
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
-import lock from "proper-lockfile";
+export type PharmacyOrderRecord = {
+  id: string;
+  drug: string;
+  pharmacy: string;
+  amount: number;
+  status: "confirmed";
+  timestamp: string;
+  network: string;
+  protocol: "MPP Charge";
+};
 
-const DATA_DIR = new URL("../../data", import.meta.url).pathname;
-const ORDERS_FILE = `${DATA_DIR}/orders.json`;
+type MppChargeResult = {
+  status: number;
+  challenge?: Response;
+  withReceipt?: (response: Response) => Response;
+};
 
-if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+export type MppChargeServer = {
+  charge(input: { amount: string; description: string }): (request: Request) => Promise<MppChargeResult>;
+};
 
-function loadOrders(): any[] {
-  if (!existsSync(ORDERS_FILE)) return [];
-  return JSON.parse(readFileSync(ORDERS_FILE, "utf-8"));
+export type CreatePharmacyPaymentAppOptions = {
+  mppx?: MppChargeServer;
+  ordersFile?: string;
+  port?: number;
+  recipient?: string;
+  network?: StellarMppNetwork;
+  currency?: typeof USDC_SAC_TESTNET;
+};
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} required in .env`);
+  return value;
+}
+
+/* v8 ignore start */
+function createDefaultMppx(options: {
+  recipient: string;
+  secretKey: string;
+  network: StellarMppNetwork;
+  currency: typeof USDC_SAC_TESTNET;
+}): MppChargeServer {
+  return Mppx.create({
+    secretKey: options.secretKey,
+    methods: [
+      stellar.charge({
+        recipient: options.recipient,
+        currency: options.currency,
+        network: options.network,
+        store: Store.memory(),
+      }),
+    ],
+  }) as unknown as MppChargeServer;
+}
+/* v8 ignore stop */
+
+function ensureOrdersFile(ordersFile: string): void {
+  mkdirSync(path.dirname(ordersFile), { recursive: true });
+  if (existsSync(ordersFile)) return;
+
+  try {
+    writeFileSync(ordersFile, JSON.stringify([]), { flag: "wx" });
+  } catch (err: any) {
+    if (err?.code !== "EEXIST") throw err;
+  }
+}
+
+export function loadOrders(ordersFile = DEFAULT_ORDERS_FILE): PharmacyOrderRecord[] {
+  if (!existsSync(ordersFile)) return [];
+  const content = readFileSync(ordersFile, "utf-8").trim();
+  if (!content) return [];
+  return JSON.parse(content);
 }
 
 /**
  * Save a new order to the orders file with file-level locking to prevent race conditions.
- * Ensures that concurrent calls don't lose data due to simultaneous read-modify-write operations.
- * 
+ * Ensures that concurrent calls do not lose data due to simultaneous read-modify-write operations.
+ *
  * Trade-off: File-based locking is slower than in-memory storage but is sufficient for the demo.
  * For production, consider switching to SQLite (#168) or a proper database.
  */
-async function saveOrder(order: any) {
-  let release: any;
+export async function saveOrder(order: PharmacyOrderRecord, ordersFile = DEFAULT_ORDERS_FILE): Promise<void> {
+  const previousSave = orderSaveQueues.get(ordersFile) ?? Promise.resolve();
+  const nextSave = previousSave
+    .catch(() => undefined)
+    .then(() => saveOrderWithLock(order, ordersFile));
+
+  orderSaveQueues.set(ordersFile, nextSave);
+
   try {
-    // Acquire exclusive lock on the orders file
-    release = await lock.lock(ORDERS_FILE, { retries: 10, stale: 5000 });
-    
-    // Safe read-modify-write within lock
-    const orders = loadOrders();
+    await nextSave;
+  } finally {
+    if (orderSaveQueues.get(ordersFile) === nextSave) {
+      orderSaveQueues.delete(ordersFile);
+    }
+  }
+}
+
+async function saveOrderWithLock(order: PharmacyOrderRecord, ordersFile: string): Promise<void> {
+  ensureOrdersFile(ordersFile);
+
+  let release: (() => Promise<void>) | undefined;
+  try {
+    release = await lock.lock(ordersFile, { retries: 100, stale: 5000 });
+
+    const orders = loadOrders(ordersFile);
     orders.push(order);
-    writeFileSync(ORDERS_FILE, JSON.stringify(orders, null, 2));
-    
-    logger.info({ orderId: order.id || 'unknown' }, 'Order saved successfully with lock');
+    writeFileSync(ordersFile, JSON.stringify(orders, null, 2));
+
+    logger.info({ orderId: order.id }, "Order saved successfully with lock");
   } catch (err: any) {
-    logger.error({ err: err.message, orderId: order.id || 'unknown' }, 'Failed to save order');
+    logger.error({ err: err.message, orderId: order.id }, "Failed to save order");
     throw err;
   } finally {
-    // Always release the lock
     if (release) {
       try {
         await release();
       } catch (err: any) {
-        logger.warn({ err: err.message }, 'Failed to release file lock');
+        logger.warn({ err: err.message }, "Failed to release file lock");
       }
     }
   }
 }
 
-const app = express();
-applySecurityMiddleware(app);
-app.use(createCorsMiddleware());
-app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
-app.use(requestContextMiddleware());
-app.use(requestLoggerMiddleware());
-
-app.get("/", (_req, res) => {
-  res.json({
-    service: "CareGuard Pharmacy Payment Service",
-    version: "1.0.0",
-    protocol: "MPP Charge on Stellar",
-    network: NETWORK,
-    recipient: RECIPIENT,
-    currency: USDC_SAC_TESTNET,
-  });
-});
-
-app.get("/pharmacy/orders", (_req, res) => {
-  res.json({ orders: loadOrders() });
-});
-
-// MPP charge server
-const mppx = Mppx.create({
-  secretKey: MPP_SECRET_KEY,
-  methods: [
-    stellar.charge({
-      recipient: RECIPIENT,
-      currency: USDC_SAC_TESTNET,
-      network: NETWORK,
-      store: Store.memory(),
-    }),
-  ],
-});
-
-// MPP-protected medication order endpoint
-app.post("/pharmacy/order", async (req, res) => {
-  const parsedOrder = MedicationOrderSchema.safeParse(req.body);
-  if (!parsedOrder.success) {
-    res.status(400).json({
-      error: "Invalid order request",
-      details: parsedOrder.error.issues.map((issue) => issue.message),
+export function createPharmacyPaymentApp(options: CreatePharmacyPaymentAppOptions = {}): Application {
+  const port = options.port ?? DEFAULT_PORT;
+  const network = options.network ?? NETWORK;
+  const currency = options.currency ?? USDC_SAC_TESTNET;
+  const runtimeRecipient = options.recipient ?? process.env.PHARMACY_1_PUBLIC_KEY;
+  const ordersFile = options.ordersFile ?? DEFAULT_ORDERS_FILE;
+  const mppxServer =
+    options.mppx ??
+    createDefaultMppx({
+      recipient: runtimeRecipient ?? requireEnv("PHARMACY_1_PUBLIC_KEY"),
+      secretKey: requireEnv("MPP_SECRET_KEY"),
+      network,
+      currency,
     });
-    return;
-  }
 
-  const order = parsedOrder.data as MedicationOrderInput;
-  const safeDrug = sanitizeUserString(order.drug);
-  const safePharmacy = sanitizeUserString(order.pharmacy);
+  const app = express();
+  applySecurityMiddleware(app);
+  app.use(createCorsMiddleware());
+  app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
+  app.use(requestContextMiddleware());
+  app.use(requestLoggerMiddleware());
 
-  // Convert Express request to Web Request for mppx
-  const headers = new Headers();
-  for (const [key, value] of Object.entries(req.headers)) {
-    if (value == null) continue;
-    if (Array.isArray(value)) {
-      for (const entry of value) headers.append(key, entry);
-    } else {
-      headers.set(key, value);
+  app.get("/", (_req, res) => {
+    res.json({
+      service: "CareGuard Pharmacy Payment Service",
+      version: "1.0.0",
+      protocol: "MPP Charge on Stellar",
+      network,
+      recipient: runtimeRecipient ?? "",
+      currency,
+    });
+  });
+
+  app.get("/pharmacy/orders", (_req, res) => {
+    res.json({ orders: loadOrders(ordersFile) });
+  });
+
+  app.post("/pharmacy/order", async (req, res) => {
+    const parsedOrder = MedicationOrderSchema.safeParse(req.body);
+    if (!parsedOrder.success) {
+      res.status(400).json({
+        error: "Invalid order request",
+        details: parsedOrder.error.issues.map((issue) => issue.message),
+      });
+      return;
     }
-  }
 
-  const webReq = new Request(`http://localhost:${PORT}${req.url}`, {
-    method: req.method,
-    headers,
+    const orderInput = parsedOrder.data as MedicationOrderInput;
+    const safeDrug = sanitizeUserString(orderInput.drug);
+    const safePharmacy = sanitizeUserString(orderInput.pharmacy);
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value == null) continue;
+      if (Array.isArray(value)) {
+        for (const entry of value) headers.append(key, entry);
+      } else {
+        headers.set(key, value);
+      }
+    }
+
+    const webReq = new Request(`http://localhost:${port}${req.url}`, {
+      method: req.method,
+      headers,
+    });
+
+    const result = await mppxServer.charge({
+      amount: orderInput.amount.toFixed(2),
+      description: `Medication: ${safeDrug} from ${safePharmacy}`,
+    })(webReq);
+
+    if (result.status === 402) {
+      if (!result.challenge) throw new Error("MPP charge returned 402 without a challenge");
+      result.challenge.headers.forEach((value: string, key: string) => res.setHeader(key, value));
+      const body = await result.challenge.text();
+      res.status(402).send(body);
+      return;
+    }
+
+    if (!result.withReceipt) throw new Error("MPP charge result did not include a receipt builder");
+
+    const confirmedOrder: PharmacyOrderRecord = {
+      id: `order-${Date.now()}-${randomUUID()}`,
+      drug: safeDrug,
+      pharmacy: safePharmacy,
+      amount: orderInput.amount,
+      status: "confirmed",
+      timestamp: new Date().toISOString(),
+      network,
+      protocol: "MPP Charge",
+    };
+    await saveOrder(confirmedOrder, ordersFile);
+
+    const response = result.withReceipt(
+      Response.json({
+        success: true,
+        order: confirmedOrder,
+        message: `Payment of $${confirmedOrder.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
+      }),
+    );
+
+    response.headers.forEach((value: string, key: string) => res.setHeader(key, value));
+    const responseBody = await response.json();
+    res.status(response.status).json(responseBody);
   });
 
-  // Run MPP charge flow
-  const result = await mppx.charge({
-    amount: order.amount.toFixed(2),
-    description: `Medication: ${safeDrug} from ${safePharmacy}`,
-  })(webReq);
+  app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (err.type === "entity.too.large") {
+      return res.status(413).json({ error: "Request body too large", limit: err.limit });
+    }
+    next(err);
+  });
 
-  // 402 = client needs to sign and pay
-  if (result.status === 402) {
-    const challenge = result.challenge;
-    challenge.headers.forEach((value: string, key: string) => res.setHeader(key, value));
-    const body = await challenge.text();
-    res.status(402).send(body);
-    return;
-  }
+  let isDraining = false;
+  app.get("/ready", (_req, res) => {
+    if (isDraining) {
+      res.status(503).send("Service Unavailable");
+      return;
+    }
+    res.send("OK");
+  });
 
-  // Payment verified and settled on Stellar — create order
-  const order = {
-    id: `order-${Date.now()}`,
-    drug: safeDrug,
-    pharmacy: safePharmacy,
-    amount: order.amount,
-    status: "confirmed",
-    timestamp: new Date().toISOString(),
-    network: NETWORK,
-    protocol: "MPP Charge",
+  app.locals.startDraining = () => {
+    isDraining = true;
   };
-  await saveOrder(order);
 
-  // Return response with payment receipt headers
-  const response = result.withReceipt(
-    Response.json({
-      success: true,
-      order,
-      message: `Payment of $${order.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
-    })
-  );
+  return app;
+}
 
-  response.headers.forEach((value: string, key: string) => res.setHeader(key, value));
-  const responseBody = await response.json();
-  res.status(response.status).json(responseBody);
-});
-
-app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
-  if (err.type === "entity.too.large") {
-    return res.status(413).json({ error: "Request body too large", limit: err.limit });
-  }
-  next(err);
-});
-
-let isDraining = false;
-app.get("/ready", (_req, res) => {
-  if (isDraining) {
-    res.status(503).send("Service Unavailable");
-    return;
-  }
-  res.send("OK");
-});
-
-const server = app.listen(PORT, () => {
-  logger.info({ port: PORT, network: NETWORK, recipient: RECIPIENT, currency: USDC_SAC_TESTNET }, "Pharmacy Payment Service (MPP Charge) started");
-});
-
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM received. Draining server...");
-  isDraining = true;
-  server.close(() => {
-    logger.info("Server closed. Exiting process.");
-    process.exit(0);
+export function startPharmacyPaymentServer(options: CreatePharmacyPaymentAppOptions = {}): Server {
+  const port = options.port ?? DEFAULT_PORT;
+  const app = createPharmacyPaymentApp({ ...options, port });
+  const server = app.listen(port, () => {
+    logger.info(
+      {
+        port,
+        network: options.network ?? NETWORK,
+        recipient: options.recipient ?? process.env.PHARMACY_1_PUBLIC_KEY,
+        currency: options.currency ?? USDC_SAC_TESTNET,
+      },
+      "Pharmacy Payment Service (MPP Charge) started",
+    );
   });
-  setTimeout(() => {
-    logger.error("Graceful shutdown timeout. Forcing exit.");
-    process.exit(1);
-  }, 30000);
-});
+
+  /* v8 ignore start */
+  process.on("SIGTERM", () => {
+    logger.info("SIGTERM received. Draining server...");
+    app.locals.startDraining();
+    server.close(() => {
+      logger.info("Server closed. Exiting process.");
+      process.exit(0);
+    });
+    setTimeout(() => {
+      logger.error("Graceful shutdown timeout. Forcing exit.");
+      process.exit(1);
+    }, 30000);
+  });
+  /* v8 ignore stop */
+
+  return server;
+}
+
+function isMainModule(): boolean {
+  if (!process.argv[1]) return false;
+  return import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+/* v8 ignore start */
+if (isMainModule()) {
+  startPharmacyPaymentServer();
+}
+/* v8 ignore stop */


### PR DESCRIPTION
## Summary
- add focused Supertest coverage for the pharmacy payment service MPP 402 challenge, successful payment receipt headers, 400 validation, persisted order listing, and 50 parallel POSTs
- refactor the service into an injectable app factory so tests can use temp order files and mocked MPP charge results without starting the real listener
- keep runtime startup behavior via `startPharmacyPaymentServer()` and add same-process save queueing before the existing file lock to make concurrent order persistence reliable

Closes #31

## Validation
- `npm test -- services/pharmacy-payment`
- `npm test -- services/pharmacy-payment --coverage --coverage.include=services/pharmacy-payment/server.ts --coverage.reporter=text` (server.ts 95.43% statements/lines)
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest services/pharmacy-payment/server.ts services/pharmacy-payment/__tests__/server.test.ts`
- `git diff --check`