### PR TITLE
[codex] Make order JSON writes atomic

### DIFF
--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -62,6 +62,11 @@ import {
 import { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds } from './tz.ts';
 export { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds };
 import { appendAuditEntry } from '../shared/audit-log.ts';
+import {
+  readJsonFile,
+  writeTextFileAtomic,
+  writeJsonFileAtomicLocked,
+} from '../shared/atomic-json.ts';
 import { notify } from '../shared/notifications.ts';
 import {
   getAdherenceSummary,
@@ -393,7 +398,7 @@ function migrateLegacyData() {
   }
   if (existsSync(legacyOrders) && !existsSync(`${rosaDir}/orders.json`)) {
     const data = readFileSync(legacyOrders, 'utf-8');
-    writeFileSync(`${rosaDir}/orders.json`, data);
+    writeTextFileAtomic(`${rosaDir}/orders.json`, data);
   }
   if (!existsSync(`${rosaDir}/policy.json`)) {
     writeFileSync(`${rosaDir}/policy.json`, JSON.stringify(DEFAULT_POLICY, null, 2));
@@ -1840,12 +1845,10 @@ interface OrderRecord {
   status: string; timestamp: string; network?: string; protocol?: string;
 }
 function loadOrders(recipientId?: string): OrderRecord[] {
-  const file = getOrdersFile(recipientId);
-  if (!existsSync(file)) return [];
-  return JSON.parse(readFileSync(file, "utf-8"));
+  return readJsonFile<OrderRecord[]>(getOrdersFile(recipientId), []);
 }
 function saveOrders(orders: OrderRecord[], recipientId?: string) {
-  writeFileSync(getOrdersFile(recipientId), JSON.stringify(orders, null, 2));
+  writeJsonFileAtomicLocked(getOrdersFile(recipientId), orders);
 }
 
 // --- Tool: Schedule an adherence reminder after pharmacy order (Issue #264) ---

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,10 @@ import {
   validateBillAuditRequest,
 } from "./shared/bill-audit.ts";
 import { sanitizeUserString } from "./shared/sanitize.ts";
+import {
+  appendJsonArrayItem,
+  readJsonFile,
+} from "./shared/atomic-json.ts";
 
 // Sentry (gated by SENTRY_DSN)
 import { initSentry } from "./shared/sentry.ts";
@@ -770,13 +774,10 @@ const ORDERS_FILE = `${DATA_DIR}/orders.json`;
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
 function loadOrders(): any[] {
-  if (!existsSync(ORDERS_FILE)) return [];
-  return JSON.parse(readFileSync(ORDERS_FILE, "utf-8"));
+  return readJsonFile<any[]>(ORDERS_FILE, []);
 }
-function saveOrder(order: any) {
-  const orders = loadOrders();
-  orders.push(order);
-  writeFileSync(ORDERS_FILE, JSON.stringify(orders, null, 2));
+async function saveOrder(order: any) {
+  await appendJsonArrayItem(ORDERS_FILE, order);
 }
 
 const mppx = Mppx.create({
@@ -845,7 +846,7 @@ app.post("/pharmacy/order", async (req, res) => {
     network: NETWORK,
     protocol: "MPP Charge",
   };
-  saveOrder(order);
+  await saveOrder(order);
   const response = result.withReceipt(
     Response.json({
       success: true,

--- a/services/pharmacy-payment/__tests__/concurrent-orders.test.ts
+++ b/services/pharmacy-payment/__tests__/concurrent-orders.test.ts
@@ -1,167 +1,69 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { writeFileSync, readFileSync, unlinkSync, existsSync } from 'fs';
-import { mkdirSync } from 'fs';
-import path from 'path';
-import lock from 'proper-lockfile';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendJsonArrayItem,
+  readJsonFile,
+} from "../../../shared/atomic-json.ts";
 
-/**
- * Test suite for concurrent order saving with file locking.
- * Ensures that the proper-lockfile mechanism prevents race conditions
- * when multiple orders are saved simultaneously to orders.json.
- */
+let testDir: string;
+let ordersFile: string;
 
-const TEST_DATA_DIR = path.resolve('./test-data-concurrent');
-const TEST_ORDERS_FILE = path.join(TEST_DATA_DIR, 'orders.json');
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), "careguard-orders-"));
+  ordersFile = join(testDir, "orders.json");
+});
 
-// Mock logger
-const mockLogger = {
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-};
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
 
-function loadOrders(): any[] {
-  if (!existsSync(TEST_ORDERS_FILE)) return [];
-  return JSON.parse(readFileSync(TEST_ORDERS_FILE, 'utf-8'));
-}
+describe("Pharmacy Payment - atomic order saving (#203)", () => {
+  it("preserves all 100 parallel order writes", async () => {
+    await Promise.all(
+      Array.from({ length: 100 }, (_unused, index) =>
+        appendJsonArrayItem(ordersFile, {
+          id: `order-${index}`,
+          drug: `drug-${index}`,
+          pharmacy: `pharmacy-${index % 5}`,
+          amount: index + 1,
+          status: "confirmed",
+          timestamp: new Date(0).toISOString(),
+        }),
+      ),
+    );
 
-/**
- * Save a new order to the orders file with file-level locking to prevent race conditions.
- * Ensures that concurrent calls don't lose data due to simultaneous read-modify-write operations.
- */
-async function saveOrder(order: any) {
-  let release: any;
-  try {
-    // Acquire exclusive lock on the orders file with reasonable timeout for testing
-    release = await lock.lock(TEST_ORDERS_FILE, { retries: 5, stale: 3000 });
+    const savedOrders = readJsonFile<any[]>(ordersFile, []);
+    const ids = new Set(savedOrders.map((order) => order.id));
 
-    // Safe read-modify-write within lock
-    const orders = loadOrders();
-    orders.push(order);
-    writeFileSync(TEST_ORDERS_FILE, JSON.stringify(orders, null, 2));
+    expect(savedOrders).toHaveLength(100);
+    expect(ids.size).toBe(100);
+  });
 
-    mockLogger.info({ orderId: order.id || 'unknown' }, 'Order saved successfully with lock');
-  } catch (err: any) {
-    mockLogger.error({ err: err.message, orderId: order.id || 'unknown' }, 'Failed to save order');
-    throw err;
-  } finally {
-    // Always release the lock
-    if (release) {
+  it("keeps intermediate reads parseable while writes are in flight", async () => {
+    const writes = Array.from({ length: 100 }, (_unused, index) =>
+      appendJsonArrayItem(ordersFile, { id: `order-${index}` }),
+    );
+    const reads = Array.from({ length: 100 }, async () => {
       try {
-        await release();
+        JSON.parse(readFileSync(ordersFile, "utf-8"));
       } catch (err: any) {
-        mockLogger.warn({ err: err.message }, 'Failed to release file lock');
+        if (err?.code !== "ENOENT") throw err;
       }
-    }
-  }
-}
+    });
 
-describe('Pharmacy Payment - Concurrent Order Saving', () => {
-  beforeEach(() => {
-    // Create test data directory
-    if (!existsSync(TEST_DATA_DIR)) {
-      mkdirSync(TEST_DATA_DIR, { recursive: true });
-    }
-    // Clean up any existing orders file
-    if (existsSync(TEST_ORDERS_FILE)) {
-      unlinkSync(TEST_ORDERS_FILE);
-    }
-    // Initialize empty orders file
-    writeFileSync(TEST_ORDERS_FILE, JSON.stringify([]));
-    vi.clearAllMocks();
+    await Promise.all([...writes, ...reads]);
+
+    expect(readJsonFile<any[]>(ordersFile, [])).toHaveLength(100);
   });
 
-  afterEach(() => {
-    // Clean up test files
-    if (existsSync(TEST_ORDERS_FILE)) {
-      unlinkSync(TEST_ORDERS_FILE);
-    }
-    if (existsSync(TEST_DATA_DIR)) {
-      try {
-        // Try to check if directory is empty, but don't worry if it fails
-        // Just clean up what we can
-      } catch (err) {
-        // Directory cleanup is optional
-      }
-    }
+  it("uses temp-file promotion without leaving temp files behind", async () => {
+    await appendJsonArrayItem(ordersFile, { id: "order-atomic-1" });
+
+    expect(readJsonFile<any[]>(ordersFile, [])).toEqual([
+      { id: "order-atomic-1" },
+    ]);
+    expect(readdirSync(testDir).some((name) => name.includes(".tmp-"))).toBe(false);
   });
-
-  it('should save orders sequentially without losing data', async () => {
-    const orders: any[] = [];
-
-    // Create 10 sequential order saves (file locking prevents data loss in concurrent scenarios)
-    for (let i = 0; i < 10; i++) {
-      const order = {
-        id: `order-${i}`,
-        drug: `drug-${i}`,
-        pharmacy: `pharmacy-${Math.floor(i / 5)}`,
-        amount: 10 + i,
-        status: 'confirmed',
-        timestamp: new Date().toISOString(),
-      };
-      orders.push(order);
-      await saveOrder(order);
-    }
-
-    // Verify all 10 orders are in the file
-    const savedOrders = loadOrders();
-    expect(savedOrders).toHaveLength(10);
-
-    // Verify order IDs match what we saved
-    const ids = savedOrders.map((o) => o.id);
-    const uniqueIds = new Set(ids);
-    expect(uniqueIds.size).toBe(10);
-
-    // Verify all orders have required fields
-    for (const order of savedOrders) {
-      expect(order).toHaveProperty('id');
-      expect(order).toHaveProperty('drug');
-      expect(order).toHaveProperty('pharmacy');
-      expect(order).toHaveProperty('amount');
-      expect(order).toHaveProperty('status');
-      expect(order).toHaveProperty('timestamp');
-    }
-  });
-
-  it('should handle rapid sequential saves correctly', async () => {
-    for (let i = 0; i < 10; i++) {
-      const order = {
-        id: `rapid-order-${i}`,
-        drug: `drug-rapid-${i}`,
-        amount: 25,
-        timestamp: new Date().toISOString(),
-      };
-      await saveOrder(order);
-    }
-
-    const savedOrders = loadOrders();
-    expect(savedOrders).toHaveLength(10);
-    expect(savedOrders[0].id).toBe('rapid-order-0');
-    expect(savedOrders[9].id).toBe('rapid-order-9');
-  });
-
-  it('should maintain order consistency with multiple saves', async () => {
-    // Create 2 batches of 5 sequential saves each
-    for (let batch = 0; batch < 2; batch++) {
-      for (let i = 0; i < 5; i++) {
-        const order = {
-          id: `batch-${batch}-order-${i}`,
-          batchNumber: batch,
-          orderInBatch: i,
-          amount: 15 + batch * 100 + i,
-        };
-        await saveOrder(order);
-      }
-    }
-
-    const savedOrders = loadOrders();
-    expect(savedOrders).toHaveLength(10);
-
-    // Verify batch structure is intact
-    const batch0Orders = savedOrders.filter((o) => o.batchNumber === 0);
-    const batch1Orders = savedOrders.filter((o) => o.batchNumber === 1);
-
-    expect(batch0Orders).toHaveLength(5);
-    expect(batch1Orders).toHaveLength(5);
-  }, 30000);
 });

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -27,6 +27,10 @@ import {
   MedicationOrderSchema,
   type MedicationOrderInput,
 } from "./validation.ts";
+import {
+  appendJsonArrayItem,
+  readJsonFile,
+} from "../../shared/atomic-json.ts";
 
 const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005");
 const RECIPIENT = process.env.PHARMACY_1_PUBLIC_KEY;
@@ -37,8 +41,7 @@ if (!RECIPIENT) throw new Error("PHARMACY_1_PUBLIC_KEY required in .env");
 if (!MPP_SECRET_KEY) throw new Error("MPP_SECRET_KEY required in .env");
 
 // Order storage (persisted to file)
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
-import lock from "proper-lockfile";
+import { existsSync, mkdirSync } from "fs";
 
 const DATA_DIR = new URL("../../data", import.meta.url).pathname;
 const ORDERS_FILE = `${DATA_DIR}/orders.json`;
@@ -46,42 +49,12 @@ const ORDERS_FILE = `${DATA_DIR}/orders.json`;
 if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
 
 function loadOrders(): any[] {
-  if (!existsSync(ORDERS_FILE)) return [];
-  return JSON.parse(readFileSync(ORDERS_FILE, "utf-8"));
+  return readJsonFile<any[]>(ORDERS_FILE, []);
 }
 
-/**
- * Save a new order to the orders file with file-level locking to prevent race conditions.
- * Ensures that concurrent calls don't lose data due to simultaneous read-modify-write operations.
- * 
- * Trade-off: File-based locking is slower than in-memory storage but is sufficient for the demo.
- * For production, consider switching to SQLite (#168) or a proper database.
- */
 async function saveOrder(order: any) {
-  let release: any;
-  try {
-    // Acquire exclusive lock on the orders file
-    release = await lock.lock(ORDERS_FILE, { retries: 10, stale: 5000 });
-    
-    // Safe read-modify-write within lock
-    const orders = loadOrders();
-    orders.push(order);
-    writeFileSync(ORDERS_FILE, JSON.stringify(orders, null, 2));
-    
-    logger.info({ orderId: order.id || 'unknown' }, 'Order saved successfully with lock');
-  } catch (err: any) {
-    logger.error({ err: err.message, orderId: order.id || 'unknown' }, 'Failed to save order');
-    throw err;
-  } finally {
-    // Always release the lock
-    if (release) {
-      try {
-        await release();
-      } catch (err: any) {
-        logger.warn({ err: err.message }, 'Failed to release file lock');
-      }
-    }
-  }
+  await appendJsonArrayItem(ORDERS_FILE, order);
+  logger.info({ orderId: order.id || "unknown" }, "Order saved atomically");
 }
 
 const app = express();
@@ -130,9 +103,9 @@ app.post("/pharmacy/order", async (req, res) => {
     return;
   }
 
-  const order = parsedOrder.data as MedicationOrderInput;
-  const safeDrug = sanitizeUserString(order.drug);
-  const safePharmacy = sanitizeUserString(order.pharmacy);
+  const orderInput = parsedOrder.data as MedicationOrderInput;
+  const safeDrug = sanitizeUserString(orderInput.drug);
+  const safePharmacy = sanitizeUserString(orderInput.pharmacy);
 
   // Convert Express request to Web Request for mppx
   const headers = new Headers();
@@ -152,7 +125,7 @@ app.post("/pharmacy/order", async (req, res) => {
 
   // Run MPP charge flow
   const result = await mppx.charge({
-    amount: order.amount.toFixed(2),
+    amount: orderInput.amount.toFixed(2),
     description: `Medication: ${safeDrug} from ${safePharmacy}`,
   })(webReq);
 
@@ -166,24 +139,24 @@ app.post("/pharmacy/order", async (req, res) => {
   }
 
   // Payment verified and settled on Stellar — create order
-  const order = {
+  const confirmedOrder = {
     id: `order-${Date.now()}`,
     drug: safeDrug,
     pharmacy: safePharmacy,
-    amount: order.amount,
+    amount: orderInput.amount,
     status: "confirmed",
     timestamp: new Date().toISOString(),
     network: NETWORK,
     protocol: "MPP Charge",
   };
-  await saveOrder(order);
+  await saveOrder(confirmedOrder);
 
   // Return response with payment receipt headers
   const response = result.withReceipt(
     Response.json({
       success: true,
-      order,
-      message: `Payment of $${order.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
+      order: confirmedOrder,
+      message: `Payment of $${confirmedOrder.amount} USDC settled on Stellar. ${safeDrug} order from ${safePharmacy} confirmed.`,
     })
   );
 

--- a/shared/atomic-json.ts
+++ b/shared/atomic-json.ts
@@ -1,0 +1,121 @@
+import { createRequire } from "module";
+import { dirname } from "path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "fs";
+
+type ReleaseLock = () => Promise<void> | void;
+type ReleaseLockSync = () => void;
+
+const require = createRequire(import.meta.url);
+const lock = require("proper-lockfile") as {
+  lock: (
+    filePath: string,
+    options?: {
+      retries?:
+        | number
+        | {
+            retries: number;
+            factor?: number;
+            minTimeout?: number;
+            maxTimeout?: number;
+          };
+      stale?: number;
+      realpath?: boolean;
+    },
+  ) => Promise<ReleaseLock>;
+  lockSync: (
+    filePath: string,
+    options?: { stale?: number; realpath?: boolean },
+  ) => ReleaseLockSync;
+};
+
+const ASYNC_LOCK_OPTIONS = {
+  retries: { retries: 200, factor: 1, minTimeout: 1, maxTimeout: 10 },
+  stale: 5000,
+  realpath: false,
+};
+
+const SYNC_LOCK_OPTIONS = { stale: 5000, realpath: false };
+
+function ensureParentDir(filePath: string) {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function tempPathFor(filePath: string) {
+  return `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+}
+
+export function readJsonFile<T>(filePath: string, fallback: T): T {
+  if (!existsSync(filePath)) return fallback;
+  return JSON.parse(readFileSync(filePath, "utf-8")) as T;
+}
+
+export function writeJsonFileAtomic(filePath: string, value: unknown) {
+  ensureParentDir(filePath);
+  const tempFile = tempPathFor(filePath);
+  writeFileSync(tempFile, JSON.stringify(value, null, 2), "utf-8");
+  renameSync(tempFile, filePath);
+}
+
+export function writeTextFileAtomic(filePath: string, value: string) {
+  ensureParentDir(filePath);
+  const tempFile = tempPathFor(filePath);
+  writeFileSync(tempFile, value, "utf-8");
+  renameSync(tempFile, filePath);
+}
+
+export async function withJsonFileLock<TData, TResult>(
+  filePath: string,
+  fallback: TData,
+  fn: (data: TData) => TResult | Promise<TResult>,
+): Promise<TResult> {
+  ensureParentDir(filePath);
+  const release = await lock.lock(filePath, ASYNC_LOCK_OPTIONS);
+  try {
+    const data = readJsonFile<TData>(filePath, fallback);
+    return await fn(data);
+  } finally {
+    await release();
+  }
+}
+
+export function withJsonFileLockSync<TData, TResult>(
+  filePath: string,
+  fallback: TData,
+  fn: (data: TData) => TResult,
+): TResult {
+  ensureParentDir(filePath);
+  const release = lock.lockSync(filePath, SYNC_LOCK_OPTIONS);
+  try {
+    const data = readJsonFile<TData>(filePath, fallback);
+    return fn(data);
+  } finally {
+    release();
+  }
+}
+
+export async function appendJsonArrayItem<T>(
+  filePath: string,
+  item: T,
+): Promise<T[]> {
+  return await withJsonFileLock<T[], T[]>(filePath, [], (data) => {
+    const items = Array.isArray(data) ? data : [];
+    items.push(item);
+    writeJsonFileAtomic(filePath, items);
+    return items;
+  });
+}
+
+export function writeJsonFileAtomicLocked<T>(filePath: string, value: T): void {
+  withJsonFileLockSync(filePath, value, () => {
+    writeJsonFileAtomic(filePath, value);
+  });
+}


### PR DESCRIPTION
Closes #203.

## Summary
- Added a shared atomic JSON helper that locks the target path and promotes temp files with rename.
- Moved root and pharmacy order saves to locked atomic array appends.
- Moved agent order persistence and legacy order migration off direct `writeFileSync` writes.
- Replaced the old concurrency test with 100 parallel writes plus concurrent parse-read coverage.

## Validation
- `npm test -- services/pharmacy-payment/__tests__/concurrent-orders.test.ts agent/__tests__/persistence.test.ts agent/__tests__/pay-for-medication.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest shared/atomic-json.ts services/pharmacy-payment/server.ts services/pharmacy-payment/__tests__/concurrent-orders.test.ts`
- `git diff --check`

## Notes
- A narrower typecheck that also includes `agent/tools.ts` still reports the existing x402 template literal type errors at `agent/tools.ts:269` and `agent/tools.ts:271`; no new errors were introduced by this change.