### PR TITLE
Retry payBill after tx_bad_seq

### DIFF
--- a/agent/__tests__/timebounds.test.ts
+++ b/agent/__tests__/timebounds.test.ts
@@ -1,5 +1,6 @@
 /**
  * Tests for issue #284 — STELLAR_TIMEBOUNDS_SECONDS env var and tx_too_late retry.
+ * Also covers issue #282 — rebuilding payBill transactions after tx_bad_seq.
  */
 
 const { mockSubmit, mockSetTimeout, mockBuild, mockLoadAccount } = vi.hoisted(() => {
@@ -68,6 +69,7 @@ vi.mock("mppx/client", () => ({
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { payBill } from "../tools.ts";
+import { registry } from "../../shared/metrics.ts";
 
 describe("#284 Stellar timebounds", () => {
   beforeEach(() => {
@@ -92,7 +94,36 @@ describe("#284 Stellar timebounds", () => {
     expect(mockLoadAccount).toHaveBeenCalledTimes(2);
     expect(mockSubmit).toHaveBeenCalledTimes(2);
     expect(result.success).toBe(true);
-    expect(result.transaction.stellarTxHash).toBe("RETRYHASH");
+    expect(result.transaction?.stellarTxHash).toBe("RETRYHASH");
+  });
+
+  it("reloads account and retries on tx_bad_seq", async () => {
+    mockLoadAccount
+      .mockResolvedValueOnce({ id: "GPUB123", sequence: "1", balances: [] })
+      .mockResolvedValueOnce({ id: "GPUB123", sequence: "2", balances: [] });
+    mockSubmit
+      .mockRejectedValueOnce(new Error("tx_bad_seq"))
+      .mockResolvedValueOnce({ hash: "SEQRETRYHASH" });
+
+    const result = await payBill("provider-1", "Hospital", "ER Visit", 5, true);
+
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+    expect(mockBuild).toHaveBeenCalledTimes(2);
+    expect(mockSubmit).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+    expect(result.transaction?.stellarTxHash).toBe("SEQRETRYHASH");
+    await expect(registry.metrics()).resolves.toMatch(/paybill_seq_retry_total\s+[1-9]/);
+  });
+
+  it("surfaces tx_bad_seq after retries are exhausted", async () => {
+    mockSubmit.mockRejectedValue(new Error("tx_bad_seq"));
+
+    const result = await payBill("provider-1", "Hospital", "ER Visit", 5, true);
+
+    expect(mockLoadAccount).toHaveBeenCalledTimes(3);
+    expect(mockSubmit).toHaveBeenCalledTimes(3);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/tx_bad_seq/);
   });
 
   it("gives up after retry if tx_too_late persists", async () => {

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -74,6 +74,7 @@ import {
   x402SettlementsTotal,
   paymentsUsdcTotal,
   stellarTxSubmittedTotal,
+  paybillSeqRetryTotal,
   policyBlocksTotal,
   agentSpendingUsd,
   agentTransactionsTotal,
@@ -153,7 +154,8 @@ async function submitTransactionWithRetry(
   tx: any,
   maxRetries = 2,
   timeoutMs = 35000,
-  rebuildTx?: () => Promise<any>
+  rebuildTx?: () => Promise<any>,
+  onRebuildRetry?: (reason: string, attempt: number) => void,
 ): Promise<any> {
   let lastError: any;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -164,9 +166,16 @@ async function submitTransactionWithRetry(
       lastError = err;
       if (err?.response?.status) throw err;
       const msg = err?.message ?? "";
-      // tx_too_late: timebounds expired — retry once with fresh timebounds if rebuild fn provided
-      if (msg.includes("tx_too_late") && rebuildTx && attempt < maxRetries) {
-        logger.warn({ attempt: attempt + 1 }, "[Stellar] tx_too_late, rebuilding with fresh timebounds");
+      const rebuildReason = msg.includes("tx_bad_seq")
+        ? "tx_bad_seq"
+        : msg.includes("tx_too_late")
+          ? "tx_too_late"
+          : undefined;
+      // tx_bad_seq: sequence stale; tx_too_late: timebounds expired.
+      // Rebuild with a freshly loaded account/timebounds when the caller can do so.
+      if (rebuildReason && rebuildTx && attempt < maxRetries) {
+        logger.warn({ attempt: attempt + 1 }, `[Stellar] ${rebuildReason}, rebuilding transaction`);
+        onRebuildRetry?.(rebuildReason, attempt + 1);
         tx = await rebuildTx();
         continue;
       }
@@ -1693,7 +1702,16 @@ export async function payBill(
     let stellarTx = await buildStellarTx();
     console.log(`  [Stellar] Signer verified: ${agentKeypair.publicKey().slice(0, 8)}...`);
 
-    const result = await submitTransactionWithRetry(horizonServer, stellarTx, 2, 35000, buildStellarTx);
+    const result = await submitTransactionWithRetry(
+      horizonServer,
+      stellarTx,
+      2,
+      35000,
+      buildStellarTx,
+      (reason) => {
+        if (reason === "tx_bad_seq") paybillSeqRetryTotal.inc();
+      },
+    );
 
     stellarTxHash = result.hash;
     logger.info({ txHash: stellarTxHash, fee: result.fee }, '[Stellar] TX confirmed');

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -50,6 +50,12 @@ export const stellarTxSubmittedTotal = new Counter({
   registers: [registry],
 });
 
+export const paybillSeqRetryTotal = new Counter({
+  name: "paybill_seq_retry_total",
+  help: "Total payBill retries after Horizon tx_bad_seq responses",
+  registers: [registry],
+});
+
 export const policyBlocksTotal = new Counter({
   name: "policy_blocks_total",
   help: "Total spending policy blocks",


### PR DESCRIPTION
Closes #282

## Summary
- Rebuild and resubmit payBill Stellar transactions when Horizon returns `tx_bad_seq`, so stale sequence numbers get a fresh account load before retrying.
- Keep the existing `tx_too_late` rebuild behavior and share the same bounded retry path.
- Add `paybill_seq_retry_total` for sequence retry visibility.
- Extend the timebounds/payBill tests to cover successful `tx_bad_seq` retry and exhausted retries.

## Testing
- `npm test -- agent/__tests__/timebounds.test.ts`
- `git diff --check`

Additional check attempted:
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest agent/tools.ts agent/__tests__/timebounds.test.ts shared/metrics.ts` is still blocked by existing x402 template-literal type errors in `agent/tools.ts`.
