### PR TITLE
[codex] Validate spending policy input

### DIFF
--- a/agent/__tests__/agent-endpoints.test.ts
+++ b/agent/__tests__/agent-endpoints.test.ts
@@ -57,6 +57,35 @@ vi.mock("../../shared/x402-middleware.ts", () => ({
   DEFAULT_FACILITATOR_URL: "https://channels.openzeppelin.com/x402/testnet",
 }));
 
+vi.mock("../../shared/audit-log.ts", () => ({
+  appendAuditEntry: vi.fn(),
+  auditRouter: vi.fn((_req, _res, next) => next()),
+}));
+
+vi.mock("../../shared/rate-limit.ts", () => {
+  const passThrough = vi.fn((_req, _res, next) => next());
+  return {
+    rateLimiters: {
+      agent: passThrough,
+      health: passThrough,
+      default: passThrough,
+    },
+  };
+});
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn((filePath: any) => {
+      const normalized = String(filePath).replace(/\\/g, "/");
+      if (normalized.endsWith("/careguard/data")) return true;
+      return actual.existsSync(filePath);
+    }),
+    mkdirSync: vi.fn(),
+  };
+});
+
 vi.mock("@stellar/stellar-sdk", () => ({
   Keypair: { fromSecret: vi.fn(() => ({ publicKey: () => "GMOCKAGENTWALLETPUBKEY123456" })) },
   Horizon: { Server: vi.fn(() => ({ loadAccount: vi.fn() })) },
@@ -78,6 +107,7 @@ process.env.MPP_SECRET_KEY = "test-mpp-secret-key";
 process.env.CAREGIVER_TOKEN = "test-caregiver-token";
 
 const { app } = await import("../../server.ts");
+const tools = await import("../tools.ts");
 const auth = (req: any) => req.set("Authorization", "Bearer test-caregiver-token");
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -205,41 +235,111 @@ describe("POST /agent/policy (Issue #42)", () => {
     approvalThreshold: 80,
   };
 
+  beforeEach(() => {
+    vi.mocked(tools.setSpendingPolicy).mockClear();
+  });
+
   it("valid body → 200 with success: true", async () => {
     const res = await auth(request(app).post("/agent/policy")).send(VALID_POLICY);
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+    expect(tools.setSpendingPolicy).toHaveBeenCalledWith({
+      ...VALID_POLICY,
+      holdTimeSeconds: 0,
+    });
   });
 
   it("invalid body (missing fields) → 400", async () => {
     const res = await auth(request(app).post("/agent/policy")).send({ dailyLimit: 100 });
     expect(res.status).toBe(400);
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({ field: "monthlyLimit" }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
   });
 
   it("negative value → 400", async () => {
     const res = await auth(request(app).post("/agent/policy"))
       .send({ ...VALID_POLICY, dailyLimit: -10 });
     expect(res.status).toBe(400);
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({
+        field: "dailyLimit",
+        message: "dailyLimit must be greater than 0",
+      }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
   });
 
   it("zero value → 400", async () => {
     const res = await auth(request(app).post("/agent/policy"))
       .send({ ...VALID_POLICY, monthlyLimit: 0 });
     expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_SPENDING_POLICY");
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
+  });
+
+  it("over-sane-upper-bound value → 400", async () => {
+    const res = await auth(request(app).post("/agent/policy"))
+      .send({ ...VALID_POLICY, monthlyLimit: 50_001 });
+    expect(res.status).toBe(400);
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({
+        field: "monthlyLimit",
+        message: "monthlyLimit cannot exceed 50000",
+      }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
+  });
+
+  it("dailyLimit greater than monthlyLimit → 400", async () => {
+    const res = await auth(request(app).post("/agent/policy"))
+      .send({ ...VALID_POLICY, dailyLimit: 901 });
+    expect(res.status).toBe(400);
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({
+        field: "dailyLimit",
+        message: "dailyLimit cannot exceed monthlyLimit",
+      }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
+  });
+
+  it("approvalThreshold greater than dailyLimit → 400", async () => {
+    const res = await auth(request(app).post("/agent/policy"))
+      .send({ ...VALID_POLICY, approvalThreshold: 151 });
+    expect(res.status).toBe(400);
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({
+        field: "approvalThreshold",
+        message: "approvalThreshold cannot exceed dailyLimit",
+      }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
   });
 
   it("category budgets exceeding monthlyLimit → 400", async () => {
     const res = await auth(request(app).post("/agent/policy"))
       .send({ ...VALID_POLICY, monthlyLimit: 600 });
     expect(res.status).toBe(400);
-    expect(res.body.details.join(" ")).toContain("monthlyLimit");
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({
+        field: "medicationMonthlyBudget",
+        message: "medicationMonthlyBudget + billMonthlyBudget cannot exceed monthlyLimit",
+      }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
   });
 
   it("non-object body → 400", async () => {
     const res = await auth(request(app).post("/agent/policy"))
       .set("Content-Type", "application/json")
-      .send('"just a string"');
+      .send([]);
     expect(res.status).toBe(400);
+    expect(res.body.details).toContainEqual(
+      expect.objectContaining({ field: "policy" }),
+    );
+    expect(tools.setSpendingPolicy).not.toHaveBeenCalled();
   });
 });
 

--- a/agent/__tests__/pay-for-medication.test.ts
+++ b/agent/__tests__/pay-for-medication.test.ts
@@ -132,7 +132,11 @@ describe("payForMedication — policy-blocked (Issue #35)", () => {
   });
 
   it("returns success:false when daily limit would be exceeded", async () => {
-    setSpendingPolicy("rosa", { ...DEFAULT_POLICY, dailyLimit: 10 });
+    setSpendingPolicy("rosa", {
+      ...DEFAULT_POLICY,
+      dailyLimit: 10,
+      approvalThreshold: 10,
+    });
     const r = await payForMedication("p1", "Pharma", "Drug", 50);
     expect(r.success).toBe(false);
     expect(r.error).toContain("BLOCKED BY SPENDING POLICY");
@@ -289,11 +293,11 @@ describe("checkSpendingPolicy — basic rules (Issue #35)", () => {
   it("blocks medication + bill spending at the global monthly cap", async () => {
     setSpendingPolicy("rosa", {
       ...DEFAULT_POLICY,
-      dailyLimit: 500,
+      dailyLimit: 120,
       monthlyLimit: 120,
       medicationMonthlyBudget: 80,
       billMonthlyBudget: 40,
-      approvalThreshold: 500,
+      approvalThreshold: 120,
     });
     mockMppFetch.mockResolvedValueOnce({
       json: async () => ({ success: true, order: { id: "order-global-cap" } }),

--- a/agent/__tests__/persistence.test.ts
+++ b/agent/__tests__/persistence.test.ts
@@ -120,6 +120,14 @@ import { describe, it, expect, beforeEach } from "vitest";
 // Mirrors the DATA_DIR computation in agent/tools.ts so the fake fs paths
 // we seed/inspect line up regardless of where the repo is checked out.
 const DATA_DIR = new URL("../../data", import.meta.url).pathname;
+const POLICY_FILE = `${DATA_DIR}/recipients/rosa/policy.json`;
+const VALID_POLICY = {
+  dailyLimit: 100,
+  monthlyLimit: 800,
+  medicationMonthlyBudget: 300,
+  billMonthlyBudget: 400,
+  approvalThreshold: 75,
+};
 
 function freshTracker(transactionCount: number) {
   return {
@@ -181,6 +189,116 @@ describe("Spending tracker persistence across restart (#44)", () => {
     expect(summary.policy.dailyLimit).toBe(123);
     expect(summary.policy.monthlyLimit).toBe(500);
     expect(summary.policy.approvalThreshold).toBe(90);
+  });
+});
+
+describe("Spending policy validation before persistence (#210)", () => {
+  it.each([
+    ["dailyLimit", "dailyLimit"],
+    ["monthlyLimit", "monthlyLimit"],
+    ["medicationMonthlyBudget", "medicationMonthlyBudget"],
+    ["billMonthlyBudget", "billMonthlyBudget"],
+    ["approvalThreshold", "approvalThreshold"],
+  ] as const)("rejects non-positive %s", async (field, expectedField) => {
+    vi.resetModules();
+    const tools = await import("../tools.ts");
+
+    let thrown: any;
+    try {
+      tools.setSpendingPolicy({ ...VALID_POLICY, [field]: 0 } as any);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown?.issues).toContainEqual(
+      expect.objectContaining({
+        field: expectedField,
+        message: `${expectedField} must be greater than 0`,
+      }),
+    );
+  });
+
+  it.each([
+    [
+      "missing required field",
+      (() => {
+        const { monthlyLimit: _monthlyLimit, ...rest } = VALID_POLICY;
+        return rest;
+      })(),
+      "monthlyLimit",
+      "monthlyLimit is required",
+    ],
+    [
+      "sane upper bound",
+      { ...VALID_POLICY, monthlyLimit: 50_001 },
+      "monthlyLimit",
+      "monthlyLimit cannot exceed 50000",
+    ],
+    [
+      "daily over monthly",
+      { ...VALID_POLICY, dailyLimit: 801 },
+      "dailyLimit",
+      "dailyLimit cannot exceed monthlyLimit",
+    ],
+    [
+      "approval over daily",
+      { ...VALID_POLICY, approvalThreshold: 101 },
+      "approvalThreshold",
+      "approvalThreshold cannot exceed dailyLimit",
+    ],
+    [
+      "category budgets over monthly",
+      { ...VALID_POLICY, medicationMonthlyBudget: 500, billMonthlyBudget: 400 },
+      "medicationMonthlyBudget",
+      "medicationMonthlyBudget + billMonthlyBudget cannot exceed monthlyLimit",
+    ],
+    [
+      "negative hold time",
+      { ...VALID_POLICY, holdTimeSeconds: -1 },
+      "holdTimeSeconds",
+      "holdTimeSeconds cannot be negative",
+    ],
+    [
+      "unknown field",
+      { ...VALID_POLICY, unsafeOverride: true },
+      "policy",
+      "Unrecognized key(s) in object: 'unsafeOverride'",
+    ],
+  ])("rejects %s", async (_name, policy, expectedField, expectedMessage) => {
+    vi.resetModules();
+    const tools = await import("../tools.ts");
+
+    let thrown: any;
+    try {
+      tools.setSpendingPolicy(policy as any);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown?.issues).toContainEqual(
+      expect.objectContaining({
+        field: expectedField,
+        message: expectedMessage,
+      }),
+    );
+  });
+
+  it("does not overwrite policy.json when validation fails", async () => {
+    vi.resetModules();
+    const tools = await import("../tools.ts");
+
+    tools.setSpendingPolicy(VALID_POLICY);
+    const persistedPolicy = fsState.files.get(POLICY_FILE);
+    expect(JSON.parse(persistedPolicy!).approvalThreshold).toBe(75);
+
+    expect(() =>
+      tools.setSpendingPolicy({
+        ...VALID_POLICY,
+        approvalThreshold: 101,
+      }),
+    ).toThrow(/Invalid spending policy/);
+
+    expect(fsState.files.get(POLICY_FILE)).toBe(persistedPolicy);
   });
 });
 

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -11,7 +11,7 @@
 import "dotenv/config";
 import { createHash } from "crypto";
 import { existsSync, mkdirSync } from "fs";
-import express from "express";
+import express, { type Response } from "express";
 import OpenAI from "openai";
 import { Keypair, Horizon } from "@stellar/stellar-sdk";
 import { createCorsMiddleware } from "../shared/cors.ts";
@@ -61,6 +61,13 @@ import {
 import { getPendingAdherences } from "../shared/adherence.ts";
 import { notify } from "../shared/notifications.ts";
 import { resolveStellarNetwork, validateSignerKeyForNetwork } from "../shared/stellar-network.ts";
+import {
+  SpendingPolicyInputSchema,
+  SpendingPolicyValidationError,
+  formatSpendingPolicyValidationIssues,
+  type SpendingPolicy,
+  type SpendingPolicyValidationIssue,
+} from "../shared/types.ts";
 
 const PORT = parseInt(process.env.AGENT_PORT || "3004");
 
@@ -637,41 +644,41 @@ app.get("/agent/transactions", (req, res) => {
   setCurrentRecipient(recipientId);
   res.json(getSpendingTracker());
 });
-function validatePolicyPayload(body: any): { ok: true; policy: any } | { ok: false; errors: string[] } {
-  const errors: string[] = [];
-  if (!body || typeof body !== "object") return { ok: false, errors: ["body must be a JSON object"] };
-  const fields = ["dailyLimit", "monthlyLimit", "medicationMonthlyBudget", "billMonthlyBudget", "approvalThreshold"] as const;
-  for (const f of fields) {
-    const v = body[f];
-    if (typeof v !== "number" || !Number.isFinite(v)) errors.push(`${f} must be a finite number`);
-    else if (v <= 0) errors.push(`${f} must be greater than 0`);
+function validatePolicyPayload(
+  body: unknown,
+): { ok: true; policy: SpendingPolicy } | { ok: false; errors: SpendingPolicyValidationIssue[] } {
+  const parsed = SpendingPolicyInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: formatSpendingPolicyValidationIssues(parsed.error),
+    };
   }
-  if (typeof body.dailyLimit === "number" && typeof body.monthlyLimit === "number" && body.dailyLimit > body.monthlyLimit) {
-    errors.push("dailyLimit cannot exceed monthlyLimit");
-  }
-  if (typeof body.approvalThreshold === "number" && typeof body.dailyLimit === "number" && body.approvalThreshold > body.dailyLimit) {
-    errors.push("approvalThreshold cannot exceed dailyLimit");
-  }
-  if (
-    typeof body.medicationMonthlyBudget === "number" &&
-    typeof body.billMonthlyBudget === "number" &&
-    typeof body.monthlyLimit === "number" &&
-    body.medicationMonthlyBudget + body.billMonthlyBudget > body.monthlyLimit
-  ) {
-    errors.push("medicationMonthlyBudget + billMonthlyBudget cannot exceed monthlyLimit");
-  }
-  if (errors.length > 0) return { ok: false, errors };
-  const policy = Object.fromEntries(fields.map((f) => [f, body[f]]));
-  return { ok: true, policy };
+  return { ok: true, policy: parsed.data as SpendingPolicy };
+}
+
+function invalidPolicyResponse(res: Response, details: SpendingPolicyValidationIssue[]) {
+  return res.status(400).json({
+    error: "Invalid policy",
+    code: "INVALID_SPENDING_POLICY",
+    details,
+  });
 }
 
 app.post("/agent/policy", (req, res) => {
   const result = validatePolicyPayload(req.body);
-  if (!result.ok) return res.status(400).json({ error: "Invalid policy", details: result.errors });
+  if (!result.ok) return invalidPolicyResponse(res, result.errors);
   const recipientId = (req.query.recipient_id as string) || "rosa";
   setCurrentRecipient(recipientId);
-  setSpendingPolicy(result.policy);
-  res.json({ success: true, policy: result.policy, recipientId });
+  try {
+    const policy = setSpendingPolicy(result.policy);
+    res.json({ success: true, policy: policy ?? result.policy, recipientId });
+  } catch (err) {
+    if (err instanceof SpendingPolicyValidationError) {
+      return invalidPolicyResponse(res, err.issues);
+    }
+    throw err;
+  }
 });
 app.post("/agent/reset", (req, res) => {
   const recipientId = (req.query.recipient_id as string) || "rosa";

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -56,7 +56,10 @@ import {
   TRANSACTION_CATEGORY,
   isTransactionCategory,
   normalizeTransactionCategory,
+  parseSpendingPolicyInput,
   type SpendingPolicy,
+  type SpendingPolicyInput,
+  SpendingPolicyValidationError,
   type Transaction,
 } from '../shared/types.ts';
 import { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds } from './tz.ts';
@@ -415,14 +418,6 @@ type PaymentCategory =
   | typeof TRANSACTION_CATEGORY.MEDICATIONS
   | typeof TRANSACTION_CATEGORY.BILLS;
 
-type SpendingPolicyInput = Partial<SpendingPolicy> & {
-  dailyLimit: number;
-  monthlyLimit: number;
-  medicationMonthlyBudget: number;
-  billMonthlyBudget: number;
-  approvalThreshold: number;
-};
-
 const SPENDING_CACHE_TTL_MS = 5000;
 /** Compact the JSONL log into a snapshot every this many transactions (Issue #205). */
 export const SNAPSHOT_INTERVAL = 100;
@@ -677,20 +672,13 @@ function savePolicy(policy: SpendingPolicy, recipientId?: string) {
 }
 
 function assertValidSpendingPolicy(policy: SpendingPolicy) {
-  if (
-    policy.medicationMonthlyBudget + policy.billMonthlyBudget >
-    policy.monthlyLimit
-  ) {
-    throw new Error(
-      'Invalid spending policy: medicationMonthlyBudget + billMonthlyBudget cannot exceed monthlyLimit',
-    );
-  }
+  parseSpendingPolicyInput(policy);
 }
 
 let currentPolicy: SpendingPolicy = loadPolicy();
 
-export function setSpendingPolicy(policy: SpendingPolicyInput): void;
-export function setSpendingPolicy(recipientId: string, policy: SpendingPolicyInput): void;
+export function setSpendingPolicy(policy: SpendingPolicyInput): SpendingPolicy;
+export function setSpendingPolicy(recipientId: string, policy: SpendingPolicyInput): SpendingPolicy;
 export function setSpendingPolicy(
   policyOrRecipientId: SpendingPolicyInput | string,
   maybePolicy?: SpendingPolicyInput,
@@ -701,16 +689,23 @@ export function setSpendingPolicy(
   const policy =
     typeof policyOrRecipientId === 'string' ? maybePolicy : policyOrRecipientId;
   if (!policy) {
-    throw new Error('Spending policy required');
+    throw new SpendingPolicyValidationError([
+      {
+        field: 'policy',
+        code: 'required',
+        message: 'Spending policy required',
+      },
+    ]);
   }
+  const parsedPolicy = parseSpendingPolicyInput(policy);
   const normalizedPolicy: SpendingPolicy = {
     ...DEFAULT_POLICY,
-    ...policy,
+    ...parsedPolicy,
     notifications: {
       ...DEFAULT_POLICY.notifications,
-      ...(policy.notifications || {}),
-      email: policy.notifications?.email ?? false,
-      sms: policy.notifications?.sms ?? false,
+      ...(parsedPolicy.notifications || {}),
+      email: parsedPolicy.notifications?.email ?? false,
+      sms: parsedPolicy.notifications?.sms ?? false,
     },
   };
   assertValidSpendingPolicy(normalizedPolicy);
@@ -730,6 +725,7 @@ export function setSpendingPolicy(
     title: "Spending Policy Updated",
     description: `Daily: $${normalizedPolicy.dailyLimit}, Monthly: $${normalizedPolicy.monthlyLimit}, Meds: $${normalizedPolicy.medicationMonthlyBudget}, Bills: $${normalizedPolicy.billMonthlyBudget}, Approval: $${normalizedPolicy.approvalThreshold}`,
   });
+  return normalizedPolicy;
 }
 export function getSpendingTracker(): any {
   // Return the latest disk-backed policy rather than the potentially stale

--- a/server.ts
+++ b/server.ts
@@ -10,7 +10,7 @@
 
 import "dotenv/config";
 import { createHash } from "crypto";
-import express from "express";
+import express, { type Response } from "express";
 import { Keypair, Horizon } from "@stellar/stellar-sdk";
 import OpenAI from "openai";
 import { Mppx, Store } from "mppx/server";
@@ -31,6 +31,13 @@ import {
   validateBillAuditRequest,
 } from "./shared/bill-audit.ts";
 import { sanitizeUserString } from "./shared/sanitize.ts";
+import {
+  SpendingPolicyInputSchema,
+  SpendingPolicyValidationError,
+  formatSpendingPolicyValidationIssues,
+  type SpendingPolicy,
+  type SpendingPolicyValidationIssue,
+} from "./shared/types.ts";
 
 // Sentry (gated by SENTRY_DSN)
 import { initSentry } from "./shared/sentry.ts";
@@ -1103,20 +1110,39 @@ app.get("/agent/transactions", (req, res) => {
     },
   });
 });
+function validatePolicyPayload(
+  body: unknown,
+): { ok: true; policy: SpendingPolicy } | { ok: false; errors: SpendingPolicyValidationIssue[] } {
+  const parsed = SpendingPolicyInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      errors: formatSpendingPolicyValidationIssues(parsed.error),
+    };
+  }
+  return { ok: true, policy: parsed.data as SpendingPolicy };
+}
+
+function invalidPolicyResponse(res: Response, details: SpendingPolicyValidationIssue[]) {
+  return res.status(400).json({
+    error: "Invalid policy",
+    code: "INVALID_SPENDING_POLICY",
+    details,
+  });
+}
+
 app.post("/agent/policy", (req, res) => {
-  const body = req.body;
-  if (!body || typeof body !== "object") {
-    return res.status(400).json({ error: "Invalid policy" });
+  const result = validatePolicyPayload(req.body);
+  if (!result.ok) return invalidPolicyResponse(res, result.errors);
+  try {
+    const policy = setSpendingPolicy(result.policy);
+    res.json({ success: true, policy: policy ?? result.policy });
+  } catch (err) {
+    if (err instanceof SpendingPolicyValidationError) {
+      return invalidPolicyResponse(res, err.issues);
+    }
+    throw err;
   }
-  const fields = ["dailyLimit", "monthlyLimit", "medicationMonthlyBudget", "billMonthlyBudget", "approvalThreshold"] as const;
-  const errors: string[] = [];
-  for (const f of fields) {
-    const v = body[f];
-    if (typeof v !== "number" || !Number.isFinite(v) || v <= 0) errors.push(`${f} must be a positive finite number`);
-  }
-  if (errors.length > 0) return res.status(400).json({ error: "Invalid policy", details: errors });
-  setSpendingPolicy(body);
-  res.json({ success: true, policy: body });
 });
 app.post("/agent/reset", (_req, res) => {
   resetSpendingTracker();

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,7 @@
 // CareGuard Shared Types
 
+import { z } from 'zod';
+
 /**
  * Drug Interaction Severity Convention
  * 
@@ -81,6 +83,125 @@ export interface SpendingPolicy {
     emailAddress?: string;
     phoneNumber?: string;
   };
+}
+
+export const SPENDING_POLICY_MAX_VALUE = 50_000;
+
+const moneyPolicyField = (name: string) =>
+  z
+    .number({
+      required_error: `${name} is required`,
+      invalid_type_error: `${name} must be a finite number`,
+    })
+    .finite(`${name} must be a finite number`)
+    .positive(`${name} must be greater than 0`)
+    .max(SPENDING_POLICY_MAX_VALUE, `${name} cannot exceed ${SPENDING_POLICY_MAX_VALUE}`);
+
+export const SpendingPolicyInputSchema = z
+  .object({
+    dailyLimit: moneyPolicyField('dailyLimit'),
+    monthlyLimit: moneyPolicyField('monthlyLimit'),
+    medicationMonthlyBudget: moneyPolicyField('medicationMonthlyBudget'),
+    billMonthlyBudget: moneyPolicyField('billMonthlyBudget'),
+    approvalThreshold: moneyPolicyField('approvalThreshold'),
+    holdTimeSeconds: z
+      .number({
+        invalid_type_error: 'holdTimeSeconds must be a finite number',
+      })
+      .finite('holdTimeSeconds must be a finite number')
+      .nonnegative('holdTimeSeconds cannot be negative')
+      .max(
+        SPENDING_POLICY_MAX_VALUE,
+        `holdTimeSeconds cannot exceed ${SPENDING_POLICY_MAX_VALUE}`,
+      )
+      .optional()
+      .default(0),
+    timezone: z.string().min(1, 'timezone cannot be empty').optional(),
+    toolFees: z
+      .record(
+        z
+          .number({ invalid_type_error: 'tool fee must be a finite number' })
+          .finite('tool fee must be a finite number')
+          .nonnegative('tool fee cannot be negative')
+          .max(SPENDING_POLICY_MAX_VALUE, `tool fee cannot exceed ${SPENDING_POLICY_MAX_VALUE}`),
+      )
+      .optional(),
+    notifications: z
+      .object({
+        email: z.boolean().optional().default(false),
+        sms: z.boolean().optional().default(false),
+        emailAddress: z.string().min(1, 'emailAddress cannot be empty').optional(),
+        phoneNumber: z.string().min(1, 'phoneNumber cannot be empty').optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((policy, ctx) => {
+    if (policy.dailyLimit > policy.monthlyLimit) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dailyLimit'],
+        message: 'dailyLimit cannot exceed monthlyLimit',
+      });
+    }
+
+    if (policy.approvalThreshold > policy.dailyLimit) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['approvalThreshold'],
+        message: 'approvalThreshold cannot exceed dailyLimit',
+      });
+    }
+
+    if (policy.medicationMonthlyBudget + policy.billMonthlyBudget > policy.monthlyLimit) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['medicationMonthlyBudget'],
+        message: 'medicationMonthlyBudget + billMonthlyBudget cannot exceed monthlyLimit',
+      });
+    }
+  });
+
+export type SpendingPolicyInput = z.input<typeof SpendingPolicyInputSchema>;
+
+export type SpendingPolicyValidationIssue = {
+  field: string;
+  code: string;
+  message: string;
+};
+
+export function formatSpendingPolicyValidationIssues(
+  error: z.ZodError,
+): SpendingPolicyValidationIssue[] {
+  return error.issues.map((issue) => ({
+    field: issue.path.length > 0 ? issue.path.join('.') : 'policy',
+    code: issue.code,
+    message: issue.message,
+  }));
+}
+
+export class SpendingPolicyValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = 'INVALID_SPENDING_POLICY';
+  readonly issues: SpendingPolicyValidationIssue[];
+
+  constructor(issues: SpendingPolicyValidationIssue[]) {
+    const reason = issues.map((issue) => issue.message).join('; ');
+    super(reason ? `Invalid spending policy: ${reason}` : 'Invalid spending policy');
+    this.name = 'SpendingPolicyValidationError';
+    this.issues = issues;
+  }
+}
+
+export function parseSpendingPolicyInput(input: unknown): SpendingPolicy {
+  const result = SpendingPolicyInputSchema.safeParse(input);
+  if (!result.success) {
+    throw new SpendingPolicyValidationError(
+      formatSpendingPolicyValidationIssues(result.error),
+    );
+  }
+  return result.data as SpendingPolicy;
 }
 
 // A confirmed Stellar transaction hash is always 64 lowercase/uppercase hex chars.


### PR DESCRIPTION
Closes #210

## Summary
- Add a shared zod schema for spending policy input, including required positive money fields, a 50,000 upper bound, `dailyLimit <= monthlyLimit`, `approvalThreshold <= dailyLimit`, and category budgets not exceeding the monthly cap.
- Validate `/agent/policy` requests in both server entrypoints and return 400 responses with structured `{ field, code, message }` details.
- Validate `setSpendingPolicy` before normalizing defaults or writing `policy.json`, so invalid direct tool calls cannot persist arbitrary input.

## Tests
- `npm test -- agent/__tests__/agent-endpoints.test.ts agent/__tests__/persistence.test.ts agent/__tests__/pay-for-medication.test.ts`
- `git diff --check`

## Notes
- Targeted `tsc` is blocked by existing repository type errors unrelated to this change: `agentLlmErrorTotal`, x402 template literal arguments in `agent/tools.ts`, `DatabaseSync`, and rate-limit/redis typings.
