### PR TITLE
Add policy enforcement boundary tests

### DIFF
--- a/agent/__tests__/policy-boundary.test.ts
+++ b/agent/__tests__/policy-boundary.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Boundary integration tests for spending-policy enforcement (#45).
+ * External Stellar, MPP, x402, and filesystem effects are mocked so these tests
+ * exercise the real exported payment and policy tools.
+ */
+
+const { mockMppFetch, onProgressHolder, mockFiles, MOCK_HINT } = vi.hoisted(() => {
+  process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+  process.env.BILL_PROVIDER_PUBLIC_KEY = "GBILLPROVIDER";
+  process.env.SPENDING_TIMEZONE = "UTC";
+  const onProgressHolder: { fn?: (event: any) => void } = {};
+  return {
+    mockMppFetch: vi.fn(),
+    onProgressHolder,
+    mockFiles: new Map<string, string>(),
+    MOCK_HINT: Buffer.from([0xca, 0xfe, 0xba, 0xbe]),
+  };
+});
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("fs", () => ({
+  readFileSync: vi.fn((filePath: string) => mockFiles.get(String(filePath)) ?? "{}"),
+  writeFileSync: vi.fn((filePath: string, data: string) => {
+    mockFiles.set(String(filePath), String(data));
+  }),
+  appendFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  existsSync: vi.fn((filePath: string) => mockFiles.has(String(filePath))),
+  mkdirSync: vi.fn(),
+  renameSync: vi.fn((from: string, to: string) => {
+    const data = mockFiles.get(String(from));
+    if (data !== undefined) {
+      mockFiles.set(String(to), data);
+      mockFiles.delete(String(from));
+    }
+  }),
+}));
+vi.mock("@stellar/stellar-sdk", () => ({
+  Keypair: {
+    fromSecret: vi.fn().mockReturnValue({
+      publicKey: () => "GPUB123",
+      sign: vi.fn(),
+      signatureHint: () => MOCK_HINT,
+    }),
+  },
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  TransactionBuilder: vi.fn().mockReturnValue({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockReturnValue({
+      sign: vi.fn(),
+      signatures: [{ hint: () => MOCK_HINT }],
+    }),
+  }),
+  Operation: { payment: vi.fn() },
+  Asset: vi.fn(),
+  Horizon: {
+    Server: vi.fn().mockReturnValue({
+      loadAccount: vi.fn(),
+      submitTransaction: vi.fn().mockResolvedValue({ hash: "b".repeat(64), fee: "100" }),
+    }),
+  },
+}));
+vi.mock("@x402/stellar", () => ({
+  createEd25519Signer: vi.fn().mockReturnValue({}),
+  ExactStellarScheme: vi.fn(),
+}));
+vi.mock("@x402/fetch", () => ({
+  wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
+  x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }),
+  decodePaymentResponseHeader: vi.fn(),
+}));
+vi.mock("@stellar/mpp/charge/client", () => ({
+  stellar: vi.fn().mockImplementation((opts: any) => {
+    if (opts?.onProgress) onProgressHolder.fn = opts.onProgress;
+    return {};
+  }),
+}));
+vi.mock("mppx/client", () => ({
+  Mppx: { create: vi.fn().mockReturnValue({ fetch: mockMppFetch }) },
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  checkSpendingPolicy,
+  getSpendingSummary,
+  payBill,
+  payForMedication,
+  resetSpendingTracker,
+  setSpendingPolicy,
+} from "../tools.ts";
+
+const DEFAULT_POLICY = {
+  dailyLimit: 100,
+  monthlyLimit: 800,
+  medicationMonthlyBudget: 300,
+  billMonthlyBudget: 500,
+  approvalThreshold: 75,
+};
+
+beforeEach(() => {
+  mockFiles.clear();
+  mockMppFetch.mockReset();
+  resetSpendingTracker("rosa");
+  setSpendingPolicy("rosa", { ...DEFAULT_POLICY });
+});
+
+describe("policy enforcement boundaries (#45)", () => {
+  it("allows medication amount exactly equal to medicationMonthlyBudget", () => {
+    setSpendingPolicy("rosa", { ...DEFAULT_POLICY, dailyLimit: 300, approvalThreshold: 1000 });
+
+    const result = checkSpendingPolicy(300, "medications");
+
+    expect(result).toMatchObject({
+      allowed: true,
+      requiresApproval: false,
+      currentSpending: 0,
+      budgetRemaining: 0,
+    });
+  });
+
+  it("blocks a medication payment one cent over the monthly budget with a precise reason", () => {
+    setSpendingPolicy("rosa", { ...DEFAULT_POLICY, dailyLimit: 500, approvalThreshold: 1000 });
+
+    const result = checkSpendingPolicy(300.01, "medications");
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe(
+      "Payment of $300.01 exceeds medications monthly budget. Budget: $300, spent: $0.00, remaining: $300.00",
+    );
+    expect(result.requiresApproval).toBe(false);
+  });
+
+  it("allows amount exactly equal to the daily limit when other budgets permit it", () => {
+    setSpendingPolicy("rosa", {
+      ...DEFAULT_POLICY,
+      dailyLimit: 250,
+      medicationMonthlyBudget: 400,
+      monthlyLimit: 900,
+      approvalThreshold: 1000,
+    });
+
+    const result = checkSpendingPolicy(250, "medications");
+
+    expect(result.allowed).toBe(true);
+    expect(result.budgetRemaining).toBe(150);
+  });
+
+  it("requires approval when amount is exactly equal to approvalThreshold", async () => {
+    const policyCheck = checkSpendingPolicy(75, "medications");
+
+    expect(policyCheck.allowed).toBe(true);
+    expect(policyCheck.requiresApproval).toBe(true);
+
+    const result = await payForMedication("pharm-1", "Pharmacy", "Metformin", 75);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("REQUIRES CAREGIVER APPROVAL");
+    expect((result as any).transaction).toMatchObject({
+      amount: 75,
+      status: "pending",
+      category: "medications",
+    });
+    expect(mockMppFetch).not.toHaveBeenCalled();
+  });
+
+  it("records a blocked dashboard bill payment and does not poison the next valid payment", async () => {
+    setSpendingPolicy("rosa", {
+      dailyLimit: 600,
+      monthlyLimit: 1000,
+      medicationMonthlyBudget: 400,
+      billMonthlyBudget: 500,
+      approvalThreshold: 1000,
+    });
+
+    const blocked = await payBill("provider-1", "General Hospital", "Try Over-Budget Payment", 600);
+
+    expect(blocked.success).toBe(false);
+    expect(blocked.error).toContain(
+      "Payment of $600.00 exceeds bills monthly budget. Budget: $500, spent: $0.00, remaining: $500.00",
+    );
+    expect((blocked as any).transaction).toMatchObject({
+      amount: 600,
+      status: "blocked",
+      category: "bills",
+    });
+
+    let summary = getSpendingSummary();
+    expect(summary.spending.bills).toBe(0);
+    expect(summary.transactionCount).toBe(1);
+    expect(summary.recentTransactions[0].status).toBe("blocked");
+
+    const paid = await payBill("provider-1", "General Hospital", "Follow-up copay", 50);
+
+    expect(paid.success).toBe(true);
+    expect((paid as any).transaction).toMatchObject({
+      amount: 50,
+      status: "completed",
+      category: "bills",
+    });
+    summary = getSpendingSummary();
+    expect(summary.spending.bills).toBe(50);
+    expect(summary.transactionCount).toBe(2);
+    expect(summary.recentTransactions.map((tx: any) => tx.status)).toEqual(["blocked", "completed"]);
+  });
+});

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -625,8 +625,35 @@ let spendingTracker = loadSpending();
 const MAX_PAYMENT = 1000;
 const MAX_ERROR_LENGTH = 500;
 
+function countsTowardDailyLimit(tx: Transaction): boolean {
+  return !['blocked', 'rejected', 'cancelled'].includes(tx.status);
+}
+
 function truncateError(message: string): string {
   return message.replace(/<[^>]*>/g, '').slice(0, MAX_ERROR_LENGTH);
+}
+
+function recordBlockedPayment(
+  type: 'medication' | 'bill',
+  description: string,
+  amount: number,
+  recipient: string,
+  category: PaymentCategory,
+): Transaction {
+  const tx: Transaction = {
+    id: `tx-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    type,
+    description,
+    amount,
+    recipient,
+    status: 'blocked',
+    category,
+  };
+  spendingTracker.transactions.push(tx);
+  agentTransactionsTotal.inc({ status: 'blocked' });
+  appendTransaction(tx);
+  return tx;
 }
 
 function recordServiceFee(
@@ -1191,7 +1218,8 @@ export function checkSpendingPolicy(
           Number.isFinite(txTimestamp) &&
           txTimestamp >= dayStartMs &&
           txTimestamp < dayEndMs &&
-          t.category === category
+          t.category === category &&
+          countsTowardDailyLimit(t)
         );
       },
     )
@@ -1209,7 +1237,7 @@ export function checkSpendingPolicy(
 
   return {
     allowed: true,
-    requiresApproval: amount > policy.approvalThreshold,
+    requiresApproval: amount >= policy.approvalThreshold,
     currentSpending,
     budgetRemaining: remaining - amount,
   };
@@ -1501,9 +1529,17 @@ export async function payForMedication(
       ? 'daily_limit'
       : 'budget';
     policyBlocksTotal.inc({ reason });
+    const tx = recordBlockedPayment(
+      'medication',
+      `${drugName} from ${pharmacyName}`,
+      amount,
+      pharmacyId,
+      TRANSACTION_CATEGORY.MEDICATIONS,
+    );
     return {
       success: false,
       error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}`,
+      transaction: tx,
     };
   }
   if (policyCheck.requiresApproval && !skipApproval) {
@@ -1531,7 +1567,7 @@ export async function payForMedication(
     appendTransaction(tx);
     return {
       success: false,
-      error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} exceeds the $${currentPolicy.approvalThreshold} approval threshold.`,
+      error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} meets or exceeds the $${currentPolicy.approvalThreshold} approval threshold.`,
       transaction: tx,
     };
   }
@@ -1580,7 +1616,7 @@ export async function payForMedication(
   });
 
   // Notify on significant payment (Issue #265)
-  if (amount > currentPolicy.approvalThreshold) {
+  if (amount >= currentPolicy.approvalThreshold) {
     notify({
       level: "info",
       title: "Medication Payment Made",
@@ -1613,9 +1649,17 @@ export async function payBill(
       ? 'daily_limit'
       : 'budget';
     policyBlocksTotal.inc({ reason });
+    const tx = recordBlockedPayment(
+      'bill',
+      `${description} — ${providerName}`,
+      amount,
+      providerId,
+      TRANSACTION_CATEGORY.BILLS,
+    );
     return {
       success: false,
       error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}`,
+      transaction: tx,
     };
   }
   if (policyCheck.requiresApproval && !skipApproval) {
@@ -1643,7 +1687,7 @@ export async function payBill(
     appendTransaction(tx);
     return {
       success: false,
-      error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} exceeds the $${currentPolicy.approvalThreshold} approval threshold.`,
+      error: `REQUIRES CAREGIVER APPROVAL: $${amount.toFixed(2)} meets or exceeds the $${currentPolicy.approvalThreshold} approval threshold.`,
       transaction: tx,
     };
   }
@@ -1730,7 +1774,7 @@ export async function payBill(
   appendTransaction(tx);
 
   // Notify on significant payment (Issue #265)
-  if (amount > currentPolicy.approvalThreshold) {
+  if (amount >= currentPolicy.approvalThreshold) {
     notify({
       level: "info",
       title: "Bill Payment Made",

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -64,7 +64,7 @@ export interface SpendingPolicy {
   monthlyLimit: number;
   medicationMonthlyBudget: number;
   billMonthlyBudget: number;
-  approvalThreshold: number; // require caregiver approval above this amount
+  approvalThreshold: number; // require caregiver approval at or above this amount
   holdTimeSeconds: number; // time before pending approvals auto-approve
   /**
    * IANA timezone string for the caregiver's local day (Issue #207).


### PR DESCRIPTION
## Summary
- add focused policy-boundary integration tests for the exact monthly-budget, daily-limit, and approval-threshold edges requested in #45
- treat payments equal to `approvalThreshold` as approval-required, matching the boundary acceptance criteria
- record policy-blocked medication/bill attempts as `status: blocked` transactions without counting those blocked attempts toward later daily-limit checks

Closes #45

## Validation
- `npm test -- agent/__tests__/policy-boundary.test.ts`
- `npm test -- agent/__tests__/policy-boundary.test.ts agent/__tests__/pay-for-medication.test.ts agent/__tests__/tools.test.ts`
- `npm test -- agent/__tests__/policy-boundary.test.ts --coverage --coverage.include=agent/tools.ts --coverage.reporter=json --coverage.reporter=text`
  - Full-file `agent/tools.ts` coverage is 40.87% because the file contains many unrelated tools.
  - Coverage JSON confirms the target paths are exercised: `checkSpendingPolicy` 7 hits, `payBill` 2 hits, `payForMedication` 1 hit, `recordBlockedPayment` 1 hit, and `countsTowardDailyLimit` 1 hit.
- `git diff --check`

## Notes
- A targeted `tsc` including `agent/tools.ts` still hits pre-existing template-literal type errors around `x402SchemeId` / `createEd25519Signer`; this PR does not touch that code path.
- I also tried a broader nearby agent test command including `pending-approvals` and `mock-network`; it still hits existing test-harness issues around missing `appendFileSync` in old fs mocks and Windows data path setup.