### PR TITLE
Retry Friendbot funding setup

### DIFF
--- a/docs/scripts/setup-wallets.md
+++ b/docs/scripts/setup-wallets.md
@@ -9,6 +9,18 @@
 3. Store the `.dev-seed` mnemonic somewhere safe.
 4. Re-run `npm run setup` whenever you need the same test wallets again.
 
+## Friendbot funding reliability
+
+Each generated account is funded through Stellar testnet Friendbot. The setup
+script retries transient Friendbot or Horizon verification failures five times
+with exponential backoff: 1s, 2s, 4s, 8s, and 16s. After Friendbot responds, the
+script loads the account from Horizon and requires a positive native XLM balance
+before continuing to USDC trustline creation.
+
+If all attempts fail, rerun `npm run setup` with the same `.dev-seed` or
+`--seed` value. Wallet derivation is deterministic, so a retry targets the same
+accounts.
+
 ## Using your own seed
 
 Pass a BIP-39 mnemonic directly:

--- a/scripts/__tests__/setup-wallets.test.ts
+++ b/scripts/__tests__/setup-wallets.test.ts
@@ -1,10 +1,12 @@
 import { mkdtempSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deriveWalletsFromSeed,
   DEV_SEED_FILE,
+  FRIENDBOT_RETRY_BACKOFF_MS,
+  fundAccount,
   isMnemonicSeed,
   resolveSetupSeed,
 } from "../setup-wallets.ts";
@@ -79,5 +81,85 @@ describe("setup-wallets seed handling", () => {
         confirmGenerate: async () => false,
       }),
     ).rejects.toThrow(/Aborted/);
+  });
+});
+
+describe("Friendbot funding retries", () => {
+  const publicKey = "GTESTFRIENDBOTACCOUNT";
+  const fundedAccount = {
+    balances: [{ asset_type: "native", balance: "10000.0000000" }],
+  };
+
+  function response(ok: boolean, text = "") {
+    return {
+      ok,
+      text: async () => text,
+    } as Response;
+  }
+
+  it("returns after a successful Friendbot response and Horizon balance verification", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response(true));
+    const server = { loadAccount: vi.fn().mockResolvedValue(fundedAccount) };
+
+    await fundAccount(publicKey, { fetchFn, server });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(server.loadAccount).toHaveBeenCalledWith(publicKey);
+  });
+
+  it("retries transient Friendbot failures with exponential backoff before success", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce(response(false, "temporary unavailable"))
+      .mockResolvedValueOnce(response(true));
+    const server = { loadAccount: vi.fn().mockResolvedValue(fundedAccount) };
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await fundAccount(publicKey, { fetchFn, server, sleep });
+
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 1000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 2000);
+  });
+
+  it("retries until total failure and reports the last Friendbot error", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response(false, "rate limited"));
+    const server = { loadAccount: vi.fn().mockResolvedValue(fundedAccount) };
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(fundAccount(publicKey, { fetchFn, server, sleep })).rejects.toThrow(
+      /after 6 attempts: Friendbot failed.*rate limited/,
+    );
+
+    expect(fetchFn).toHaveBeenCalledTimes(FRIENDBOT_RETRY_BACKOFF_MS.length + 1);
+    expect(sleep).toHaveBeenCalledTimes(FRIENDBOT_RETRY_BACKOFF_MS.length);
+    expect(sleep.mock.calls.map(([delay]) => delay)).toEqual([
+      1000,
+      2000,
+      4000,
+      8000,
+      16000,
+    ]);
+  });
+
+  it("retries when Friendbot responds but Horizon does not show a native balance", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(response(true))
+      .mockResolvedValueOnce(response(true));
+    const server = {
+      loadAccount: vi
+        .fn()
+        .mockResolvedValueOnce({ balances: [] })
+        .mockResolvedValueOnce(fundedAccount),
+    };
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await fundAccount(publicKey, { fetchFn, server, sleep });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(server.loadAccount).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(1000);
   });
 });

--- a/scripts/setup-wallets.ts
+++ b/scripts/setup-wallets.ts
@@ -17,6 +17,7 @@ import { logger } from "../shared/logger.ts";
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 const FRIENDBOT_URL = "https://friendbot.stellar.org";
 const USDC_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+export const FRIENDBOT_RETRY_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000] as const;
 export const DEV_SEED_FILE = ".dev-seed";
 export const WALLET_NAMES = [
   "AGENT",
@@ -34,6 +35,13 @@ export interface WalletInfo {
   name: string;
   publicKey: string;
   secretKey: string;
+}
+
+export interface FundAccountOptions {
+  fetchFn?: typeof fetch;
+  server?: Pick<Horizon.Server, "loadAccount">;
+  sleep?: (ms: number) => Promise<void>;
+  backoffMs?: readonly number[];
 }
 
 function normalizeSeedMaterial(seedMaterial: string) {
@@ -162,15 +170,65 @@ export async function resolveSetupSeed(options: {
   return { seed, source: "generated", path: seedPath };
 }
 
-async function fundAccount(publicKey: string): Promise<void> {
-  const response = await fetch(`${FRIENDBOT_URL}?addr=${publicKey}`);
-  if (!response.ok) {
-    const text = await response.text();
-    // Friendbot returns an error if already funded, which is fine
-    if (!text.includes("createAccountAlreadyExist")) {
-      throw new Error(`Friendbot failed for ${publicKey}: ${text}`);
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function hasNativeBalance(
+  publicKey: string,
+  server: Pick<Horizon.Server, "loadAccount">,
+): Promise<boolean> {
+  const account = await server.loadAccount(publicKey);
+  return account.balances.some(
+    (balance: any) =>
+      balance.asset_type === "native" &&
+      Number.parseFloat(balance.balance ?? "0") > 0,
+  );
+}
+
+export async function fundAccount(
+  publicKey: string,
+  options: FundAccountOptions = {},
+): Promise<void> {
+  const fetchFn = options.fetchFn || fetch;
+  const server = options.server || new Horizon.Server(HORIZON_URL);
+  const sleepFn = options.sleep || sleep;
+  const backoffMs = options.backoffMs || FRIENDBOT_RETRY_BACKOFF_MS;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= backoffMs.length; attempt++) {
+    try {
+      const response = await fetchFn(`${FRIENDBOT_URL}?addr=${publicKey}`);
+      if (!response.ok) {
+        const text = await response.text();
+        // Friendbot returns an error if already funded, which is fine as long
+        // as Horizon confirms the account has native XLM before we continue.
+        if (!text.includes("createAccountAlreadyExist")) {
+          throw new Error(`Friendbot failed for ${publicKey}: ${text}`);
+        }
+      }
+
+      if (await hasNativeBalance(publicKey, server)) {
+        return;
+      }
+
+      throw new Error(`Friendbot did not fund ${publicKey}: native XLM balance missing`);
+    } catch (err) {
+      lastError = err;
+      const delay = backoffMs[attempt];
+      if (delay === undefined) break;
+      logger.warn(
+        { wallet: publicKey.slice(0, 8), attempt: attempt + 1, retryInMs: delay },
+        "Friendbot funding attempt failed; retrying",
+      );
+      await sleepFn(delay);
     }
   }
+
+  const detail = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Friendbot failed for ${publicKey} after ${backoffMs.length + 1} attempts: ${detail}`,
+  );
 }
 
 async function addUsdcTrustline(keypair: Keypair): Promise<void> {


### PR DESCRIPTION
## Summary
- add Friendbot funding retries with 1s, 2s, 4s, 8s, and 16s exponential backoff
- verify each funded account through Horizon native XLM balance before continuing to trustline creation
- make the funding helper injectable for tests and cover success, retry-then-success, Horizon verification retry, and total failure
- document the retry and recovery behavior in `docs/scripts/setup-wallets.md`

Closes #279

## Validation
- `npm test -- scripts/__tests__/setup-wallets.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest scripts/setup-wallets.ts scripts/__tests__/setup-wallets.test.ts`
- `git diff --check`

## Notes
- `npm test -- scripts/__tests__/setup-wallets.test.ts scripts/__tests__/dev.test.ts` still fails in `scripts/__tests__/dev.test.ts` because that existing suite calls `vi.isolateModules`, which is unavailable in the installed Vitest version. The updated setup-wallets suite passes.
