### PR TITLE
Cover TxLink receipt hash handling

### DIFF
--- a/dashboard/src/__tests__/tx-link.test.tsx
+++ b/dashboard/src/__tests__/tx-link.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TxLink } from "../components/primitives/tx-link";
+
+const LOWER_HASH =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const UPPER_HASH = LOWER_HASH.toUpperCase();
+const SHORT_HASH = "0123456789abcdef0123456789abcdef";
+
+function encodeReceipt(payload: Record<string, string>) {
+  return globalThis.btoa(JSON.stringify(payload));
+}
+
+function expectTxLink(hash: string, label = `${hash.slice(0, 8)}...`) {
+  const link = screen.getByRole("link", { name: label });
+  expect(link.getAttribute("href")).toBe(
+    `https://stellar.expert/explorer/testnet/tx/${hash}`,
+  );
+  expect(link.getAttribute("target")).toBe("_blank");
+  expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  expect(link.getAttribute("title")).toBe(`View on Stellar Explorer: ${hash}`);
+}
+
+function expectPlainText(text: string) {
+  expect(screen.getByText(text).textContent).toBe(text);
+  expect(screen.queryByRole("link")).toBeNull();
+}
+
+describe("TxLink", () => {
+  it("renders a Stellar explorer link for 64-character lowercase hex hashes", () => {
+    render(<TxLink hash={LOWER_HASH} />);
+
+    expectTxLink(LOWER_HASH);
+  });
+
+  it("renders a Stellar explorer link for 64-character uppercase hex hashes", () => {
+    render(<TxLink hash={UPPER_HASH} />);
+
+    expectTxLink(UPPER_HASH);
+  });
+
+  it("decodes base64 receipts with a transaction hash", () => {
+    render(<TxLink hash={encodeReceipt({ transaction: LOWER_HASH })} />);
+
+    expectTxLink(LOWER_HASH);
+  });
+
+  it("decodes MPP receipts with a reference hash", () => {
+    render(<TxLink hash={encodeReceipt({ reference: LOWER_HASH })} />);
+
+    expectTxLink(LOWER_HASH);
+  });
+
+  it("renders order IDs as plain non-link text", () => {
+    render(<TxLink hash="order-1775720261932" />);
+
+    expectPlainText("order-1775720261932");
+  });
+
+  it("renders a dash for missing hashes", () => {
+    render(<TxLink />);
+
+    expectPlainText("-");
+  });
+
+  it("renders wrong-length hex strings as plain non-link text", () => {
+    render(<TxLink hash={SHORT_HASH} />);
+
+    expectPlainText(SHORT_HASH);
+  });
+
+  it("renders base64 receipts without a valid hash as plain non-link text", () => {
+    const receipt = encodeReceipt({ reference: SHORT_HASH });
+
+    render(<TxLink hash={receipt} />);
+
+    expectPlainText(receipt);
+  });
+
+  it("renders base64 JSON without receipt hash fields as plain non-link text", () => {
+    const receipt = encodeReceipt({ status: "paid" });
+
+    render(<TxLink hash={receipt} />);
+
+    expectPlainText(receipt);
+  });
+});

--- a/dashboard/src/components/primitives/tx-link.tsx
+++ b/dashboard/src/components/primitives/tx-link.tsx
@@ -1,27 +1,60 @@
 import { EXPLORER_TX_URL } from "../../lib/stellar-network";
 
-// Backend guarantees stellarTxHash is always a real 64-char hex hash or
-// undefined (#14) — no more base64/receipt decoding needed here.
 const STELLAR_TX_HASH_RE = /^[0-9a-f]{64}$/i;
 
 export interface TxLinkProps {
   hash?: string;
 }
 
+function decodeReceipt(value: string): unknown {
+  try {
+    return JSON.parse(globalThis.atob(value));
+  } catch {
+    return null;
+  }
+}
+
+function resolveTxHash(value: string): string | null {
+  if (STELLAR_TX_HASH_RE.test(value)) {
+    return value;
+  }
+
+  const receipt = decodeReceipt(value);
+  if (!receipt || typeof receipt !== "object") {
+    return null;
+  }
+
+  const candidate =
+    "transaction" in receipt
+      ? receipt.transaction
+      : "reference" in receipt
+        ? receipt.reference
+        : null;
+
+  return typeof candidate === "string" && STELLAR_TX_HASH_RE.test(candidate)
+    ? candidate
+    : null;
+}
+
 export function TxLink({ hash }: TxLinkProps) {
-  if (!hash || !STELLAR_TX_HASH_RE.test(hash)) {
+  if (!hash) {
     return <span className="text-xs text-slate-300">-</span>;
+  }
+
+  const txHash = resolveTxHash(hash);
+  if (!txHash) {
+    return <span className="text-xs text-slate-500 font-mono break-all">{hash}</span>;
   }
 
   return (
     <a
-      href={`${EXPLORER_TX_URL}/${hash}`}
+      href={`${EXPLORER_TX_URL}/${txHash}`}
       target="_blank"
       rel="noopener noreferrer"
       className="text-xs text-sky-600 hover:text-sky-800 underline font-mono"
-      title={`View on Stellar Explorer: ${hash}`}
+      title={`View on Stellar Explorer: ${txHash}`}
     >
-      {hash.slice(0, 8)}...
+      {txHash.slice(0, 8)}...
     </a>
   );
 }


### PR DESCRIPTION
Closes #48

## Summary
- Restore defensive TxLink handling for raw 64-character Stellar transaction hashes and base64 receipt payloads.
- Decode receipt payloads containing either `transaction` or MPP-style `reference` hashes before building the Stellar explorer URL.
- Render provided non-hash values, such as `order-1775720261932` or wrong-length hex, as plain non-link text while keeping missing hashes as `-`.
- Add focused React coverage for lowercase hex, uppercase hex, transaction receipts, reference receipts, order IDs, missing hashes, wrong-length hex, and invalid receipt payloads.

## Testing
- `npm test -- dashboard/src/__tests__/tx-link.test.tsx`
- `npx vitest run dashboard/src/__tests__/tx-link.test.tsx --coverage --coverage.include=dashboard/src/components/primitives/tx-link.tsx` (100% statements/branches/functions/lines for `tx-link.tsx`)
- `git diff --check`

## Notes
- A targeted `tsc` command for these files is still blocked in this checkout by missing React JSX type declarations (`@types/react` / `react/jsx-runtime`), which also affects existing dashboard TSX files.