### PR TITLE
Show wallet balance error state

### DIFF
--- a/dashboard/src/__tests__/wallet-tab.test.tsx
+++ b/dashboard/src/__tests__/wallet-tab.test.tsx
@@ -20,6 +20,10 @@ function buildProps(overrides: Partial<WalletTabProps> = {}): WalletTabProps {
     } as any,
     walletBalance: "42.50",
     walletXlm: "10.20",
+    walletBalanceStatus: "ok",
+    walletBalanceError: null,
+    onRetryWalletBalance: vi.fn(),
+    loadingAgentInfo: false,
     ...overrides,
   };
 }
@@ -52,9 +56,49 @@ describe("WalletTab — balance display (Issue #49)", () => {
     expect(screen.getByText("$0")).toBeTruthy();
   });
 
-  it("Horizon error (both null) shows $0.00 placeholder for USDC", () => {
+  it("ok state with both balances null shows zero placeholders", () => {
     render(<WalletTab {...buildProps({ walletBalance: null, walletXlm: null })} />);
     expect(screen.getByText("$0.00")).toBeTruthy();
+    expect(screen.getByText("0.00")).toBeTruthy();
+  });
+
+  it("loading state shows a distinct balance loading UI", () => {
+    render(<WalletTab {...buildProps({ walletBalanceStatus: "loading" })} />);
+    expect(screen.getByText("Loading wallet balances")).toBeTruthy();
+    expect(screen.queryByText("$42.50")).toBeNull();
+  });
+
+  it("error state shows balance unavailable with retry", () => {
+    render(
+      <WalletTab
+        {...buildProps({
+          walletBalanceStatus: "error",
+          walletBalanceError: "Balance unavailable (503)",
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain("Balance unavailable");
+    expect(screen.getByText("Balance unavailable (503)")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Try again/i })).toBeTruthy();
+    expect(screen.queryByText("$42.50")).toBeNull();
+  });
+
+  it("Try again calls the wallet balance retry handler", async () => {
+    const user = userEvent.setup();
+    const onRetryWalletBalance = vi.fn();
+
+    render(
+      <WalletTab
+        {...buildProps({
+          walletBalanceStatus: "error",
+          onRetryWalletBalance,
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Try again/i }));
+    expect(onRetryWalletBalance).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -133,6 +133,11 @@ export default function Dashboard() {
             agentInfo={state.agentInfo}
             walletBalance={state.walletBalance}
             walletXlm={state.walletXlm}
+            walletBalanceStatus={state.walletBalanceStatus}
+            walletBalanceError={state.walletBalanceError}
+            onRetryWalletBalance={() =>
+              state.fetchWalletBalance({ showLoading: true })
+            }
             loadingAgentInfo={state.loadingAgentInfo}
           />
         )}

--- a/dashboard/src/components/tabs/wallet-tab.tsx
+++ b/dashboard/src/components/tabs/wallet-tab.tsx
@@ -3,16 +3,27 @@
 import { useState } from "react";
 import { copyText } from "../../lib/clipboard";
 import { Toast } from "../primitives/toast";
-import type { AgentInfo } from "../types";
+import type { AgentInfo, WalletBalanceStatus } from "../types";
 import { EXPLORER_ACCOUNT_URL, NETWORK_LABEL } from "../../lib/stellar-network";
 
 export interface WalletTabProps {
   agentInfo: AgentInfo | null;
   walletBalance: string | null;
   walletXlm: string | null;
+  walletBalanceStatus: WalletBalanceStatus;
+  walletBalanceError: string | null;
+  onRetryWalletBalance: () => void;
+  loadingAgentInfo?: boolean;
 }
 
-export function WalletTab({ agentInfo, walletBalance, walletXlm }: WalletTabProps) {
+export function WalletTab({
+  agentInfo,
+  walletBalance,
+  walletXlm,
+  walletBalanceStatus,
+  walletBalanceError,
+  onRetryWalletBalance,
+}: WalletTabProps) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [toastFallback, setToastFallback] = useState<string | undefined>(undefined);
@@ -52,18 +63,53 @@ export function WalletTab({ agentInfo, walletBalance, walletXlm }: WalletTabProp
           {NETWORK_LABEL.replace('Stellar ', '').toLowerCase()}.
         </p>
         <div className="grid grid-cols-2 gap-4 mb-6">
-          <div className="bg-sky-50 rounded-lg p-4 text-center border border-sky-200">
-            <div className="text-2xl font-bold text-sky-700">
-              ${walletBalance ?? "0.00"}
+          {walletBalanceStatus === "loading" && (
+            <div
+              className="col-span-2 rounded-lg border border-slate-200 bg-slate-50 p-4"
+              aria-live="polite"
+            >
+              <div className="text-sm font-semibold text-slate-700">
+                Loading wallet balances
+              </div>
+              <div className="mt-2 h-7 w-32 rounded bg-slate-200" />
             </div>
-            <div className="text-xs text-slate-500 mt-1">USDC Balance</div>
-          </div>
-          <div className="bg-slate-50 rounded-lg p-4 text-center border border-slate-200">
-            <div className="text-2xl font-bold text-slate-700">
-              {walletXlm ?? "0.00"}
+          )}
+          {walletBalanceStatus === "error" && (
+            <div
+              role="alert"
+              className="col-span-2 rounded-lg border border-amber-200 bg-amber-50 p-4"
+            >
+              <div className="text-sm font-semibold text-amber-800">
+                Balance unavailable
+              </div>
+              <p className="mt-1 text-xs text-amber-700">
+                {walletBalanceError || "Unable to load wallet balances."}
+              </p>
+              <button
+                type="button"
+                onClick={onRetryWalletBalance}
+                className="mt-3 px-3 py-1.5 rounded-lg bg-amber-100 text-xs font-medium text-amber-800 hover:bg-amber-200 cursor-pointer transition-all"
+              >
+                Try again
+              </button>
             </div>
-            <div className="text-xs text-slate-500 mt-1">XLM Balance</div>
-          </div>
+          )}
+          {walletBalanceStatus === "ok" && (
+            <>
+              <div className="bg-sky-50 rounded-lg p-4 text-center border border-sky-200">
+                <div className="text-2xl font-bold text-sky-700">
+                  ${walletBalance ?? "0.00"}
+                </div>
+                <div className="text-xs text-slate-500 mt-1">USDC Balance</div>
+              </div>
+              <div className="bg-slate-50 rounded-lg p-4 text-center border border-slate-200">
+                <div className="text-2xl font-bold text-slate-700">
+                  {walletXlm ?? "0.00"}
+                </div>
+                <div className="text-xs text-slate-500 mt-1">XLM Balance</div>
+              </div>
+            </>
+          )}
         </div>
         <div className="space-y-3">
           <div>

--- a/dashboard/src/components/types.ts
+++ b/dashboard/src/components/types.ts
@@ -20,6 +20,8 @@ export interface AgentInfo {
   paused?: boolean;
 }
 
+export type WalletBalanceStatus = "loading" | "ok" | "error";
+
 export interface AgentLogEntry {
   id: string;
   timestamp: number;

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -16,6 +16,7 @@ import type {
   PaginationData,
   Tab,
   AuditLogEvent,
+  WalletBalanceStatus,
 } from '../components/types';
 import { usePoll } from './use-poll';
 import { AGENT_URL } from '../lib/agent-url';
@@ -55,6 +56,11 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   );
   const [walletBalance, setWalletBalance] = useState<string | null>(null);
   const [walletXlm, setWalletXlm] = useState<string | null>(null);
+  const [walletBalanceStatus, setWalletBalanceStatus] =
+    useState<WalletBalanceStatus>('loading');
+  const [walletBalanceError, setWalletBalanceError] = useState<string | null>(
+    null,
+  );
   const [liveMessage, setLiveMessage] = useState('');
   const [policyForm, setPolicyForm] = useState<PolicyForm>(DEFAULT_POLICY);
   const [policyDirty, setPolicyDirty] = useState(false);
@@ -69,6 +75,11 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   const activeTabRef = useRef(activeTab);
   const policyDirtyRef = useRef(policyDirty);
   const lastConnectionStateRef = useRef<string | null>(null);
+  const walletStatusRef = useRef<WalletBalanceStatus>('loading');
+  const walletRetryAttemptRef = useRef(0);
+  const walletRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
     activeTabRef.current = activeTab;
@@ -104,6 +115,60 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     });
   }, []);
 
+  const setWalletStatus = useCallback((status: WalletBalanceStatus) => {
+    walletStatusRef.current = status;
+    setWalletBalanceStatus(status);
+  }, []);
+
+  const clearWalletRetry = useCallback(() => {
+    if (walletRetryTimeoutRef.current) {
+      clearTimeout(walletRetryTimeoutRef.current);
+      walletRetryTimeoutRef.current = null;
+    }
+  }, []);
+
+  const fetchWalletBalance = useCallback(
+    async (opts?: { showLoading?: boolean }) => {
+      clearWalletRetry();
+      if (opts?.showLoading ?? walletStatusRef.current !== 'ok') {
+        setWalletStatus('loading');
+      }
+      setWalletBalanceError(null);
+
+      try {
+        const wres = await fetch(`${AGENT_URL}/agent/wallet`);
+        if (!wres.ok) {
+          throw new Error(`Balance unavailable (${wres.status})`);
+        }
+        const wdata = await wres.json();
+        setWalletBalance(wdata.usdc || '0.00');
+        setWalletXlm(wdata.xlm || '0.00');
+        walletRetryAttemptRef.current = 0;
+        setWalletStatus('ok');
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Balance unavailable';
+        setWalletBalance(null);
+        setWalletXlm(null);
+        setWalletBalanceError(message);
+        setWalletStatus('error');
+
+        const delayMs = Math.min(
+          30000,
+          1000 * 2 ** Math.min(walletRetryAttemptRef.current, 5),
+        );
+        walletRetryAttemptRef.current += 1;
+        walletRetryTimeoutRef.current = setTimeout(() => {
+          walletRetryTimeoutRef.current = null;
+          void fetchWalletBalance({ showLoading: true });
+        }, delayMs);
+      }
+    },
+    [clearWalletRetry, setWalletStatus],
+  );
+
+  useEffect(() => clearWalletRetry, [clearWalletRetry]);
+
   const fetchAgentInfo = useCallback(async () => {
     setLoadingAgentInfo(true);
     try {
@@ -120,23 +185,24 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       setAgentPausedReason(
         typeof data.pausedReason === 'string' ? data.pausedReason : null,
       );
-      // Fetch wallet balance from server (Issue #134 - server-side cache)
       if (data.agentWallet) {
-        try {
-          const wres = await fetch(`${AGENT_URL}/agent/wallet`);
-          if (wres.ok) {
-            const wdata = await wres.json();
-            setWalletBalance(wdata.usdc || '0.00');
-            setWalletXlm(wdata.xlm || '0.00');
-          }
-        } catch {}
+        void fetchWalletBalance({
+          showLoading: walletStatusRef.current !== 'ok',
+        });
+      } else {
+        clearWalletRetry();
+        walletRetryAttemptRef.current = 0;
+        setWalletBalance(null);
+        setWalletXlm(null);
+        setWalletBalanceError(null);
+        setWalletStatus('ok');
       }
     } catch {
       setAgentConnected(false);
     } finally {
       setLoadingAgentInfo(false);
     }
-  }, []);
+  }, [clearWalletRetry, fetchWalletBalance, setWalletStatus]);
 
   const fetchSpending = useCallback(
     async (opts?: { forcePolicySync?: boolean }) => {
@@ -404,6 +470,8 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     agentPausedReason,
     walletBalance,
     walletXlm,
+    walletBalanceStatus,
+    walletBalanceError,
     liveMessage,
     setLiveMessage,
     policyForm,
@@ -417,6 +485,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     loadingTransactions,
     // actions
     fetchSpending,
+    fetchWalletBalance,
     runAgentTask,
     cancelAgentTask,
     updatePolicy,


### PR DESCRIPTION
Closes #212

## Summary
- Add an explicit wallet balance state machine: `loading`, `ok`, and `error`.
- Move wallet balance fetching into `fetchWalletBalance`, with failed requests surfacing an error state instead of silently leaving balances null.
- Add exponential backoff auto-retry for wallet balance failures, capped at 30 seconds.
- Add a Wallet tab error UI with a manual `Try again` button wired to the same balance fetcher.
- Extend WalletTab tests to cover ok, loading, error, and manual retry states.

## Testing
- `npm test -- dashboard/src/__tests__/wallet-tab.test.tsx`
- `git diff --check`

## Notes
- A targeted `tsc` check is still blocked in this checkout by existing dashboard dependency/type issues, including missing React/Next JSX types, `sonner`, `jspdf`, and several pre-existing prop type mismatches in dashboard components.