### PR TITLE
Guard dashboard bar percentages

### DIFF
--- a/dashboard/src/__tests__/bar.test.tsx
+++ b/dashboard/src/__tests__/bar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Bar, getBarPercent } from "../components/primitives/bar";
+
+describe("Bar percentage calculation", () => {
+  it.each([
+    ["undefined spent", undefined, 100, 0],
+    ["undefined budget", 25, undefined, 0],
+    ["null spent", null, 100, 0],
+    ["null budget", 25, null, 0],
+    ["NaN spent", Number.NaN, 100, 0],
+    ["NaN budget", 25, Number.NaN, 0],
+    ["Infinity spent", Number.POSITIVE_INFINITY, 100, 0],
+    ["Infinity budget", 25, Number.POSITIVE_INFINITY, 0],
+    ["negative spent", -5, 100, 0],
+    ["over budget", 150, 100, 100],
+    ["normal usage", 25, 100, 25],
+  ])("%s resolves to a finite clamped percent", (_name, spent, budget, expected) => {
+    expect(getBarPercent(spent, budget)).toBe(expected);
+  });
+});
+
+describe("Bar rendering", () => {
+  it("never renders a NaN width when values are missing or invalid", () => {
+    render(<Bar label="Medical Bills" spent={Number.NaN} budget={undefined} />);
+
+    const fill = screen.getByTestId("bar-fill") as HTMLDivElement;
+    expect(fill.style.width).toBe("0%");
+    expect(fill.getAttribute("style")).not.toContain("NaN");
+  });
+
+  it("keeps a visible track even when the fill is clamped to zero", () => {
+    render(<Bar label="Medications" spent={undefined} budget={null} />);
+
+    expect(screen.getByTestId("bar-track").outerHTML).toMatchInlineSnapshot(
+      `"<div class="h-2 bg-slate-100 rounded-full overflow-hidden" data-testid="bar-track"><div class="h-full rounded-full transition-all duration-500 bg-sky-500" data-testid="bar-fill" style="width: 0%;"></div></div>"`,
+    );
+  });
+});

--- a/dashboard/src/components/primitives/bar.tsx
+++ b/dashboard/src/components/primitives/bar.tsx
@@ -1,23 +1,50 @@
 export interface BarProps {
   label: string;
-  spent: number;
-  budget: number;
+  spent?: number | null;
+  budget?: number | null;
+}
+
+function finiteOrZero(value: number | null | undefined): number {
+  const normalized = value ?? 0;
+  return Number.isFinite(normalized) ? normalized : 0;
+}
+
+export function getBarPercent(spent?: number | null, budget?: number | null): number {
+  const safeSpent = finiteOrZero(spent);
+  const safeBudget = finiteOrZero(budget);
+
+  if (safeBudget <= 0) {
+    return 0;
+  }
+
+  const pct = (safeSpent / safeBudget) * 100;
+  if (!Number.isFinite(pct)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(pct, 100));
 }
 
 export function Bar({ label, spent, budget }: BarProps) {
-  const pct = Math.min((spent / budget) * 100, 100);
+  const safeSpent = finiteOrZero(spent);
+  const safeBudget = finiteOrZero(budget);
+  const pct = getBarPercent(spent, budget);
   const color = pct > 90 ? "bg-red-500" : pct > 70 ? "bg-amber-500" : "bg-sky-500";
   return (
     <div>
       <div className="flex items-center justify-between text-xs mb-1">
         <span className="font-medium text-slate-600">{label}</span>
         <span className="text-slate-400">
-          ${spent.toFixed(2)} / ${budget}
+          ${safeSpent.toFixed(2)} / ${safeBudget}
         </span>
       </div>
-      <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+      <div
+        className="h-2 bg-slate-100 rounded-full overflow-hidden"
+        data-testid="bar-track"
+      >
         <div
           className={`h-full rounded-full transition-all duration-500 ${color}`}
+          data-testid="bar-fill"
           style={{ width: `${pct}%` }}
         />
       </div>


### PR DESCRIPTION
## Summary
- make the dashboard `Bar` primitive tolerant of missing, null, NaN, infinite, and negative values
- clamp the computed fill percentage to the finite `[0, 100]` range before writing inline width
- keep the empty track visible and cover the regression with focused Vitest cases plus an inline DOM snapshot

Closes #288

## Validation
- `npm test -- dashboard/src/__tests__/bar.test.tsx`
- `git diff --check`

## Notes
- `cd dashboard && npm run lint` could not run in this checkout because dashboard dependencies are not installed in `dashboard/node_modules`; the focused root Vitest command above covers the changed component.
