### PR TITLE
Validate LLM tool arguments against schemas

### DIFF
--- a/agent/__tests__/agent-endpoints.test.ts
+++ b/agent/__tests__/agent-endpoints.test.ts
@@ -57,6 +57,19 @@ vi.mock("../../shared/x402-middleware.ts", () => ({
   DEFAULT_FACILITATOR_URL: "https://channels.openzeppelin.com/x402/testnet",
 }));
 
+vi.mock("../../shared/rate-limit.ts", () => {
+  const passThrough = (_req: any, _res: any, next: any) => next();
+  return {
+    rateLimiters: {
+      agent: passThrough,
+      x402: passThrough,
+      health: passThrough,
+      default: passThrough,
+    },
+    rateLimitHitsTotal: { inc: vi.fn() },
+  };
+});
+
 vi.mock("@stellar/stellar-sdk", () => ({
   Keypair: { fromSecret: vi.fn(() => ({ publicKey: () => "GMOCKAGENTWALLETPUBKEY123456" })) },
   Horizon: { Server: vi.fn(() => ({ loadAccount: vi.fn() })) },
@@ -189,6 +202,48 @@ describe("POST /agent/run — validation (Issue #42)", () => {
     expect(res.body.toolCalls).toHaveLength(1);
     expect(res.body.toolCalls[0].tool).toBe("get_spending_summary");
     expect(res.body.response).toBe("Task complete.");
+  });
+
+  it("returns a typed tool error when LLM tool arguments are malformed JSON", async () => {
+    createMock.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call-bad-json",
+                type: "function",
+                function: { name: "get_spending_summary", arguments: "{bad-json" },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    });
+    createMock.mockResolvedValueOnce({
+      choices: [
+        {
+          message: { role: "assistant", content: "Retried after tool error.", tool_calls: undefined },
+          finish_reason: "stop",
+        },
+      ],
+    });
+
+    const res = await auth(request(app).post("/agent/run"))
+      .send({ task: "What is the current spending summary?" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.toolCalls).toHaveLength(1);
+    expect(res.body.toolCalls[0].result).toMatchObject({
+      ok: false,
+      reason: "INVALID_TOOL_ARGUMENTS",
+      tool: "get_spending_summary",
+      message: "Tool arguments must be valid JSON.",
+    });
+    expect(res.body.response).toBe("Retried after tool error.");
   });
 });
 

--- a/agent/__tests__/tool-schema-validation.test.ts
+++ b/agent/__tests__/tool-schema-validation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.hoisted(() => {
   process.env.MOCK_NETWORK = "1";
-  process.env.AGENT_SECRET_KEY = "test-agent-secret";
+  process.env.AGENT_SECRET_KEY = "SCZANGBA5YHTNYVS23C4QSOT45PZCBL2D4ZO5TSRE73UFYS3FMAJNMX";
 });
 
 vi.mock("@stellar/stellar-sdk", () => ({
@@ -29,9 +29,101 @@ vi.mock("@stellar/stellar-sdk", () => ({
   },
 }));
 
-const { TOOL_DEFINITIONS, validateToolInput } = await import("../tools.ts");
+const { TOOL_DEFINITIONS, ToolInputValidationError, validateToolInput } = await import("../tools.ts");
+
+const validToolInputs: Record<string, Record<string, unknown>> = {
+  compare_pharmacy_prices: {
+    drug_name: "Lisinopril",
+    dosage: "10mg",
+    zip_code: "90210",
+    recipient_id: "rosa",
+  },
+  audit_medical_bill: {
+    line_items_json: JSON.stringify([
+      { description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: 130 },
+    ]),
+    recipient_id: "rosa",
+  },
+  check_drug_interactions: {
+    medications: ["Lisinopril", "Ibuprofen"],
+    recipient_id: "rosa",
+  },
+  fetch_tool_result: {
+    result_id: "tool-result-123",
+    offset: 0,
+    limit: 10,
+  },
+  pay_for_medication: {
+    pharmacy_id: "pharmacy-1",
+    pharmacy_name: "Care Pharmacy",
+    drug_name: "Metformin",
+    amount: 12.5,
+    days_supply: 30,
+    recipient_id: "rosa",
+  },
+  pay_bill: {
+    provider_id: "provider-1",
+    provider_name: "Care Hospital",
+    description: "Copay",
+    amount: 25,
+    recipient_id: "rosa",
+  },
+  check_spending_policy: {
+    amount: 25,
+    category: "bills",
+    recipient_id: "rosa",
+  },
+  fetch_rosa_bill: {},
+  fetch_and_audit_bill: {
+    recipient_id: "rosa",
+  },
+  get_spending_summary: {
+    recipient_id: "rosa",
+  },
+  get_wallet_balance: {},
+  generate_dispute_letter: {
+    bill_id: "bill-123",
+    audit_result_json: JSON.stringify({ totalOvercharge: 25, errorCount: 1, lineItems: [] }),
+    error_descriptions: ["Duplicate charge"],
+    recipient_name: "Rosa Garcia",
+    facility: "Care Hospital",
+    caregiver_name: "Maria Garcia",
+    caregiver_email: "maria@example.com",
+    recipient_id: "rosa",
+  },
+  get_adherence_status: {
+    recipient_id: "rosa",
+  },
+  confirm_adherence: {
+    record_id: "record-123",
+  },
+};
+
+const wrongTypeInputs: Record<string, unknown> = {
+  compare_pharmacy_prices: { ...validToolInputs.compare_pharmacy_prices, drug_name: 123 },
+  audit_medical_bill: { ...validToolInputs.audit_medical_bill, line_items_json: 42 },
+  check_drug_interactions: { ...validToolInputs.check_drug_interactions, medications: "Lisinopril" },
+  fetch_tool_result: { ...validToolInputs.fetch_tool_result, result_id: 123 },
+  pay_for_medication: { ...validToolInputs.pay_for_medication, pharmacy_id: 123 },
+  pay_bill: { ...validToolInputs.pay_bill, provider_id: 123 },
+  check_spending_policy: { ...validToolInputs.check_spending_policy, category: "groceries" },
+  fetch_rosa_bill: [],
+  fetch_and_audit_bill: { recipient_id: 123 },
+  get_spending_summary: { recipient_id: 123 },
+  get_wallet_balance: [],
+  generate_dispute_letter: { ...validToolInputs.generate_dispute_letter, audit_result_json: 42 },
+  get_adherence_status: { recipient_id: 123 },
+  confirm_adherence: { record_id: 123 },
+};
 
 describe("tool schema strictness", () => {
+  it("has a validation fixture for every tool definition", () => {
+    const toolNames = TOOL_DEFINITIONS.map((tool) => tool.name).sort();
+
+    expect(Object.keys(validToolInputs).sort()).toEqual(toolNames);
+    expect(Object.keys(wrongTypeInputs).sort()).toEqual(toolNames);
+  });
+
   it("sets additionalProperties:false on every object tool schema", () => {
     for (const tool of TOOL_DEFINITIONS) {
       expect(tool.input_schema.type).toBe("object");
@@ -50,11 +142,47 @@ describe("tool schema strictness", () => {
   });
 
   it("rejects unknown LLM tool fields with a clear message", () => {
-    expect(() =>
+    for (const tool of TOOL_DEFINITIONS) {
+      expect(() =>
+        validateToolInput(tool.name, {
+          ...validToolInputs[tool.name],
+          unexpected: "ignored-before",
+        }),
+      ).toThrow(/unknown field\(s\) not allowed: unexpected/);
+    }
+  });
+
+  it("rejects missing required fields for every tool that declares them", () => {
+    for (const tool of TOOL_DEFINITIONS) {
+      for (const requiredField of tool.input_schema.required) {
+        const input = { ...validToolInputs[tool.name] };
+        delete input[requiredField];
+
+        expect(() => validateToolInput(tool.name, input)).toThrow(ToolInputValidationError);
+      }
+    }
+  });
+
+  it("rejects wrong-type arguments for every tool", () => {
+    for (const tool of TOOL_DEFINITIONS) {
+      expect(() => validateToolInput(tool.name, wrongTypeInputs[tool.name])).toThrow(
+        ToolInputValidationError,
+      );
+    }
+  });
+
+  it("returns typed validation errors for the agent loop", () => {
+    try {
       validateToolInput("get_spending_summary", {
-        recipient_id: "rosa",
-        unexpected: "ignored-before",
-      }),
-    ).toThrow(/unknown field\(s\) not allowed: unexpected/);
+        recipient_id: 123,
+      });
+      throw new Error("Expected validateToolInput to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolInputValidationError);
+      expect(err).toMatchObject({
+        reason: "INVALID_TOOL_ARGUMENTS",
+        issues: expect.arrayContaining([expect.stringContaining("recipient_id")]),
+      });
+    }
   });
 });

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -165,6 +165,34 @@ const LLM_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] = TOOL_DEFINITIONS
 
 type ToolResult = Record<string, unknown>;
 
+function invalidToolArgumentsResult(
+  tool: string,
+  message: string,
+  details: Record<string, unknown> = {},
+): ToolResult {
+  return {
+    ok: false,
+    reason: "INVALID_TOOL_ARGUMENTS",
+    tool,
+    message,
+    ...details,
+  };
+}
+
+function toolErrorResult(tool: string, err: any): ToolResult {
+  if (err?.reason === "INVALID_TOOL_ARGUMENTS" || err?.reason === "UNKNOWN_TOOL") {
+    return {
+      ok: false,
+      reason: err.reason,
+      tool,
+      message: err.message,
+      issues: Array.isArray(err.issues) ? err.issues : [],
+    };
+  }
+
+  return { error: err?.message || String(err) };
+}
+
 async function executeTool(name: string, input: Record<string, unknown>): Promise<ToolResult> {
   try {
     input = validateToolInput(name, input);
@@ -400,23 +428,43 @@ async function runAgent(task: string) {
     for (const toolCall of message.tool_calls) {
       if (toolCall.type !== "function") continue;
       const fnName = toolCall.function.name;
-      let fnArgs: any;
+      let fnArgs: Record<string, unknown> = {};
+      let parseErrorResult: ToolResult | undefined;
       try {
-        fnArgs = JSON.parse(toolCall.function.arguments);
-      } catch {
-        fnArgs = {};
+        const parsedArgs = JSON.parse(toolCall.function.arguments || "{}");
+        if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
+          parseErrorResult = invalidToolArgumentsResult(
+            fnName,
+            "Tool arguments must be a JSON object.",
+            { receivedType: Array.isArray(parsedArgs) ? "array" : typeof parsedArgs },
+          );
+        } else {
+          fnArgs = parsedArgs as Record<string, unknown>;
+        }
+      } catch (err: any) {
+        parseErrorResult = invalidToolArgumentsResult(
+          fnName,
+          "Tool arguments must be valid JSON.",
+          { error: err?.message || String(err) },
+        );
       }
 
       logger.info({ tool: fnName, args: JSON.stringify(fnArgs).slice(0, 100) }, "tool call");
 
       let result: ToolResult;
-      try {
-        result = await executeTool(fnName, fnArgs);
+      if (parseErrorResult) {
+        result = parseErrorResult;
+        agentToolCallsTotal.inc({ tool: fnName, status: "error" });
         toolCalls.push({ tool: fnName, input: fnArgs, result });
-      } catch (err: any) {
-        logger.error({ tool: fnName, err: err.message }, "tool error");
-        result = { error: err.message };
-        toolCalls.push({ tool: fnName, input: fnArgs, result });
+      } else {
+        try {
+          result = await executeTool(fnName, fnArgs);
+          toolCalls.push({ tool: fnName, input: fnArgs, result });
+        } catch (err: any) {
+          logger.error({ tool: fnName, err: err?.message || err }, "tool error");
+          result = toolErrorResult(fnName, err);
+          toolCalls.push({ tool: fnName, input: fnArgs, result });
+        }
       }
 
       appendAuditEntry({

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -28,6 +28,8 @@
 
 import 'dotenv/config';
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, renameSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { z } from 'zod';
 import { logger } from '../shared/logger.ts';
 import { resolveStellarNetwork, validateSignerKeyForNetwork } from '../shared/stellar-network.ts';
@@ -320,7 +322,7 @@ export function getMppClient(): MppClientInstance {
 }
 
 // --- Per-recipient data directories (Issue #261) ---
-const DATA_DIR = new URL('../data', import.meta.url).pathname;
+const DATA_DIR = join(dirname(fileURLToPath(import.meta.url)), '../data');
 
 let currentRecipientId = 'rosa';
 
@@ -1991,33 +1993,20 @@ const TOOL_INPUT_SCHEMAS = {
   }).strict(),
 } as const;
 
-export function validateToolInput(
-  name: string,
-  input: unknown,
-): Record<string, unknown> {
-  const schema = TOOL_INPUT_SCHEMAS[name as keyof typeof TOOL_INPUT_SCHEMAS];
-  if (!schema) {
-    throw new Error(`Unknown tool: ${name}`);
-  }
+export class ToolInputValidationError extends Error {
+  readonly reason: 'INVALID_TOOL_ARGUMENTS' | 'UNKNOWN_TOOL';
+  readonly issues: string[];
 
-  const result = schema.safeParse(input ?? {});
-  if (result.success) {
-    return result.data as Record<string, unknown>;
+  constructor(
+    message: string,
+    issues: string[] = [],
+    reason: 'INVALID_TOOL_ARGUMENTS' | 'UNKNOWN_TOOL' = 'INVALID_TOOL_ARGUMENTS',
+  ) {
+    super(message);
+    this.name = 'ToolInputValidationError';
+    this.reason = reason;
+    this.issues = issues;
   }
-
-  const unknownKeys = result.error.issues
-    .filter((issue) => issue.code === 'unrecognized_keys')
-    .flatMap((issue) => (issue as z.ZodUnrecognizedKeysIssue).keys);
-  if (unknownKeys.length > 0) {
-    throw new Error(
-      `Invalid tool input for ${name}: unknown field(s) not allowed: ${unknownKeys.join(', ')}`,
-    );
-  }
-
-  const details = result.error.issues
-    .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
-    .join('; ');
-  throw new Error(`Invalid tool input for ${name}: ${details}`);
 }
 
 function strictInputSchema<
@@ -2030,10 +2019,12 @@ function strictInputSchema<
   return { ...schema, additionalProperties: false };
 }
 
-// Claude API tool definitions
-export const TOOL_DEFINITIONS = [
+// Claude API tool definitions are generated from this registry so validation
+// and provider-facing schemas cannot drift into separate tool lists.
+const TOOL_REGISTRY = [
   {
     name: 'compare_pharmacy_prices',
+    schema: TOOL_INPUT_SCHEMAS.compare_pharmacy_prices,
     description:
       'Compare medication prices across multiple pharmacies. Pays $0.002 USDC per query via x402 on Stellar. Pass the medication dosage exactly as known; the returned dosage field is reliable and echoed from the request for safety. Returns prices sorted cheapest to most expensive, with potential savings. Each pharmacy has an inStock field: "unknown" means real-time inventory is unavailable (proceed with caution), true means in stock. Never assume a medication is in stock if inStock is "unknown" — confirm with the pharmacy before ordering.',
     input_schema: strictInputSchema({
@@ -2049,6 +2040,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'audit_medical_bill',
+    schema: TOOL_INPUT_SCHEMAS.audit_medical_bill,
     description:
       'Audit a medical bill for errors (duplicates, upcoding, overcharges). 80% of medical bills contain errors. Pays $0.01 USDC per audit via x402 on Stellar. Pass line_items_json as a JSON string array of line items. Each line item must include description, cptCode, quantity, and chargedAmount. cptCode must match /^(?:\\d{5}|J\\d{4})$/, quantity must be > 0, and chargedAmount must be > 0.',
     input_schema: strictInputSchema({
@@ -2065,6 +2057,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'check_drug_interactions',
+    schema: TOOL_INPUT_SCHEMAS.check_drug_interactions,
     description:
       'Check for drug-drug interactions. Pays $0.001 USDC per check via x402 on Stellar. Requires at least 2 medications; if fewer are supplied, the tool returns NEED_AT_LEAST_TWO_MEDS instead of claiming there are no interactions. Returns severity levels and clinical recommendations.',
     input_schema: strictInputSchema({
@@ -2082,6 +2075,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'fetch_tool_result',
+    schema: TOOL_INPUT_SCHEMAS.fetch_tool_result,
     description:
       'Fetch the remainder of a previously truncated tool result by result_id. Use this when a tool response includes resultId, summary, or hasMore=true and you need the full data before concluding.',
     input_schema: strictInputSchema({
@@ -2096,6 +2090,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'pay_for_medication',
+    schema: TOOL_INPUT_SCHEMAS.pay_for_medication,
     description:
       'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits. Amount must be between $0.01 and $10,000.',
     input_schema: strictInputSchema({
@@ -2113,6 +2108,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'pay_bill',
+    schema: TOOL_INPUT_SCHEMAS.pay_bill,
     description:
       'Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount. Amount must be between $0.01 and $10,000.',
     input_schema: strictInputSchema({
@@ -2129,6 +2125,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'check_spending_policy',
+    schema: TOOL_INPUT_SCHEMAS.check_spending_policy,
     description:
       'Check if a payment amount is within the caregiver-set spending policy limits before attempting payment.',
     input_schema: strictInputSchema({
@@ -2143,6 +2140,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'fetch_rosa_bill',
+    schema: TOOL_INPUT_SCHEMAS.fetch_rosa_bill,
     description:
       "Fetch the current care recipient's hospital bill. Returns the bill with line items including CPT codes and charged amounts.",
     input_schema: strictInputSchema({
@@ -2153,6 +2151,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'fetch_and_audit_bill',
+    schema: TOOL_INPUT_SCHEMAS.fetch_and_audit_bill,
     description:
       "Fetch the care recipient's hospital bill AND audit it for errors in one step. Pays $0.01 USDC via x402. Returns the audit results with errors found, overcharges, and corrected total. Use this instead of calling fetch_bill + audit_medical_bill separately.",
     input_schema: strictInputSchema({
@@ -2165,6 +2164,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'get_spending_summary',
+    schema: TOOL_INPUT_SCHEMAS.get_spending_summary,
     description:
       'Get current spending summary: total spent, budget remaining per category, recent transactions with Stellar tx hashes for the current care recipient.',
     input_schema: strictInputSchema({
@@ -2177,6 +2177,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'get_wallet_balance',
+    schema: TOOL_INPUT_SCHEMAS.get_wallet_balance,
     description:
       'Get the current on-chain wallet balance (USDC and XLM) from Stellar Horizon. Returns real-time balance data. If usdcTrustlineMissing is true, the agent wallet lacks a USDC trustline — instruct the caregiver to fund the wallet at https://faucet.circle.com.',
     input_schema: strictInputSchema({
@@ -2187,6 +2188,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'generate_dispute_letter',
+    schema: TOOL_INPUT_SCHEMAS.generate_dispute_letter,
     description:
       'Generate a dispute letter PDF and email body for a billing error. Use after audit finds overcharges. Letter includes audit findings, CPT codes, fair-market rates, and caregiver contact info.',
     input_schema: strictInputSchema({
@@ -2206,6 +2208,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'get_adherence_status',
+    schema: TOOL_INPUT_SCHEMAS.get_adherence_status,
     description:
       'Get medication adherence status for a recipient — pending reminders, confirmed doses, skipped doses, and flagged persistent skips.',
     input_schema: strictInputSchema({
@@ -2218,6 +2221,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'confirm_adherence',
+    schema: TOOL_INPUT_SCHEMAS.confirm_adherence,
     description:
       'Confirm that a medication dose was taken. Call this when the caregiver reports the recipient took their medication.',
     input_schema: strictInputSchema({
@@ -2228,7 +2232,48 @@ export const TOOL_DEFINITIONS = [
       required: ['record_id'],
     }),
   },
-];
+] as const;
+
+export const TOOL_DEFINITIONS = TOOL_REGISTRY.map(({ schema: _schema, ...tool }) => tool);
+
+const TOOL_INPUT_SCHEMA_BY_NAME = new Map<string, z.ZodTypeAny>(
+  TOOL_REGISTRY.map((tool) => [tool.name, tool.schema]),
+);
+
+export function validateToolInput(
+  name: string,
+  input: unknown,
+): Record<string, unknown> {
+  const schema = TOOL_INPUT_SCHEMA_BY_NAME.get(name);
+  if (!schema) {
+    throw new ToolInputValidationError(
+      `Unknown tool: ${name}`,
+      [],
+      'UNKNOWN_TOOL',
+    );
+  }
+
+  const result = schema.safeParse(input ?? {});
+  if (result.success) {
+    return result.data as Record<string, unknown>;
+  }
+
+  const unknownKeys = result.error.issues
+    .filter((issue) => issue.code === 'unrecognized_keys')
+    .flatMap((issue) => (issue as z.ZodUnrecognizedKeysIssue).keys);
+  if (unknownKeys.length > 0) {
+    const issue = `unknown field(s) not allowed: ${unknownKeys.join(', ')}`;
+    throw new ToolInputValidationError(`Invalid tool input for ${name}: ${issue}`, [issue]);
+  }
+
+  const issues = result.error.issues.map(
+    (issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`,
+  );
+  throw new ToolInputValidationError(
+    `Invalid tool input for ${name}: ${issues.join('; ')}`,
+    issues,
+  );
+}
 
 // Start scanner (runs in-process). Interval is conservative (5s).
 const pendingTransactionScanner = setInterval(() => {

--- a/server.ts
+++ b/server.ts
@@ -17,6 +17,8 @@ import { Mppx, Store } from "mppx/server";
 import { stellar } from "@stellar/mpp/charge/server";
 import { USDC_SAC_TESTNET } from "@stellar/mpp";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { z } from "zod";
 
 // x402 middleware
@@ -765,7 +767,7 @@ app.get("/drug/interactions", (req, res) => {
 // MPP PHARMACY PAYMENT (was port 3005)
 // ============================================================
 
-const DATA_DIR = new URL("./data", import.meta.url).pathname;
+const DATA_DIR = join(dirname(fileURLToPath(import.meta.url)), "data");
 const ORDERS_FILE = `${DATA_DIR}/orders.json`;
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
@@ -896,6 +898,34 @@ const LLM_TOOLS: OpenAI.Chat.Completions.ChatCompletionTool[] =
     },
   }));
 
+function invalidToolArgumentsResult(
+  tool: string,
+  message: string,
+  details: Record<string, unknown> = {},
+) {
+  return {
+    ok: false,
+    reason: "INVALID_TOOL_ARGUMENTS",
+    tool,
+    message,
+    ...details,
+  };
+}
+
+function toolErrorResult(tool: string, err: any) {
+  if (err?.reason === "INVALID_TOOL_ARGUMENTS" || err?.reason === "UNKNOWN_TOOL") {
+    return {
+      ok: false,
+      reason: err.reason,
+      tool,
+      message: err.message,
+      issues: Array.isArray(err.issues) ? err.issues : [],
+    };
+  }
+
+  return { error: err?.message || String(err) };
+}
+
 async function executeTool(name: string, input: any): Promise<any> {
   let result: any;
   try {
@@ -1019,21 +1049,41 @@ async function runAgent(task: string) {
 
     for (const tc of choice.message.tool_calls) {
       if (tc.type !== "function") continue;
-      let args: any;
+      let args: Record<string, unknown> = {};
+      let parseErrorResult: Record<string, unknown> | undefined;
       try {
-        args = JSON.parse(tc.function.arguments);
-      } catch {
-        args = {};
+        const parsedArgs = JSON.parse(tc.function.arguments || "{}");
+        if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
+          parseErrorResult = invalidToolArgumentsResult(
+            tc.function.name,
+            "Tool arguments must be a JSON object.",
+            { receivedType: Array.isArray(parsedArgs) ? "array" : typeof parsedArgs },
+          );
+        } else {
+          args = parsedArgs as Record<string, unknown>;
+        }
+      } catch (err: any) {
+        parseErrorResult = invalidToolArgumentsResult(
+          tc.function.name,
+          "Tool arguments must be valid JSON.",
+          { error: err?.message || String(err) },
+        );
       }
       logger.info({ tool: tc.function.name, args: JSON.stringify(args).slice(0, 100) }, "tool call");
       let result: any;
-      try {
-        result = await executeTool(tc.function.name, args);
+      if (parseErrorResult) {
+        result = parseErrorResult;
+        agentToolCallsTotal.inc({ tool: tc.function.name, status: "error" });
         toolCalls.push({ tool: tc.function.name, input: args, result });
-      } catch (err: any) {
-        logger.error({ tool: tc.function.name, err: err.message }, "tool error");
-        result = { error: err.message };
-        toolCalls.push({ tool: tc.function.name, input: args, result });
+      } else {
+        try {
+          result = await executeTool(tc.function.name, args);
+          toolCalls.push({ tool: tc.function.name, input: args, result });
+        } catch (err: any) {
+          logger.error({ tool: tc.function.name, err: err?.message || err }, "tool error");
+          result = toolErrorResult(tc.function.name, err);
+          toolCalls.push({ tool: tc.function.name, input: args, result });
+        }
       }
 
       appendAuditEntry({
@@ -1103,20 +1153,40 @@ app.get("/agent/transactions", (req, res) => {
     },
   });
 });
-app.post("/agent/policy", (req, res) => {
-  const body = req.body;
-  if (!body || typeof body !== "object") {
-    return res.status(400).json({ error: "Invalid policy" });
-  }
-  const fields = ["dailyLimit", "monthlyLimit", "medicationMonthlyBudget", "billMonthlyBudget", "approvalThreshold"] as const;
+
+function validatePolicyPayload(body: any): { ok: true; policy: any } | { ok: false; errors: string[] } {
   const errors: string[] = [];
+  if (!body || typeof body !== "object") return { ok: false, errors: ["body must be a JSON object"] };
+  const fields = ["dailyLimit", "monthlyLimit", "medicationMonthlyBudget", "billMonthlyBudget", "approvalThreshold"] as const;
   for (const f of fields) {
     const v = body[f];
-    if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) errors.push(`${f} must be a positive finite number`);
+    if (typeof v !== "number" || !Number.isFinite(v)) errors.push(`${f} must be a finite number`);
+    else if (v <= 0) errors.push(`${f} must be greater than 0`);
   }
-  if (errors.length > 0) return res.status(400).json({ error: "Invalid policy", details: errors });
-  setSpendingPolicy(body);
-  res.json({ success: true, policy: body });
+  if (typeof body.dailyLimit === "number" && typeof body.monthlyLimit === "number" && body.dailyLimit > body.monthlyLimit) {
+    errors.push("dailyLimit cannot exceed monthlyLimit");
+  }
+  if (typeof body.approvalThreshold === "number" && typeof body.dailyLimit === "number" && body.approvalThreshold > body.dailyLimit) {
+    errors.push("approvalThreshold cannot exceed dailyLimit");
+  }
+  if (
+    typeof body.medicationMonthlyBudget === "number" &&
+    typeof body.billMonthlyBudget === "number" &&
+    typeof body.monthlyLimit === "number" &&
+    body.medicationMonthlyBudget + body.billMonthlyBudget > body.monthlyLimit
+  ) {
+    errors.push("medicationMonthlyBudget + billMonthlyBudget cannot exceed monthlyLimit");
+  }
+  if (errors.length > 0) return { ok: false, errors };
+  const policy = Object.fromEntries(fields.map((f) => [f, body[f]]));
+  return { ok: true, policy };
+}
+
+app.post("/agent/policy", (req, res) => {
+  const result = validatePolicyPayload(req.body);
+  if (!result.ok) return res.status(400).json({ error: "Invalid policy", details: result.errors });
+  setSpendingPolicy(result.policy);
+  res.json({ success: true, policy: result.policy });
 });
 app.post("/agent/reset", (_req, res) => {
   resetSpendingTracker();

--- a/shared/adherence.ts
+++ b/shared/adherence.ts
@@ -7,8 +7,10 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
-const DATA_DIR = new URL("../data", import.meta.url).pathname;
+const DATA_DIR = join(dirname(fileURLToPath(import.meta.url)), "../data");
 const ADHERENCE_FILE = `${DATA_DIR}/adherence.jsonl`;
 
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });

--- a/shared/audit-log.ts
+++ b/shared/audit-log.ts
@@ -4,9 +4,11 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, statSync, unlinkSync, renameSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { Router, Request, Response } from "express";
 
-const DATA_DIR = new URL("../data", import.meta.url).pathname;
+const DATA_DIR = join(dirname(fileURLToPath(import.meta.url)), "../data");
 const AUDIT_FILE = `${DATA_DIR}/audit.log.jsonl`;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const MAX_ARCHIVES = 12;


### PR DESCRIPTION
Closes #277

## Summary
- Centralize the agent tool registry so exported tool definitions are generated from entries that carry their zod validation schema.
- Return typed `INVALID_TOOL_ARGUMENTS` results to the LLM for malformed JSON and schema validation failures in both agent entrypoints.
- Expand schema tests across every tool for extra fields, missing required fields, and wrong-type inputs.
- Use `fileURLToPath` for data directories touched by the tests, and align root server policy validation with the agent server.

## Testing
- `npm test -- agent/__tests__/tool-schema-validation.test.ts agent/__tests__/agent-endpoints.test.ts`
- `git diff --check`

Additional checks attempted:
- `npm test -- agent/__tests__/tool-call-cap.test.ts` is blocked by an existing test mock missing `auditRouter` from `shared/audit-log.ts`.
- Targeted `npx tsc --noEmit ...` is blocked by existing unrelated type errors in x402 signer typing, SQLite `DatabaseSync`, and `shared/rate-limit.ts`.
