### PR TITLE
Enforce max single transaction cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,9 @@ NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0
 # Max tool calls executed per /agent/run invocation (prevents runaway LLM cost).
 # One iteration with 10 parallel tool calls consumes 10x API fees + possible payments.
 MAX_TOOL_CALLS_PER_RUN=30
+# Platform-level hard cap for any single medication or bill payment.
+# This is enforced before caregiver-editable spending policy and requires redeploy/env access to change.
+MAX_SINGLE_TX_USDC=100
 # Set to 1 in tests to replace x402/MPP network payments with deterministic fake receipts.
 MOCK_NETWORK=0
 

--- a/agent/__tests__/pay-for-medication.test.ts
+++ b/agent/__tests__/pay-for-medication.test.ts
@@ -7,6 +7,7 @@
 const { mockMppFetch, onProgressHolder, mockFiles, MOCK_HINT } = vi.hoisted(() => {
   process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
   process.env.BILL_PROVIDER_PUBLIC_KEY = "GBILLPROVIDER";
+  process.env.MAX_SINGLE_TX_USDC = "100";
   const onProgressHolder: { fn?: (event: any) => void } = {};
   return { mockMppFetch: vi.fn(), onProgressHolder, mockFiles: new Map<string, string>(), MOCK_HINT: Buffer.from([0xca, 0xfe, 0xba, 0xbe]) };
 });
@@ -137,6 +138,42 @@ describe("payForMedication — policy-blocked (Issue #35)", () => {
     expect(r.success).toBe(false);
     expect(r.error).toContain("BLOCKED BY SPENDING POLICY");
     expect(mockMppFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("platform transaction cap (Issue #83)", () => {
+  const permissivePolicy = {
+    ...DEFAULT_POLICY,
+    dailyLimit: 1000,
+    monthlyLimit: 1000,
+    medicationMonthlyBudget: 500,
+    billMonthlyBudget: 500,
+    approvalThreshold: 1000,
+  };
+
+  it("blocks medication payments above MAX_SINGLE_TX_USDC before policy approval", async () => {
+    setSpendingPolicy("rosa", permissivePolicy);
+
+    const result = await payForMedication("p1", "Pharma", "Drug", 150);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("BLOCKED BY PLATFORM CAP"),
+    });
+    expect(result.error).toContain("MAX_SINGLE_TX_USDC");
+    expect(mockMppFetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks bill payments above MAX_SINGLE_TX_USDC even when policy allows them", async () => {
+    setSpendingPolicy("rosa", permissivePolicy);
+
+    const result = await payBill("provider-1", "Hospital", "Visit", 150, true);
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.stringContaining("BLOCKED BY PLATFORM CAP"),
+    });
+    expect(result.error).toContain("MAX_SINGLE_TX_USDC");
   });
 });
 

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -255,7 +255,7 @@ async function waitForStellarSettlement(
 
 // --- x402 Client: Auto-handles 402 Payment Required for API queries ---
 // Use stellar:testnet or stellar:public scheme based on STELLAR_NETWORK env
-const x402SchemeId = `stellar:${STELLAR_CONFIG.networkType}`;
+const x402SchemeId = `stellar:${STELLAR_CONFIG.networkType}` as `${string}:${string}`;
 const x402Fetch = isMockNetwork()
   ? fetch
   : wrapFetchWithPayment(
@@ -624,9 +624,28 @@ let spendingTracker = loadSpending();
 
 const MAX_PAYMENT = 1000;
 const MAX_ERROR_LENGTH = 500;
+const MAX_SINGLE_TX_USDC = parsePositiveNumberEnv("MAX_SINGLE_TX_USDC", 100);
+
+function parsePositiveNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive finite number`);
+  }
+
+  return value;
+}
 
 function truncateError(message: string): string {
   return message.replace(/<[^>]*>/g, '').slice(0, MAX_ERROR_LENGTH);
+}
+
+function platformCapError(amount: number): string | undefined {
+  if (amount <= MAX_SINGLE_TX_USDC) return undefined;
+
+  return `BLOCKED BY PLATFORM CAP: Payment of $${amount.toFixed(2)} exceeds the platform MAX_SINGLE_TX_USDC cap of $${MAX_SINGLE_TX_USDC.toFixed(2)}. This cap is configured by environment variable and cannot be changed through the caregiver policy API.`;
 }
 
 function recordServiceFee(
@@ -1492,6 +1511,13 @@ export async function payForMedication(
       error: `Invalid payment amount: $${amount}. Amount must be a positive finite number <= $${MAX_PAYMENT}.`,
     };
   }
+
+  const platformCapBlock = platformCapError(amount);
+  if (platformCapBlock) {
+    policyBlocksTotal.inc({ reason: 'platform_cap' });
+    return { success: false, error: platformCapBlock };
+  }
+
   const policyCheck = checkSpendingPolicy(
     amount,
     TRANSACTION_CATEGORY.MEDICATIONS,
@@ -1607,6 +1633,13 @@ export async function payBill(
       error: `Invalid payment amount: $${amount}. Amount must be a positive finite number <= $${MAX_PAYMENT}.`,
     };
   }
+
+  const platformCapBlock = platformCapError(amount);
+  if (platformCapBlock) {
+    policyBlocksTotal.inc({ reason: 'platform_cap' });
+    return { success: false, error: platformCapBlock };
+  }
+
   const policyCheck = checkSpendingPolicy(amount, TRANSACTION_CATEGORY.BILLS);
   if (!policyCheck.allowed) {
     const reason = policyCheck.reason!.includes('daily')

--- a/docs/SPENDING-POLICY.md
+++ b/docs/SPENDING-POLICY.md
@@ -10,6 +10,20 @@ CareGuard enforces five limits on every payment the agent makes:
 | `billMonthlyBudget` | $500 | Monthly cap for bill payments only |
 | `approvalThreshold` | $75 | Payments above this amount require explicit caregiver approval |
 
+## Platform Single-Transaction Cap
+
+`MAX_SINGLE_TX_USDC` is a deployment-level hard cap for any single medication or bill payment. It defaults to `$100` and is checked before the caregiver-editable spending policy.
+
+This cap is intentionally not stored in `policy.json` and cannot be changed through the dashboard or policy API. Raising it requires changing the environment variable and redeploying the service.
+
+Example:
+
+```
+MAX_SINGLE_TX_USDC=100
+```
+
+If a payment is above this cap, the agent returns `BLOCKED BY PLATFORM CAP` without attempting MPP, Horizon, or spending-policy approval.
+
 ## Daily Limit and Timezones
 
 The daily limit resets at **local midnight** in the caregiver's timezone, not UTC midnight.

--- a/render.yaml
+++ b/render.yaml
@@ -61,6 +61,8 @@ services:
         value: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
       - key: USDC_SAC
         value: CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
+      - key: MAX_SINGLE_TX_USDC
+        value: "100"
       - key: PHARMACY_API_URL
         value: http://localhost:3004
       - key: BILL_AUDIT_API_URL


### PR DESCRIPTION
## Summary
- enforce `MAX_SINGLE_TX_USDC` before caregiver-editable spending policy in both `payForMedication` and `payBill`
- return a distinct `BLOCKED BY PLATFORM CAP` error without attempting MPP, Horizon, or policy approval
- document the deployment-only cap in `.env.example`, `docs/SPENDING-POLICY.md`, and Render env vars
- add regression coverage proving over-cap medication and bill payments stay blocked even when policy limits/approval threshold are permissive

Closes #83

## Validation
- `npm test -- agent/__tests__/pay-for-medication.test.ts` (23 tests)
- `npm test -- agent/__tests__/pay-for-medication.test.ts agent/__tests__/tools.test.ts agent/__tests__/pay-bill.test.ts` (42 tests on this branch; `pay-bill.test.ts` is not present on `main` yet, so Vitest ran the two existing matching files)
- `npm test -- agent/__tests__/pay-for-medication.test.ts --coverage --coverage.include=agent/tools.ts --coverage.reporter=json --coverage.reporter=text`
  - Full-file `agent/tools.ts` coverage is 46.08% because the file contains many unrelated tools.
  - Coverage JSON shows `platformCapError` exercised 14 times, `payForMedication` 17 times, and `payBill` 2 times.
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest agent/tools.ts agent/__tests__/pay-for-medication.test.ts`
- `git diff --check`