### PR TITLE
Recover corrupt spending data

### DIFF
--- a/agent/__tests__/persistence.test.ts
+++ b/agent/__tests__/persistence.test.ts
@@ -104,15 +104,17 @@ vi.mock("@stellar/mpp/charge/client", () => ({
 vi.mock("mppx/client", () => ({
   Mppx: { create: vi.fn().mockReturnValue({ fetch: vi.fn() }) },
 }));
-// Persistence behavior is the thing under test — audit logging and
-// notifications are unrelated collaborators, so they're stubbed out.
+// Persistence behavior is the thing under test — audit logging is an unrelated
+// collaborator, and notifications are observed only for critical alerts.
 vi.mock("../../shared/audit-log.ts", () => ({ appendAuditEntry: vi.fn() }));
-vi.mock("../../shared/notifications.ts", () => ({ notify: vi.fn().mockResolvedValue(undefined) }));
+const notifySpy = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../../shared/notifications.ts", () => ({ notify: notifySpy }));
 // Spying directly on the real pino instance is unreliable, so mock the
 // logger module the same way shared/__tests__/request-logger.test.ts does.
 const warnSpy = vi.hoisted(() => vi.fn());
+const errorSpy = vi.hoisted(() => vi.fn());
 vi.mock("../../shared/logger.ts", () => ({
-  logger: { info: vi.fn(), warn: warnSpy, error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: warnSpy, error: errorSpy, debug: vi.fn() },
 }));
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -143,6 +145,8 @@ beforeEach(() => {
   fsState.files.clear();
   fsState.readOnlyPaths.clear();
   warnSpy.mockClear();
+  errorSpy.mockClear();
+  notifySpy.mockClear();
 });
 
 describe("Spending tracker persistence across restart (#44)", () => {
@@ -184,13 +188,14 @@ describe("Spending tracker persistence across restart (#44)", () => {
   });
 });
 
-describe("Corrupted data falls back to defaults without throwing (#44)", () => {
-  it("loadSpending falls back to an empty tracker and logs a warning on malformed JSON", async () => {
+describe("Corrupted data falls back to defaults without throwing (#44, #204)", () => {
+  it("loadSpending rotates malformed spending.json, alerts, and starts fresh", async () => {
     vi.resetModules();
     const tools = await import("../tools.ts");
 
+    const spendingFile = `${DATA_DIR}/recipients/corrupt-recipient/spending.json`;
     fsState.files.set(
-      `${DATA_DIR}/recipients/corrupt-recipient/spending.json`,
+      spendingFile,
       "{not valid json",
     );
 
@@ -200,7 +205,53 @@ describe("Corrupted data falls back to defaults without throwing (#44)", () => {
     }).not.toThrow();
 
     expect(result).toEqual({ medications: 0, bills: 0, serviceFees: 0, transactions: [] });
-    expect(warnSpy).toHaveBeenCalled();
+    expect(fsState.files.has(spendingFile)).toBe(false);
+    const rotatedKey = [...fsState.files.keys()].find((key) =>
+      key.includes("/recipients/corrupt-recipient/spending.json.corrupt-"),
+    );
+    expect(rotatedKey).toBeDefined();
+    expect(fsState.files.get(rotatedKey!)).toBe("{not valid json");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: spendingFile,
+        rotatedFile: rotatedKey,
+        error: expect.any(String),
+      }),
+      expect.stringContaining("critical"),
+    );
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "critical",
+        title: "Spending data recovered from corruption",
+        context: expect.objectContaining({
+          file: spendingFile,
+          rotatedFile: rotatedKey,
+          recipientId: "corrupt-recipient",
+        }),
+      }),
+    );
+  });
+
+  it("loadSpending treats invalid spending schema as corruption", async () => {
+    vi.resetModules();
+    const tools = await import("../tools.ts");
+
+    const spendingFile = `${DATA_DIR}/recipients/invalid-schema/spending.json`;
+    fsState.files.set(
+      spendingFile,
+      JSON.stringify({ medications: "not-a-number", bills: 0, serviceFees: 0, transactions: [] }),
+    );
+
+    const result = tools.loadSpending("invalid-schema");
+
+    expect(result).toEqual({ medications: 0, bills: 0, serviceFees: 0, transactions: [] });
+    expect(fsState.files.has(spendingFile)).toBe(false);
+    expect([...fsState.files.keys()].some((key) =>
+      key.includes("/recipients/invalid-schema/spending.json.corrupt-"),
+    )).toBe(true);
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "critical" }),
+    );
   });
 
   it("a corrupt policy.json on disk does not throw and yields the default policy", async () => {

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -411,6 +411,44 @@ interface SpendingTracker {
   transactions: Transaction[];
 }
 
+const TransactionRecordSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  type: z.enum(['medication', 'bill', 'service_fee']),
+  description: z.string(),
+  amount: z.number().finite(),
+  recipient: z.string(),
+  stellarTxHash: z.string().optional(),
+  mppOrderId: z.string().optional(),
+  status: z.enum([
+    'pending',
+    'approved',
+    'completed',
+    'blocked',
+    'disputed',
+    'cancelled',
+    'rejected',
+  ]),
+  category: z.enum([
+    TRANSACTION_CATEGORY.MEDICATIONS,
+    TRANSACTION_CATEGORY.BILLS,
+    TRANSACTION_CATEGORY.SERVICE_FEES,
+  ]),
+  pendingUntil: z.string().optional(),
+  submittedAt: z.string().optional(),
+}).passthrough();
+
+const SpendingTrackerSchema = z.object({
+  medications: z.number().finite(),
+  bills: z.number().finite(),
+  serviceFees: z.number().finite(),
+  transactions: z.array(TransactionRecordSchema),
+});
+
+const SpendingSnapshotSchema = SpendingTrackerSchema.extend({
+  _snapshotTxCount: z.number().int().nonnegative().optional(),
+});
+
 type PaymentCategory =
   | typeof TRANSACTION_CATEGORY.MEDICATIONS
   | typeof TRANSACTION_CATEGORY.BILLS;
@@ -436,6 +474,40 @@ const spendingCache = new Map<string, SpendingCacheEntry>();
 
 function createEmptySpendingTracker(): SpendingTracker {
   return { medications: 0, bills: 0, serviceFees: 0, transactions: [] };
+}
+
+function rotateCorruptSpendingFile(file: string): string | null {
+  const rotatedFile = `${file}.corrupt-${Date.now()}`;
+  try {
+    renameSync(file, rotatedFile);
+    return rotatedFile;
+  } catch (err: any) {
+    logger.error(
+      { file, rotatedFile, error: err.message },
+      '[Persistence] failed to rotate corrupt spending.json',
+    );
+    return null;
+  }
+}
+
+function alertCorruptSpendingFile(
+  file: string,
+  rotatedFile: string | null,
+  error: string,
+  recipientId?: string,
+) {
+  void notify({
+    level: 'critical',
+    title: 'Spending data recovered from corruption',
+    description:
+      'CareGuard detected a corrupted spending.json file, rotated it aside, and restarted spending tracking from defaults.',
+    context: {
+      file,
+      rotatedFile,
+      error,
+      recipientId: recipientId || currentRecipientId,
+    },
+  });
 }
 
 function normalizeTransactionCategories(
@@ -487,7 +559,9 @@ function readSpendingFromDisk(recipientId?: string): SpendingTracker {
   // --- Try new snapshot + JSONL tail path first ---
   if (existsSync(snapshotFile)) {
     try {
-      const snapshot = JSON.parse(readFileSync(snapshotFile, 'utf-8')) as SpendingTracker & { _snapshotTxCount?: number };
+      const snapshot = SpendingSnapshotSchema.parse(
+        JSON.parse(readFileSync(snapshotFile, 'utf-8')),
+      );
       const snapshotTxCount = snapshot._snapshotTxCount ?? snapshot.transactions.length;
 
       // Replay transactions from the JSONL tail that came after the snapshot
@@ -527,17 +601,21 @@ function readSpendingFromDisk(recipientId?: string): SpendingTracker {
   // --- Legacy fallback: spending.json (full JSON blob) ---
   if (!existsSync(legacyFile)) return createEmptySpendingTracker();
   try {
-    const parsed = JSON.parse(readFileSync(legacyFile, 'utf-8')) as SpendingTracker;
+    const parsed = SpendingTrackerSchema.parse(
+      JSON.parse(readFileSync(legacyFile, 'utf-8')),
+    );
     const normalized = normalizeTransactionCategories(parsed, recipientId);
     if (normalized.migrated) {
       saveSpending(normalized.data, recipientId);
     }
     return normalized.data;
   } catch (err: any) {
-    logger.warn(
-      { file: legacyFile, error: err.message },
-      '[Persistence] spending.json is corrupted; falling back to an empty tracker',
+    const rotatedFile = rotateCorruptSpendingFile(legacyFile);
+    logger.error(
+      { file: legacyFile, rotatedFile, error: err.message },
+      '[Persistence] critical: spending.json is corrupted; rotated and reset to defaults',
     );
+    alertCorruptSpendingFile(legacyFile, rotatedFile, err.message, recipientId);
     return createEmptySpendingTracker();
   }
 }


### PR DESCRIPTION
Closes #204

## Summary
- Validate persisted spending data through zod before using it.
- Treat malformed JSON and invalid spending schema as corruption, rotate the bad legacy file to `spending.json.corrupt-<timestamp>`, and restart from the default empty tracker.
- Emit a critical notification when spending recovery fires, including the original file, rotated file, error, and recipient id.
- Keep snapshot parsing schema-checked so bad snapshots fall back to the legacy recovery path.
- Extend persistence tests to cover malformed JSON rotation, invalid schema recovery, critical notification, and fallback defaults.

## Testing
- `npm test -- agent/__tests__/persistence.test.ts`
- `git diff --check`

## Notes
- A targeted `tsc` check for `agent/tools.ts` and `agent/__tests__/persistence.test.ts` is still blocked by existing x402 template-literal type errors in `agent/tools.ts:264` and `agent/tools.ts:266`.