### PR TITLE
Show full tool-call error details

### DIFF
--- a/dashboard/src/__tests__/activity-log-details.test.tsx
+++ b/dashboard/src/__tests__/activity-log-details.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ActivityTab } from "../components/tabs/activity-tab";
+
+const { copyTextMock } = vi.hoisted(() => ({
+  copyTextMock: vi.fn().mockResolvedValue("ok" as const),
+}));
+
+vi.mock("../lib/clipboard", () => ({
+  copyText: copyTextMock,
+}));
+
+vi.mock("../app/pdf", () => ({
+  downloadTransactionPDF: vi.fn(),
+}));
+
+function renderActivityLog(details: string) {
+  return render(
+    <ActivityTab
+      recipient={{ name: "Rosa Garcia" }}
+      agentLog={[
+        {
+          id: "log-1",
+          timestamp: Date.now(),
+          message: "  -> pay_bill ERROR: Stellar USDC transfer failed: tx_bad_seq...",
+          details,
+        },
+      ]}
+      setAgentLog={vi.fn()}
+      allTransactions={[]}
+      auditEvents={[]}
+      pagination={null}
+      currentPage={0}
+      setCurrentPage={vi.fn()}
+      pageSize={25}
+      setPageSize={vi.fn()}
+      spending={null}
+      onResetAgent={vi.fn()}
+    />,
+  );
+}
+
+describe("ActivityTab tool error details", () => {
+  it("expands, collapses, and copies full tool-call errors", async () => {
+    const fullError =
+      'Stellar USDC transfer failed: {"transaction":"tx_bad_seq","operations":["op_bad_auth"]}';
+
+    renderActivityLog(fullError);
+
+    expect(screen.getAllByText(/tx_bad_seq\.\.\./).length).toBeGreaterThan(0);
+    expect(screen.queryByText(fullError)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Show details"));
+
+    expect(screen.getByText("Hide details")).toBeInTheDocument();
+    expect(screen.getByText(fullError)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Copy"));
+    await waitFor(() => expect(copyTextMock).toHaveBeenCalledWith(fullError));
+
+    fireEvent.click(screen.getByText("Hide details"));
+    expect(screen.queryByText(fullError)).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/tabs/activity-tab.tsx
+++ b/dashboard/src/components/tabs/activity-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { downloadTransactionPDF } from "../../app/pdf";
+import { copyText } from "../../lib/clipboard";
 import type { RecipientProfile } from "../../lib/types";
 import { ConfirmDialog } from "../primitives/confirm-dialog";
 import { TxLink } from "../primitives/tx-link";
@@ -44,6 +45,10 @@ export function ActivityTab({
 }: ActivityTabProps) {
   const [showAllLogEntries, setShowAllLogEntries] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [expandedLogIds, setExpandedLogIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [copiedLogId, setCopiedLogId] = useState<string | null>(null);
 
   const mergedTimeline = useMemo(() => {
     const items: Array<{ ts: number, kind: "tx" | "audit", id: string, data: any }> = [];
@@ -123,9 +128,57 @@ export function ActivityTab({
                 </div>
               )}
               {(showAllLogEntries ? agentLog : agentLog.slice(-50)).map(
-                (entry) => (
-                  <div key={entry.id}>{entry.message}</div>
-                ),
+                (entry) => {
+                  const expanded = expandedLogIds.has(entry.id);
+                  return (
+                    <div key={entry.id} className="py-0.5">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span>{entry.message}</span>
+                        {entry.details && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setExpandedLogIds((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(entry.id)) next.delete(entry.id);
+                                else next.add(entry.id);
+                                return next;
+                              });
+                            }}
+                            className="text-sky-300 hover:text-sky-200 underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-300 rounded"
+                          >
+                            {expanded ? "Hide details" : "Show details"}
+                          </button>
+                        )}
+                      </div>
+                      {entry.details && expanded && (
+                        <div className="mt-2 rounded border border-slate-700 bg-slate-950 p-2 text-slate-100">
+                          <div className="mb-2 flex items-center justify-between gap-2">
+                            <span className="text-[11px] uppercase text-slate-400">
+                              Full error
+                            </span>
+                            <button
+                              type="button"
+                              onClick={async () => {
+                                const result = await copyText(entry.details!);
+                                if (result === "ok" || result === "fallback") {
+                                  setCopiedLogId(entry.id);
+                                  window.setTimeout(() => setCopiedLogId(null), 1500);
+                                }
+                              }}
+                              className="text-sky-300 hover:text-sky-200 underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-300 rounded"
+                            >
+                              {copiedLogId === entry.id ? "Copied" : "Copy"}
+                            </button>
+                          </div>
+                          <pre className="max-h-36 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed">
+                            {entry.details}
+                          </pre>
+                        </div>
+                      )}
+                    </div>
+                  );
+                },
               )}
               {showAllLogEntries && agentLog.length > 50 && (
                 <div className="text-slate-400 mt-2">

--- a/dashboard/src/components/types.ts
+++ b/dashboard/src/components/types.ts
@@ -24,6 +24,7 @@ export interface AgentLogEntry {
   id: string;
   timestamp: number;
   message: string;
+  details?: string;
 }
 
 export interface PaginationData {

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -92,12 +92,13 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       setLiveMessage('Agent disconnected');
   }, [agentConnected, agentPaused]);
 
-  const addLogEntry = useCallback((message: string) => {
+  const addLogEntry = useCallback((message: string, details?: string) => {
     setAgentLog((prev) => {
       const entry: AgentLogEntry = {
         id: `${Date.now()}-${Math.random()}`,
         timestamp: Date.now(),
         message,
+        details,
       };
       const next = [...prev, entry];
       return next.length > 200 ? next.slice(-200) : next;
@@ -276,10 +277,16 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         setSpending(data.spending);
         setLiveMessage(`Task complete — ${data.toolCalls.length} tool calls`);
         for (const tc of data.toolCalls) {
-          const resultPreview = tc.result?.error
-            ? `ERROR: ${String(tc.result.error).slice(0, 60)}`
-            : 'OK';
-          addLogEntry(`  -> ${tc.tool} ${resultPreview}`);
+          const fullError = tc.result?.error ? String(tc.result.error) : '';
+          if (fullError) {
+            const shortError =
+              fullError.length > 60
+                ? `${fullError.slice(0, 60)}...`
+                : fullError;
+            addLogEntry(`  -> ${tc.tool} ERROR: ${shortError}`, fullError);
+          } else {
+            addLogEntry(`  -> ${tc.tool} OK`);
+          }
         }
         addLogEntry(
           `[${new Date().toLocaleTimeString()}] Done: ${data.toolCalls.length} tool calls`,


### PR DESCRIPTION
Closes #215

## Summary
- Keep the existing short tool-call error preview in the agent log while storing the full error on the log entry.
- Add an activity-log disclosure that expands to a `<pre>` with the full error details.
- Add a copy button for the full error details and Vitest coverage for expand/collapse/copy.

## Testing
- `npm test -- dashboard/src/__tests__/activity-log-details.test.tsx`
- `git diff --check`
- `rg -n "slice\(0, 60\)|Show details|Hide details|details\?:" dashboard\src -g "*.ts" -g "*.tsx"`

## Notes
- I also attempted to run `dashboard/src/__tests__/agent-log.test.tsx`, but that existing test currently fails in this checkout because `next/navigation` cannot be resolved.
- A targeted TypeScript check is blocked in this checkout by missing dashboard dependencies/types such as React, jsPDF, and sonner.