### PR TITLE
Handle malformed agent JSON responses

### DIFF
--- a/agent/__tests__/pay-for-medication.test.ts
+++ b/agent/__tests__/pay-for-medication.test.ts
@@ -65,6 +65,7 @@ import {
   payForMedication,
   payBill,
   checkSpendingPolicy,
+  getSpendingTracker,
   resetSpendingTracker,
   setSpendingPolicy,
 } from "../tools.ts";
@@ -173,6 +174,29 @@ describe("payForMedication — MPP failure (Issue #35)", () => {
     const r = await payForMedication("p1", "Pharma", "Drug", 50);
     expect(r.success).toBe(false);
     expect(r.error).toContain("MPP payment failed");
+  });
+
+  it("returns a structured malformed-response rejection without debiting spending", async () => {
+    mockMppFetch.mockResolvedValueOnce({
+      json: async () => {
+        throw new SyntaxError("Unexpected token '<'");
+      },
+      text: async () => "<html>gateway error</html>",
+      headers: { get: () => null },
+    });
+
+    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    const tracker = getSpendingTracker();
+
+    expect(r).toMatchObject({
+      success: false,
+      ok: false,
+      reason: "MALFORMED_RESPONSE",
+    });
+    expect(r.error).toContain("malformed response");
+    expect((r as any).responsePreview).toContain("gateway error");
+    expect(tracker.medications).toBe(0);
+    expect(tracker.transactions).toHaveLength(0);
   });
 });
 

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -629,6 +629,44 @@ function truncateError(message: string): string {
   return message.replace(/<[^>]*>/g, '').slice(0, MAX_ERROR_LENGTH);
 }
 
+class MalformedResponseError extends Error {
+  readonly reason = 'MALFORMED_RESPONSE';
+  readonly responsePreview?: string;
+
+  constructor(serviceName: string, causeMessage: string, responsePreview?: string) {
+    super(`${serviceName} returned malformed JSON: ${causeMessage}`);
+    this.name = 'MalformedResponseError';
+    this.responsePreview = responsePreview;
+  }
+}
+
+async function readResponsePreview(response: Response): Promise<string | undefined> {
+  try {
+    const previewSource =
+      typeof response.clone === 'function' ? response.clone() : response;
+    if (typeof previewSource.text !== 'function') return undefined;
+    return truncateError(await previewSource.text());
+  } catch {
+    return undefined;
+  }
+}
+
+async function parseJsonResponse<T = any>(
+  response: Response,
+  serviceName: string,
+): Promise<T> {
+  const previewPromise = readResponsePreview(response);
+  try {
+    return await response.json() as T;
+  } catch (err: any) {
+    throw new MalformedResponseError(
+      serviceName,
+      err?.message || String(err),
+      await previewPromise,
+    );
+  }
+}
+
 function recordServiceFee(
   amount: number,
   description: string,
@@ -834,7 +872,7 @@ export async function comparePharmacyPrices(
     );
   }
 
-  const data = await response.json();
+  const data = await parseJsonResponse(response, 'Pharmacy API');
 
   // Extract real Stellar tx hash from x402 payment response header
   const txHash = extractX402TxHash(response);
@@ -887,7 +925,7 @@ export async function fetchRosaBill() {
     );
   }
 
-  return await response.json();
+  return await parseJsonResponse(response, 'Bill sample API');
 }
 
 // --- Tool: Fetch Rosa's bill AND audit it in one step (pays via x402) ---
@@ -1029,7 +1067,7 @@ export async function auditBill(
     );
   }
 
-  const data = await response.json();
+  const data = await parseJsonResponse(response, 'Bill Audit API');
 
   const txHash = extractX402TxHash(response);
 
@@ -1108,7 +1146,7 @@ export async function checkDrugInteractions(medications: string[]) {
     );
   }
 
-  const data = await response.json();
+  const data = await parseJsonResponse(response, 'Drug Interaction API');
 
   const txHash = extractX402TxHash(response);
 
@@ -1259,7 +1297,7 @@ async function executeMedicationPayment(
       },
     );
 
-    const data = await response.json();
+    const data = await parseJsonResponse(response, 'MPP pharmacy payment API');
     if (!data.success) {
       throw new Error(data.error || 'MPP payment failed');
     }
@@ -1291,6 +1329,16 @@ async function executeMedicationPayment(
     mppOrderId = data.order?.id;
   } catch (err: any) {
     stellarTxSubmittedTotal.inc({ result: 'error' });
+    if (err?.reason === 'MALFORMED_RESPONSE') {
+      return {
+        success: false,
+        ok: false,
+        reason: 'MALFORMED_RESPONSE',
+        error: 'MPP payment failed: malformed response from pharmacy payment API',
+        message: err.message,
+        responsePreview: err.responsePreview,
+      };
+    }
     return { success: false, error: `MPP payment failed: ${err.message}` };
   }
 


### PR DESCRIPTION
Closes #161

## Summary
- Add a shared `parseJsonResponse` guard for agent HTTP responses so malformed JSON becomes a typed `MALFORMED_RESPONSE` failure instead of an unhandled parser crash.
- Apply the guard to every `response.json()` call in `agent/tools.ts`.
- Return a structured `{ success:false, ok:false, reason:"MALFORMED_RESPONSE" }` rejection from the MPP medication payment path.
- Cover the malformed MPP response path and assert no medication debit or transaction is recorded.

## Testing
- `npm test -- agent/__tests__/pay-for-medication.test.ts agent/__tests__/tools.test.ts`
- `git diff --check`
- `rg -n "await .*\\.json\\(\\)|\\.json\\(\\)" agent -g "*.ts"` now only finds the guarded helper.

Additional check attempted:
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest agent/tools.ts agent/__tests__/pay-for-medication.test.ts` is still blocked by existing x402 template-literal type errors in `agent/tools.ts`.
