### PR TITLE
Configurable bill-audit thresholds via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,15 @@ JSON_BODY_LIMIT=20kb
 # Bill-audit routes handle up to 500 line items; allow larger payloads.
 BILL_AUDIT_BODY_LIMIT=256kb
 
+# --- Bill audit thresholds (issue #73) ---
+# Multipliers must satisfy: upcoded > overcharge > suggested > 1.0.
+# Charges above fair market rate * overcharge are flagged as overcharged.
+BILL_AUDIT_OVERCHARGE_MULTIPLIER=1.5
+# Corrected/suggested amounts use fair market rate * suggested.
+BILL_AUDIT_SUGGESTED_MULTIPLIER=1.2
+# Charges above fair market rate * upcoded are flagged as upcoded.
+BILL_AUDIT_UPCODED_MULTIPLIER=3.0
+
 # --- LLM PHI scrubbing (issue #97) ---
 # Set to false ONLY for LLM providers with a signed BAA (e.g., enterprise OpenAI).
 LLM_PII_SCRUB=true

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -13,6 +13,7 @@ Operational runbooks for on-call engineers. Each runbook follows the template:
 | [wallet-low.md](wallet-low.md) | Agent auto-paused due to low USDC or XLM balance — how to fund and resume |
 | [csp-changes.md](csp-changes.md) | Content-Security-Policy changes — how to update without breaking the dashboard |
 | [oz-facilitator-outage.md](oz-facilitator-outage.md) | OZ facilitator unreachable — recognise, communicate, fail-open vs fail-closed decision |
+| [tune-audit-thresholds.md](tune-audit-thresholds.md) | Bill-audit threshold tuning for overcharge, suggested amount, and upcoded classification |
 | [llm-rate-limit.md](llm-rate-limit.md) | Groq 429 / LLM provider rate-limit hit — behaviour, provider switching mid-incident |
 | [dashboard-disconnected.md](dashboard-disconnected.md) | Dashboard shows "Disconnected" chip — diagnosing API connectivity issues |
 

--- a/docs/runbooks/tune-audit-thresholds.md
+++ b/docs/runbooks/tune-audit-thresholds.md
@@ -1,0 +1,86 @@
+# Runbook: Tune bill-audit thresholds
+
+**Symptom**
+
+The bill audit service is flagging too many legitimate line items as overcharged/upcoded, or it is missing charges that operations expects to dispute.
+
+**Impact**
+
+Thresholds affect caregiver-facing bill audit results from `POST /bill/audit` in both the unified server and the standalone bill-audit API. Aggressive thresholds can create false positives and unnecessary disputes. Lenient thresholds can miss overcharges and reduce savings.
+
+**Diagnosis**
+
+Check the current environment:
+
+```sh
+printenv | grep BILL_AUDIT_
+```
+
+Current defaults:
+
+| Env var | Default | Purpose |
+|---|---:|---|
+| `BILL_AUDIT_SUGGESTED_MULTIPLIER` | `1.2` | Corrected amount is `fair market rate * suggested` |
+| `BILL_AUDIT_OVERCHARGE_MULTIPLIER` | `1.5` | Charge above `fair market rate * overcharge` is `overcharged` |
+| `BILL_AUDIT_UPCODED_MULTIPLIER` | `3.0` | Charge above `fair market rate * upcoded` is `upcoded` |
+
+The service validates this ordering at boot:
+
+```text
+BILL_AUDIT_UPCODED_MULTIPLIER > BILL_AUDIT_OVERCHARGE_MULTIPLIER > BILL_AUDIT_SUGGESTED_MULTIPLIER > 1.0
+```
+
+If the order is invalid, startup fails so the service cannot run with ambiguous billing policy.
+
+**Mitigation**
+
+For false positives, raise `BILL_AUDIT_OVERCHARGE_MULTIPLIER` in small increments, for example from `1.5` to `1.75`.
+
+For missed overcharges, lower `BILL_AUDIT_OVERCHARGE_MULTIPLIER`, keeping it above `BILL_AUDIT_SUGGESTED_MULTIPLIER`.
+
+For too many `upcoded` classifications, raise `BILL_AUDIT_UPCODED_MULTIPLIER`.
+
+For corrected amounts that are too low or high, tune `BILL_AUDIT_SUGGESTED_MULTIPLIER`, keeping it below `BILL_AUDIT_OVERCHARGE_MULTIPLIER`.
+
+Restart the service after changing env vars.
+
+**Verification**
+
+Run targeted tests:
+
+```sh
+npm test -- shared/__tests__/bill-audit-thresholds.test.ts
+```
+
+Then submit a known bill payload to confirm the expected status:
+
+```sh
+curl -X POST "$BILL_AUDIT_API_URL/bill/audit" \
+  -H "Content-Type: application/json" \
+  -d '{"lineItems":[{"description":"Office visit","cptCode":"99213","quantity":1,"chargedAmount":170}]}'
+```
+
+With defaults, this line is `valid` if the charge is at or below `1.5x` the fair market rate and `overcharged` above that threshold.
+
+**Remediation**
+
+If a new threshold set becomes permanent, update deployment env vars and `.env.example` together. Keep changes incremental and compare a sample of historical audits before and after the change.
+
+The standalone bill-audit service can still use `services/bill-audit-api/audit_thresholds.json` for CPT-specific overcharge overrides. Env vars control the global defaults and the suggested/upcoded thresholds.
+
+**Post-mortem template**
+
+- Date / duration:
+- Threshold values before:
+- Threshold values after:
+- Reason for tuning:
+- Number of audits affected:
+- False positive / false negative examples:
+- Follow-up action items:
+
+**Related**
+
+- Issue [#73](https://github.com/harystyleseze/careguard/issues/73) - configurable bill-audit thresholds
+- `shared/bill-audit-thresholds.ts` - env loader and audit classification helpers
+- `services/bill-audit-api/server.ts` - standalone bill-audit API
+- `server.ts` - unified production server

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,11 @@ import {
   validateBillAuditRequest,
 } from "./shared/bill-audit.ts";
 import { sanitizeUserString } from "./shared/sanitize.ts";
+import {
+  getBillAuditChargeStatus,
+  getBillAuditSuggestedAmount,
+  readBillAuditThresholds,
+} from "./shared/bill-audit-thresholds.ts";
 
 // Sentry (gated by SENTRY_DSN)
 import { initSentry } from "./shared/sentry.ts";
@@ -538,6 +543,8 @@ const FAIR_MARKET_RATES: Record<
   "97110": { description: "Physical therapy", fairRate: 55 },
 };
 
+const BILL_AUDIT_THRESHOLDS = readBillAuditThresholds();
+
 function runBillAudit(lineItems: any[]) {
   const results: any[] = [];
   let totalCharged = 0,
@@ -563,22 +570,35 @@ function runBillAudit(lineItems: any[]) {
       });
       continue;
     }
-    if (fairAmt !== null && item.chargedAmount > fairAmt * 1.5) {
+    const auditStatus = getBillAuditChargeStatus({
+      cptCode: item.cptCode,
+      chargedAmount: item.chargedAmount,
+      fairAmount: fairAmt,
+      thresholds: BILL_AUDIT_THRESHOLDS,
+    });
+    if (auditStatus !== "valid") {
       errorCount++;
-      const suggested = +(fairAmt * 1.2).toFixed(2);
+      const suggested = getBillAuditSuggestedAmount({
+        fairAmount: fairAmt,
+        chargedAmount: item.chargedAmount,
+        thresholds: BILL_AUDIT_THRESHOLDS,
+        capAtCharged: false,
+      });
       totalCorrect += suggested;
       results.push({
         ...item,
         fairMarketRate: fairAmt,
-        status: item.chargedAmount > fairAmt * 3 ? "upcoded" : "overcharged",
-        errorDescription: `Charged $${item.chargedAmount} — fair rate $${fairAmt}. Overcharged $${(item.chargedAmount - fairAmt).toFixed(2)}`,
+        status: auditStatus,
+        errorDescription: `Charged $${item.chargedAmount} — fair rate $${fairAmt}. Overcharged $${(item.chargedAmount - fairAmt!).toFixed(2)}`,
         suggestedAmount: suggested,
       });
       continue;
     }
-    const suggested = fairAmt !== null
-      ? Math.min(item.chargedAmount, +(fairAmt * 1.2).toFixed(2))
-      : item.chargedAmount;
+    const suggested = getBillAuditSuggestedAmount({
+      fairAmount: fairAmt,
+      chargedAmount: item.chargedAmount,
+      thresholds: BILL_AUDIT_THRESHOLDS,
+    });
     totalCorrect += suggested;
     results.push({
       ...item,

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -27,6 +27,12 @@ import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
 import { sanitizeUserString } from "../../shared/sanitize.ts";
+import {
+  getBillAuditChargeStatus,
+  getBillAuditSuggestedAmount,
+  readBillAuditThresholds,
+  type BillAuditThresholds,
+} from "../../shared/bill-audit-thresholds.ts";
 
 const PORT = parseInt(process.env.BILL_AUDIT_API_PORT || "3002");
 const PAY_TO = process.env.BILL_PROVIDER_PUBLIC_KEY;
@@ -71,26 +77,29 @@ process.on('SIGHUP', () => {
 });
 
 // Audit threshold configuration
-interface AuditThresholdConfig {
-  default: number;
+interface AuditThresholdOverrides {
   byCpt: Record<string, number>;
 }
 
-let auditThresholds: AuditThresholdConfig = { default: 1.5, byCpt: {} };
+let auditThresholds: BillAuditThresholds = readBillAuditThresholds();
+let auditThresholdOverrides: AuditThresholdOverrides = { byCpt: {} };
 
 function loadAuditThresholds() {
+  auditThresholds = readBillAuditThresholds();
+
   try {
     const thresholdsPath = new URL('./audit_thresholds.json', import.meta.url).pathname;
-    auditThresholds = JSON.parse(readFileSync(thresholdsPath, 'utf-8')) as AuditThresholdConfig;
-    logger.info({ default: auditThresholds.default, cptCount: Object.keys(auditThresholds.byCpt).length }, 'Loaded audit thresholds configuration');
+    auditThresholdOverrides = JSON.parse(readFileSync(thresholdsPath, 'utf-8')) as AuditThresholdOverrides;
+    logger.info({
+      overchargeMultiplier: auditThresholds.overchargeMultiplier,
+      suggestedMultiplier: auditThresholds.suggestedMultiplier,
+      upcodedMultiplier: auditThresholds.upcodedMultiplier,
+      cptCount: Object.keys(auditThresholdOverrides.byCpt ?? {}).length,
+    }, 'Loaded audit thresholds configuration');
   } catch (err: any) {
-    logger.error({ err: err.message }, 'Failed to load audit_thresholds.json, using default threshold of 1.5');
-    auditThresholds = { default: 1.5, byCpt: {} };
+    logger.error({ err: err.message }, 'Failed to load audit_thresholds.json, using env/default audit thresholds');
+    auditThresholdOverrides = { byCpt: {} };
   }
-}
-
-function getAuditThreshold(cptCode: string): number {
-  return auditThresholds.byCpt[cptCode] ?? auditThresholds.default;
 }
 
 // Load thresholds at boot
@@ -148,7 +157,6 @@ function auditBill(lineItems: BillItem[]) {
     totalCharged += item.chargedAmount;
     const fairRate = FAIR_MARKET_RATES[item.cptCode];
     const fairAmount = fairRate !== undefined ? fairRate.fairRate * item.quantity : null;
-    const threshold = getAuditThreshold(item.cptCode);
 
     seenCodes[item.cptCode] = (seenCodes[item.cptCode] || 0) + 1;
     if (seenCodes[item.cptCode] > 1 && !duplicateAllowlist.has(item.cptCode)) {
@@ -157,15 +165,31 @@ function auditBill(lineItems: BillItem[]) {
       continue;
     }
 
-    if (fairAmount !== null && item.chargedAmount > fairAmount * threshold) {
+    const auditStatus = getBillAuditChargeStatus({
+      cptCode: item.cptCode,
+      chargedAmount: item.chargedAmount,
+      fairAmount,
+      thresholds: auditThresholds,
+      overchargeMultiplierByCpt: auditThresholdOverrides.byCpt,
+    });
+    if (auditStatus !== "valid") {
       errorCount++;
-      const suggestedAmount = +(fairAmount * 1.2).toFixed(2);
+      const suggestedAmount = getBillAuditSuggestedAmount({
+        fairAmount,
+        chargedAmount: item.chargedAmount,
+        thresholds: auditThresholds,
+        capAtCharged: false,
+      });
       totalCorrect += suggestedAmount;
-      results.push({ description: item.description, cptCode: item.cptCode, quantity: item.quantity, chargedAmount: item.chargedAmount, fairMarketRate: fairAmount, status: item.chargedAmount > fairAmount * 3 ? "upcoded" : "overcharged", errorDescription: `Charged $${item.chargedAmount} — CMS fair market rate is $${fairAmount}. Overcharged by $${(item.chargedAmount - fairAmount).toFixed(2)}.`, suggestedAmount });
+      results.push({ description: item.description, cptCode: item.cptCode, quantity: item.quantity, chargedAmount: item.chargedAmount, fairMarketRate: fairAmount, status: auditStatus, errorDescription: `Charged $${item.chargedAmount} — CMS fair market rate is $${fairAmount}. Overcharged by $${(item.chargedAmount - fairAmount!).toFixed(2)}.`, suggestedAmount });
       continue;
     }
 
-    const suggested = fairAmount !== null ? Math.min(item.chargedAmount, +(fairAmount * 1.2).toFixed(2)) : item.chargedAmount;
+    const suggested = getBillAuditSuggestedAmount({
+      fairAmount,
+      chargedAmount: item.chargedAmount,
+      thresholds: auditThresholds,
+    });
     totalCorrect += suggested;
     results.push({ description: item.description, cptCode: item.cptCode, quantity: item.quantity, chargedAmount: item.chargedAmount, fairMarketRate: fairAmount, status: "valid", errorDescription: null, suggestedAmount: suggested });
   }

--- a/shared/__tests__/bill-audit-thresholds.test.ts
+++ b/shared/__tests__/bill-audit-thresholds.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBillAuditChargeStatus,
+  getBillAuditSuggestedAmount,
+  readBillAuditThresholds,
+  validateBillAuditThresholds,
+} from "../bill-audit-thresholds.ts";
+
+describe("bill audit threshold configuration", () => {
+  it("uses the default bill audit multipliers", () => {
+    expect(readBillAuditThresholds({})).toEqual({
+      overchargeMultiplier: 1.5,
+      suggestedMultiplier: 1.2,
+      upcodedMultiplier: 3.0,
+    });
+  });
+
+  it("validates threshold ordering at boot", () => {
+    expect(() =>
+      validateBillAuditThresholds({
+        overchargeMultiplier: 1.2,
+        suggestedMultiplier: 1.5,
+        upcodedMultiplier: 3.0,
+      }),
+    ).toThrow(/UPCODED_MULTIPLIER > BILL_AUDIT_OVERCHARGE_MULTIPLIER > BILL_AUDIT_SUGGESTED_MULTIPLIER/);
+  });
+
+  it("changes audit verdicts for the same line item when env thresholds change", () => {
+    const lineItem = { cptCode: "99213", chargedAmount: 170, fairAmount: 100 };
+
+    const defaultThresholds = readBillAuditThresholds({});
+    const lenientThresholds = readBillAuditThresholds({
+      BILL_AUDIT_SUGGESTED_MULTIPLIER: "1.2",
+      BILL_AUDIT_OVERCHARGE_MULTIPLIER: "2.0",
+      BILL_AUDIT_UPCODED_MULTIPLIER: "3.0",
+    });
+    const aggressiveThresholds = readBillAuditThresholds({
+      BILL_AUDIT_SUGGESTED_MULTIPLIER: "1.1",
+      BILL_AUDIT_OVERCHARGE_MULTIPLIER: "1.25",
+      BILL_AUDIT_UPCODED_MULTIPLIER: "1.6",
+    });
+
+    expect(getBillAuditChargeStatus({ ...lineItem, thresholds: defaultThresholds })).toBe("overcharged");
+    expect(getBillAuditChargeStatus({ ...lineItem, thresholds: lenientThresholds })).toBe("valid");
+    expect(getBillAuditChargeStatus({ ...lineItem, thresholds: aggressiveThresholds })).toBe("upcoded");
+  });
+
+  it("uses the suggested multiplier when calculating corrected amounts", () => {
+    const thresholds = readBillAuditThresholds({
+      BILL_AUDIT_SUGGESTED_MULTIPLIER: "1.4",
+      BILL_AUDIT_OVERCHARGE_MULTIPLIER: "1.5",
+      BILL_AUDIT_UPCODED_MULTIPLIER: "3.0",
+    });
+
+    expect(getBillAuditSuggestedAmount({ fairAmount: 100, chargedAmount: 200, thresholds })).toBe(140);
+  });
+});

--- a/shared/bill-audit-thresholds.ts
+++ b/shared/bill-audit-thresholds.ts
@@ -1,0 +1,123 @@
+export interface BillAuditThresholds {
+  overchargeMultiplier: number;
+  suggestedMultiplier: number;
+  upcodedMultiplier: number;
+}
+
+export type BillAuditChargeStatus = "valid" | "overcharged" | "upcoded";
+
+export const DEFAULT_BILL_AUDIT_THRESHOLDS: BillAuditThresholds = {
+  overchargeMultiplier: 1.5,
+  suggestedMultiplier: 1.2,
+  upcodedMultiplier: 3.0,
+};
+
+const ENV_KEYS = {
+  overchargeMultiplier: "BILL_AUDIT_OVERCHARGE_MULTIPLIER",
+  suggestedMultiplier: "BILL_AUDIT_SUGGESTED_MULTIPLIER",
+  upcodedMultiplier: "BILL_AUDIT_UPCODED_MULTIPLIER",
+} as const;
+
+type ThresholdEnv = Record<string, string | undefined>;
+
+function parseMultiplier(env: ThresholdEnv, key: string, defaultValue: number): number {
+  const raw = env[key];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultValue;
+  }
+
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`${key} must be a finite number`);
+  }
+
+  return value;
+}
+
+export function validateBillAuditThresholds(thresholds: BillAuditThresholds): BillAuditThresholds {
+  const { overchargeMultiplier, suggestedMultiplier, upcodedMultiplier } = thresholds;
+
+  if (
+    !Number.isFinite(overchargeMultiplier) ||
+    !Number.isFinite(suggestedMultiplier) ||
+    !Number.isFinite(upcodedMultiplier)
+  ) {
+    throw new Error("Bill audit threshold multipliers must be finite numbers");
+  }
+
+  if (!(upcodedMultiplier > overchargeMultiplier && overchargeMultiplier > suggestedMultiplier && suggestedMultiplier > 1.0)) {
+    throw new Error(
+      "Bill audit threshold multipliers must satisfy BILL_AUDIT_UPCODED_MULTIPLIER > BILL_AUDIT_OVERCHARGE_MULTIPLIER > BILL_AUDIT_SUGGESTED_MULTIPLIER > 1.0",
+    );
+  }
+
+  return thresholds;
+}
+
+export function readBillAuditThresholds(env: ThresholdEnv = process.env): BillAuditThresholds {
+  return validateBillAuditThresholds({
+    overchargeMultiplier: parseMultiplier(
+      env,
+      ENV_KEYS.overchargeMultiplier,
+      DEFAULT_BILL_AUDIT_THRESHOLDS.overchargeMultiplier,
+    ),
+    suggestedMultiplier: parseMultiplier(
+      env,
+      ENV_KEYS.suggestedMultiplier,
+      DEFAULT_BILL_AUDIT_THRESHOLDS.suggestedMultiplier,
+    ),
+    upcodedMultiplier: parseMultiplier(env, ENV_KEYS.upcodedMultiplier, DEFAULT_BILL_AUDIT_THRESHOLDS.upcodedMultiplier),
+  });
+}
+
+export function getOverchargeMultiplier(
+  cptCode: string,
+  thresholds: BillAuditThresholds,
+  overchargeMultiplierByCpt: Record<string, number> = {},
+): number {
+  return overchargeMultiplierByCpt[cptCode] ?? thresholds.overchargeMultiplier;
+}
+
+export function getBillAuditChargeStatus({
+  cptCode,
+  chargedAmount,
+  fairAmount,
+  thresholds,
+  overchargeMultiplierByCpt = {},
+}: {
+  cptCode: string;
+  chargedAmount: number;
+  fairAmount: number | null;
+  thresholds: BillAuditThresholds;
+  overchargeMultiplierByCpt?: Record<string, number>;
+}): BillAuditChargeStatus {
+  if (fairAmount === null) {
+    return "valid";
+  }
+
+  const overchargeMultiplier = getOverchargeMultiplier(cptCode, thresholds, overchargeMultiplierByCpt);
+  if (chargedAmount <= fairAmount * overchargeMultiplier) {
+    return "valid";
+  }
+
+  return chargedAmount > fairAmount * thresholds.upcodedMultiplier ? "upcoded" : "overcharged";
+}
+
+export function getBillAuditSuggestedAmount({
+  fairAmount,
+  chargedAmount,
+  thresholds,
+  capAtCharged = true,
+}: {
+  fairAmount: number | null;
+  chargedAmount: number;
+  thresholds: BillAuditThresholds;
+  capAtCharged?: boolean;
+}): number {
+  if (fairAmount === null) {
+    return chargedAmount;
+  }
+
+  const suggested = +(fairAmount * thresholds.suggestedMultiplier).toFixed(2);
+  return capAtCharged ? Math.min(chargedAmount, suggested) : suggested;
+}


### PR DESCRIPTION
## Summary
- add shared bill-audit threshold env loading with boot-time validation for suggested, overcharge, and upcoded multipliers
- wire the unified server and standalone bill-audit API to use the configurable thresholds while preserving CPT-specific overcharge overrides
- document the new env vars and add an operator runbook for tuning audit thresholds

Closes #73

## Validation
- npm test -- shared/__tests__/bill-audit-thresholds.test.ts services/bill-audit-api/__tests__/bill-audit.test.ts
- npx tsc --noEmit --pretty false --allowImportingTsExtensions --moduleResolution bundler --module ESNext --target ES2022 --strict --skipLibCheck --types node,vitest shared/bill-audit-thresholds.ts shared/__tests__/bill-audit-thresholds.test.ts services/bill-audit-api/server.ts
- git diff --check