### PR TITLE
[codex] Persist pharmacy MPP state

### DIFF
--- a/docs/services/mpp.md
+++ b/docs/services/mpp.md
@@ -1,0 +1,33 @@
+# MPP Pharmacy Payment Persistence
+
+The pharmacy payment service uses MPP charge mode for medication orders. Two
+local files under `data/` make the flow restart-safe:
+
+- `data/mpp-store.json` stores MPP challenge, replay, and settlement state for
+  the `mppx` charge handler.
+- `data/orders.json` stores confirmed pharmacy orders returned by
+  `/pharmacy/orders`.
+
+Both files are protected by `proper-lockfile` during writes. JSON updates are
+written to a temporary file first and then promoted with `renameSync`, so a
+crash cannot leave a partially-written JSON document behind.
+
+## Restart Model
+
+When the service restarts, `createFileBackedMppStore()` opens the same
+`data/mpp-store.json` file and exposes the standard MPP `get`, `put`,
+`delete`, and atomic `update` operations. This replaces the previous
+`Store.memory()` setup, where in-flight charge state disappeared on process
+exit.
+
+Confirmed orders are appended to `data/orders.json` with the same lock and
+atomic-rename model. After a restart, `/pharmacy/orders` reloads that file and
+continues returning previously-confirmed orders.
+
+## Operational Notes
+
+- The file-backed store is intended for the single-process demo deployment.
+- For multi-instance production deployments, use a shared atomic store such as
+  Redis or SQLite so all instances observe the same MPP state.
+- If a temporary file named `*.tmp-*` remains after a crash, it can be removed
+  after confirming the main JSON file parses successfully.

--- a/services/pharmacy-payment/__tests__/persistence.test.ts
+++ b/services/pharmacy-payment/__tests__/persistence.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync, readdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createFileBackedMppStore,
+  loadOrders,
+  saveOrder,
+} from "../persistence.ts";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "careguard-mpp-"));
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("pharmacy payment persistence (#200)", () => {
+  it("keeps confirmed orders queryable after a restart", async () => {
+    const ordersFile = join(testDir, "orders.json");
+    const order = {
+      id: "order-restart-1",
+      drug: "atorvastatin",
+      pharmacy: "Care Pharmacy",
+      amount: 12.5,
+      status: "confirmed",
+    };
+
+    await saveOrder(ordersFile, order);
+
+    expect(loadOrders(ordersFile)).toEqual([order]);
+  });
+
+  it("writes orders with temp-file rename cleanup", async () => {
+    const ordersFile = join(testDir, "orders.json");
+
+    await saveOrder(ordersFile, { id: "order-atomic-1" });
+
+    expect(loadOrders(ordersFile)).toEqual([{ id: "order-atomic-1" }]);
+    expect(readdirSync(testDir).some((name) => name.includes(".tmp-"))).toBe(false);
+  });
+
+  it("persists MPP store values across store instances", async () => {
+    const storeFile = join(testDir, "mpp-store.json");
+    const beforeRestart = createFileBackedMppStore(storeFile);
+
+    await beforeRestart.put("challenge:abc", {
+      status: "settled",
+      orderId: "order-abc",
+    });
+
+    const afterRestart = createFileBackedMppStore(storeFile);
+
+    await expect(afterRestart.get("challenge:abc")).resolves.toEqual({
+      status: "settled",
+      orderId: "order-abc",
+    });
+  });
+
+  it("persists atomic MPP store updates across restarts", async () => {
+    const storeFile = join(testDir, "mpp-store.json");
+    const beforeRestart = createFileBackedMppStore(storeFile);
+
+    await beforeRestart.update("attempts", (current: any) => ({
+      op: "set",
+      value: { count: (current?.count ?? 0) + 1 },
+      result: "stored",
+    }));
+
+    const afterRestart = createFileBackedMppStore(storeFile);
+
+    await expect(afterRestart.get("attempts")).resolves.toEqual({ count: 1 });
+  });
+});

--- a/services/pharmacy-payment/persistence.ts
+++ b/services/pharmacy-payment/persistence.ts
@@ -1,0 +1,109 @@
+import { dirname } from "path";
+import { createRequire } from "module";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
+import { Store } from "mppx/server";
+
+type JsonObject = Record<string, unknown>;
+type ReleaseLock = () => Promise<void> | void;
+
+const require = createRequire(import.meta.url);
+const lock = require("proper-lockfile") as {
+  lock: (
+    filePath: string,
+    options?: { retries?: number; stale?: number },
+  ) => Promise<ReleaseLock>;
+};
+
+function ensureParentDir(filePath: string) {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function readJsonFile<T>(filePath: string, fallback: T): T {
+  if (!existsSync(filePath)) return fallback;
+  return JSON.parse(readFileSync(filePath, "utf-8")) as T;
+}
+
+export function atomicWriteJson(filePath: string, value: unknown) {
+  ensureParentDir(filePath);
+  const tempFile = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tempFile, JSON.stringify(value, null, 2), "utf-8");
+  renameSync(tempFile, filePath);
+}
+
+function ensureJsonFile(filePath: string, fallback: unknown) {
+  ensureParentDir(filePath);
+  if (!existsSync(filePath)) {
+    atomicWriteJson(filePath, fallback);
+  }
+}
+
+async function withJsonFileLock<TData, TResult>(
+  filePath: string,
+  fallback: TData,
+  fn: (data: TData) => TResult | Promise<TResult>,
+): Promise<TResult> {
+  ensureJsonFile(filePath, fallback);
+  const release = await lock.lock(filePath, { retries: 10, stale: 5000 });
+  try {
+    const data = readJsonFile<TData>(filePath, fallback);
+    return await fn(data);
+  } finally {
+    await release();
+  }
+}
+
+export function loadOrders(filePath: string): any[] {
+  return readJsonFile<any[]>(filePath, []);
+}
+
+export async function saveOrder(filePath: string, order: any) {
+  await withJsonFileLock(filePath, [] as any[], (data) => {
+    const orders = Array.isArray(data) ? data : [];
+    orders.push(order);
+    atomicWriteJson(filePath, orders);
+  });
+}
+
+export function createFileBackedMppStore(filePath: string): ReturnType<typeof Store.memory> {
+  ensureJsonFile(filePath, {});
+
+  return Store.from({
+    async get(key) {
+      const data = readJsonFile<JsonObject>(filePath, {});
+      return Object.prototype.hasOwnProperty.call(data, key)
+        ? (data[key] as any)
+        : null;
+    },
+    async put(key, value) {
+      await withJsonFileLock(filePath, {} as JsonObject, (data) => {
+        data[key] = value;
+        atomicWriteJson(filePath, data);
+      });
+    },
+    async delete(key) {
+      await withJsonFileLock(filePath, {} as JsonObject, (data) => {
+        delete data[key];
+        atomicWriteJson(filePath, data);
+      });
+    },
+    async update(key, fn) {
+      return await withJsonFileLock(filePath, {} as JsonObject, (data) => {
+        const current = Object.prototype.hasOwnProperty.call(data, key)
+          ? (data[key] as never)
+          : null;
+        const change = fn(current);
+        if (change.op === "set") data[key] = change.value;
+        if (change.op === "delete") delete data[key];
+        if (change.op !== "noop") atomicWriteJson(filePath, data);
+        return change.result;
+      });
+    },
+  });
+}

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -14,7 +14,7 @@ if (!process.stdout.isTTY) {
 
 import "dotenv/config";
 import express from "express";
-import { Mppx, Store } from "mppx/server";
+import { Mppx } from "mppx/server";
 import { stellar } from "@stellar/mpp/charge/server";
 import { USDC_SAC_TESTNET } from "@stellar/mpp";
 import { createCorsMiddleware } from "../../shared/cors.ts";
@@ -27,6 +27,11 @@ import {
   MedicationOrderSchema,
   type MedicationOrderInput,
 } from "./validation.ts";
+import {
+  createFileBackedMppStore,
+  loadOrders,
+  saveOrder,
+} from "./persistence.ts";
 
 const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005");
 const RECIPIENT = process.env.PHARMACY_1_PUBLIC_KEY;
@@ -36,53 +41,14 @@ const NETWORK = "stellar:testnet";
 if (!RECIPIENT) throw new Error("PHARMACY_1_PUBLIC_KEY required in .env");
 if (!MPP_SECRET_KEY) throw new Error("MPP_SECRET_KEY required in .env");
 
-// Order storage (persisted to file)
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
-import lock from "proper-lockfile";
+// Order and MPP charge storage (persisted to files)
+import { existsSync, mkdirSync } from "fs";
 
 const DATA_DIR = new URL("../../data", import.meta.url).pathname;
 const ORDERS_FILE = `${DATA_DIR}/orders.json`;
+const MPP_STORE_FILE = `${DATA_DIR}/mpp-store.json`;
 
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
-
-function loadOrders(): any[] {
-  if (!existsSync(ORDERS_FILE)) return [];
-  return JSON.parse(readFileSync(ORDERS_FILE, "utf-8"));
-}
-
-/**
- * Save a new order to the orders file with file-level locking to prevent race conditions.
- * Ensures that concurrent calls don't lose data due to simultaneous read-modify-write operations.
- * 
- * Trade-off: File-based locking is slower than in-memory storage but is sufficient for the demo.
- * For production, consider switching to SQLite (#168) or a proper database.
- */
-async function saveOrder(order: any) {
-  let release: any;
-  try {
-    // Acquire exclusive lock on the orders file
-    release = await lock.lock(ORDERS_FILE, { retries: 10, stale: 5000 });
-    
-    // Safe read-modify-write within lock
-    const orders = loadOrders();
-    orders.push(order);
-    writeFileSync(ORDERS_FILE, JSON.stringify(orders, null, 2));
-    
-    logger.info({ orderId: order.id || 'unknown' }, 'Order saved successfully with lock');
-  } catch (err: any) {
-    logger.error({ err: err.message, orderId: order.id || 'unknown' }, 'Failed to save order');
-    throw err;
-  } finally {
-    // Always release the lock
-    if (release) {
-      try {
-        await release();
-      } catch (err: any) {
-        logger.warn({ err: err.message }, 'Failed to release file lock');
-      }
-    }
-  }
-}
 
 const app = express();
 applySecurityMiddleware(app);
@@ -103,7 +69,7 @@ app.get("/", (_req, res) => {
 });
 
 app.get("/pharmacy/orders", (_req, res) => {
-  res.json({ orders: loadOrders() });
+  res.json({ orders: loadOrders(ORDERS_FILE) });
 });
 
 // MPP charge server
@@ -114,7 +80,7 @@ const mppx = Mppx.create({
       recipient: RECIPIENT,
       currency: USDC_SAC_TESTNET,
       network: NETWORK,
-      store: Store.memory(),
+      store: createFileBackedMppStore(MPP_STORE_FILE),
     }),
   ],
 });
@@ -130,9 +96,9 @@ app.post("/pharmacy/order", async (req, res) => {
     return;
   }
 
-  const order = parsedOrder.data as MedicationOrderInput;
-  const safeDrug = sanitizeUserString(order.drug);
-  const safePharmacy = sanitizeUserString(order.pharmacy);
+  const orderInput = parsedOrder.data as MedicationOrderInput;
+  const safeDrug = sanitizeUserString(orderInput.drug);
+  const safePharmacy = sanitizeUserString(orderInput.pharmacy);
 
   // Convert Express request to Web Request for mppx
   const headers = new Headers();
@@ -152,7 +118,7 @@ app.post("/pharmacy/order", async (req, res) => {
 
   // Run MPP charge flow
   const result = await mppx.charge({
-    amount: order.amount.toFixed(2),
+    amount: orderInput.amount.toFixed(2),
     description: `Medication: ${safeDrug} from ${safePharmacy}`,
   })(webReq);
 
@@ -166,24 +132,28 @@ app.post("/pharmacy/order", async (req, res) => {
   }
 
   // Payment verified and settled on Stellar — create order
-  const order = {
+  const confirmedOrder = {
     id: `order-${Date.now()}`,
     drug: safeDrug,
     pharmacy: safePharmacy,
-    amount: order.amount,
+    amount: orderInput.amount,
     status: "confirmed",
     timestamp: new Date().toISOString(),
     network: NETWORK,
     protocol: "MPP Charge",
   };
-  await saveOrder(order);
+  await saveOrder(ORDERS_FILE, confirmedOrder);
+  logger.info(
+    { orderId: confirmedOrder.id },
+    "Order saved successfully with atomic persistence",
+  );
 
   // Return response with payment receipt headers
   const response = result.withReceipt(
     Response.json({
       success: true,
-      order,
-      message: `Payment of $${order.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
+      order: confirmedOrder,
+      message: `Payment of $${confirmedOrder.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
     })
   );
 


### PR DESCRIPTION
Closes #200

## Summary
- Replace the pharmacy MPP charge `Store.memory()` with a file-backed atomic store persisted at `data/mpp-store.json`.
- Move order persistence into a shared helper that uses file locks plus temp-file/rename JSON writes for `data/orders.json`.
- Keep confirmed orders queryable after restart and document the persistence model in `docs/services/mpp.md`.
- Rename the order handler variables to avoid shadowing the parsed request with the confirmed order record.

## Tests
- `npm test -- services/pharmacy-payment/__tests__/concurrent-orders.test.ts services/pharmacy-payment/__tests__/persistence.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest services/pharmacy-payment/server.ts services/pharmacy-payment/persistence.ts services/pharmacy-payment/__tests__/persistence.test.ts`
- `git diff --check`

## Notes
- The installed `mppx` package does not expose `Store.fileSystem()`, so this PR provides a local file-backed `AtomicStore` implementation with the same `get`/`put`/`delete`/`update` contract.
