### PR TITLE
Retry stale setup trustlines

### DIFF
--- a/scripts/__tests__/setup-wallets-trustline.test.ts
+++ b/scripts/__tests__/setup-wallets-trustline.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  loadAccountMock,
+  submitTransactionMock,
+  changeTrustMock,
+  txSignMock,
+  loggerWarnMock,
+} = vi.hoisted(() => ({
+  loadAccountMock: vi.fn(),
+  submitTransactionMock: vi.fn(),
+  changeTrustMock: vi.fn(() => ({ type: "changeTrust" })),
+  txSignMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock("../../shared/logger.ts", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@stellar/stellar-sdk", () => {
+  const builder = vi.fn().mockImplementation(() => ({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn(() => ({ sign: txSignMock })),
+  }));
+
+  return {
+    Horizon: {
+      Server: vi.fn(() => ({
+        loadAccount: loadAccountMock,
+        submitTransaction: submitTransactionMock,
+      })),
+    },
+    Asset: vi.fn().mockImplementation((code: string, issuer: string) => ({ code, issuer })),
+    Networks: { TESTNET: "Test SDF Network ; September 2015" },
+    Operation: { changeTrust: changeTrustMock },
+    TransactionBuilder: builder,
+    Keypair: {
+      fromRawEd25519Seed: vi.fn(),
+      fromSecret: vi.fn(),
+    },
+  };
+});
+
+const { addUsdcTrustline } = await import("../setup-wallets.ts");
+
+const keypair = {
+  publicKey: () => "GTESTPUBLICKEY",
+  sign: vi.fn(),
+} as any;
+
+function accountWithBalances(balances: any[] = []) {
+  return { balances };
+}
+
+function txBadSeqError() {
+  return {
+    response: {
+      data: {
+        extras: {
+          result_codes: { transaction: "tx_bad_seq" },
+        },
+      },
+    },
+  };
+}
+
+describe("setup-wallets USDC trustline setup", () => {
+  beforeEach(() => {
+    loadAccountMock.mockReset();
+    submitTransactionMock.mockReset();
+    changeTrustMock.mockClear();
+    txSignMock.mockClear();
+    loggerWarnMock.mockClear();
+  });
+
+  it("reloads account state and retries once after tx_bad_seq", async () => {
+    loadAccountMock
+      .mockResolvedValueOnce(accountWithBalances())
+      .mockResolvedValueOnce(accountWithBalances());
+    submitTransactionMock
+      .mockRejectedValueOnce(txBadSeqError())
+      .mockResolvedValueOnce({});
+
+    await addUsdcTrustline(keypair);
+
+    expect(loadAccountMock).toHaveBeenCalledTimes(2);
+    expect(loadAccountMock).toHaveBeenNthCalledWith(1, "GTESTPUBLICKEY");
+    expect(loadAccountMock).toHaveBeenNthCalledWith(2, "GTESTPUBLICKEY");
+    expect(submitTransactionMock).toHaveBeenCalledTimes(2);
+    expect(txSignMock).toHaveBeenCalledTimes(2);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ wallet: "GTESTPUB" }),
+      expect.stringContaining("tx_bad_seq"),
+    );
+  });
+
+  it("skips transaction submission when the reloaded account already has the trustline", async () => {
+    loadAccountMock.mockResolvedValueOnce(
+      accountWithBalances([
+        {
+          asset_code: "USDC",
+          asset_issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+        },
+      ]),
+    );
+
+    await addUsdcTrustline(keypair);
+
+    expect(loadAccountMock).toHaveBeenCalledTimes(1);
+    expect(changeTrustMock).not.toHaveBeenCalled();
+    expect(submitTransactionMock).not.toHaveBeenCalled();
+  });
+
+  it("fails fast for non-sequence Horizon errors", async () => {
+    loadAccountMock.mockResolvedValueOnce(accountWithBalances());
+    submitTransactionMock.mockRejectedValueOnce(new Error("op_no_trust"));
+
+    await expect(addUsdcTrustline(keypair)).rejects.toThrow("op_no_trust");
+
+    expect(loadAccountMock).toHaveBeenCalledTimes(1);
+    expect(submitTransactionMock).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/setup-wallets.ts
+++ b/scripts/setup-wallets.ts
@@ -3,6 +3,10 @@
  *
  * Creates wallets for: agent, caregiver, 3 pharmacies, bill provider
  * Funds each with XLM via Friendbot, creates USDC trustlines
+ *
+ * Idempotency: safe to re-run. Already-funded Friendbot accounts are ignored,
+ * existing USDC trustlines are skipped, and stale Horizon sequence numbers are
+ * handled by reloading the account and retrying once.
  */
 
 import { Keypair, Networks, TransactionBuilder, Operation, Asset, Horizon } from "@stellar/stellar-sdk";
@@ -173,32 +177,56 @@ async function fundAccount(publicKey: string): Promise<void> {
   }
 }
 
-async function addUsdcTrustline(keypair: Keypair): Promise<void> {
-  const server = new Horizon.Server(HORIZON_URL);
-  const account = await server.loadAccount(keypair.publicKey());
+function isTxBadSeqError(err: unknown): boolean {
+  const value = err as any;
+  const resultCode =
+    value?.response?.data?.extras?.result_codes?.transaction ??
+    value?.extras?.result_codes?.transaction ??
+    value?.result_codes?.transaction;
+  const message = value?.message ? String(value.message) : "";
+  return resultCode === "tx_bad_seq" || message.includes("tx_bad_seq");
+}
 
+export async function addUsdcTrustline(keypair: Keypair): Promise<void> {
+  const server = new Horizon.Server(HORIZON_URL);
   const usdc = new Asset("USDC", USDC_ISSUER);
 
-  // Check if trustline already exists
-  const hasTrustline = account.balances.some(
-    (b: any) => b.asset_code === "USDC" && b.asset_issuer === USDC_ISSUER
-  );
+  const buildAndSubmit = async () => {
+    const account = await server.loadAccount(keypair.publicKey());
 
-  if (hasTrustline) {
-    logger.info({ wallet: keypair.publicKey().slice(0, 8) }, "USDC trustline already exists");
-    return;
+    const hasTrustline = account.balances.some(
+      (b: any) => b.asset_code === "USDC" && b.asset_issuer === USDC_ISSUER,
+    );
+
+    if (hasTrustline) {
+      logger.info({ wallet: keypair.publicKey().slice(0, 8) }, "USDC trustline already exists");
+      return;
+    }
+
+    const tx = new TransactionBuilder(account, {
+      fee: "100",
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(Operation.changeTrust({ asset: usdc }))
+      .setTimeout(30)
+      .build();
+
+    tx.sign(keypair);
+    await server.submitTransaction(tx);
+  };
+
+  try {
+    await buildAndSubmit();
+  } catch (err) {
+    if (!isTxBadSeqError(err)) {
+      throw err;
+    }
+    logger.warn(
+      { wallet: keypair.publicKey().slice(0, 8) },
+      "USDC trustline tx_bad_seq; reloading account and retrying once",
+    );
+    await buildAndSubmit();
   }
-
-  const tx = new TransactionBuilder(account, {
-    fee: "100",
-    networkPassphrase: Networks.TESTNET,
-  })
-    .addOperation(Operation.changeTrust({ asset: usdc }))
-    .setTimeout(30)
-    .build();
-
-  tx.sign(keypair);
-  await server.submitTransaction(tx);
   logger.info({ wallet: keypair.publicKey().slice(0, 8) }, "USDC trustline added");
 }
 


### PR DESCRIPTION
Closes #202

## Summary
- Reload the Horizon account immediately before building each USDC trustline transaction.
- Detect `tx_bad_seq`, reload account state, and retry the trustline transaction once.
- Preserve idempotency by skipping transaction submission when the reloaded account already has the USDC trustline.
- Document setup script idempotency guarantees in the script header.
- Add focused Vitest coverage for the stale-sequence retry path, existing-trustline skip, and non-sequence fail-fast behavior.

## Testing
- `npm test -- scripts/__tests__/setup-wallets.test.ts scripts/__tests__/setup-wallets-trustline.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest scripts/setup-wallets.ts scripts/__tests__/setup-wallets.test.ts scripts/__tests__/setup-wallets-trustline.test.ts`
- `git diff --check`