### PR TITLE
[codex] Document explicit CORS origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,11 +68,15 @@ CAREGIVER_TOKEN=
 USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 
 # --- CORS ---
-# Comma-separated list of allowed dashboard origins.
-# Example: ALLOWED_ORIGINS=https://careguard.vercel.app,https://staging.careguard.vercel.app
-ALLOWED_ORIGINS=http://localhost:3000
+# Explicit dashboard origin allowed to call the API. Never use "*".
+DASHBOARD_ORIGIN=http://localhost:3000
 
-# Optional: convenience alias used as a default allowed origin when ALLOWED_ORIGINS is unset.
+# Optional comma-separated allowlist for multiple dashboard origins.
+# When set, this takes precedence over DASHBOARD_ORIGIN.
+# ALLOWED_ORIGINS=https://careguard.vercel.app,https://staging.careguard.vercel.app
+
+# Optional: convenience alias used as a default allowed origin when both
+# ALLOWED_ORIGINS and DASHBOARD_ORIGIN are unset.
 # PROD_URL=https://careguard.onrender.com
 
 # --- Redis (optional) ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,7 +32,7 @@ The goal is to override the LLM's SYSTEM_PROMPT and trigger an unauthorized paym
 
 - **Indirect prompt injection via fetched data**: A malicious hospital bill could contain injected LLM instructions in line-item descriptions. The `auditBill()` tool fetches external content that becomes part of the LLM context. This is mitigated by the spending policy (payments still require policy approval) but not fully prevented at the input layer.
 - **Blocklist bypass**: The blocklist in `task-validation.ts` operates on lowercased substring matching. It catches common jailbreak phrases but can be defeated by novel phrasings. The spending policy is the real guard.
-- **Caregiver session hijacking**: If the caregiver dashboard is compromised, an attacker can submit any task. Mitigation: CORS allowlist, HTTPS/HSTS, session token security on the dashboard side.
+- **Caregiver session hijacking**: If the caregiver dashboard is compromised, an attacker can submit any task. Mitigation: CORS allowlist, HTTPS/HSTS, session token security on the dashboard side. See `docs/security/cors.md` for the CORS origin policy.
 
 ---
 
@@ -49,6 +49,8 @@ Helmet is mounted on all Express apps via `shared/security-middleware.ts`.
 | `Cross-Origin-Resource-Policy` | `cross-origin` | Allows dashboard to call API cross-origin |
 
 See `docs/runbooks/csp-changes.md` for how to update the CSP when adding integrations.
+
+The API CORS allowlist is configured separately from CSP. See `docs/security/cors.md` for dashboard origin configuration and verification.
 
 ---
 

--- a/docs/security/cors.md
+++ b/docs/security/cors.md
@@ -1,0 +1,46 @@
+# CORS Origin Policy
+
+CareGuard exposes payment-capable `/agent/*` endpoints. Browser access must be limited to the trusted caregiver dashboard origin so an unrelated site cannot trigger paid agent activity from a caregiver session.
+
+## Configuration
+
+Set one of these environment variables on every API deployment:
+
+| Variable | Use |
+| --- | --- |
+| `ALLOWED_ORIGINS` | Comma-separated allowlist for multiple dashboard origins. Takes precedence when set. |
+| `DASHBOARD_ORIGIN` | Single trusted dashboard origin for the common one-dashboard deployment. |
+| `PROD_URL` / `DASHBOARD_URL` | Legacy fallback aliases used only when both variables above are unset. |
+
+Local development should still use an explicit origin:
+
+```env
+DASHBOARD_ORIGIN=http://localhost:3000
+```
+
+Production should point at the deployed dashboard:
+
+```env
+DASHBOARD_ORIGIN=https://careguard.example.com
+```
+
+Staging plus production can use the allowlist:
+
+```env
+ALLOWED_ORIGINS=https://careguard.example.com,https://staging-careguard.example.com
+```
+
+## Rules
+
+- Never set `ALLOWED_ORIGINS=*` or `DASHBOARD_ORIGIN=*`; the server rejects wildcard origins at startup.
+- Requests with no `Origin` header are allowed for server-to-server and health-check calls.
+- Browser requests from origins outside the allowlist receive no `Access-Control-Allow-Origin` header, so the browser blocks access to the response.
+- Caregiver auth is expected to be sent as an explicit bearer token. If cookie-based auth is introduced later, use `SameSite=Strict` cookies and add CSRF token verification before enabling credentialed browser calls.
+
+## Verification
+
+Run the CORS regression tests after changing this policy:
+
+```sh
+npm test -- shared/__tests__/cors.test.ts
+```

--- a/shared/__tests__/cors.test.ts
+++ b/shared/__tests__/cors.test.ts
@@ -7,6 +7,8 @@ function buildApp(nodeEnv: string, allowedOrigins?: string) {
   const saved = {
     NODE_ENV: process.env.NODE_ENV,
     ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS,
+    DASHBOARD_ORIGIN: process.env.DASHBOARD_ORIGIN,
+    DASHBOARD_URL: process.env.DASHBOARD_URL,
     PROD_URL: process.env.PROD_URL,
   };
 
@@ -16,24 +18,61 @@ function buildApp(nodeEnv: string, allowedOrigins?: string) {
   } else {
     delete process.env.ALLOWED_ORIGINS;
   }
+  delete process.env.DASHBOARD_ORIGIN;
+  delete process.env.DASHBOARD_URL;
   delete process.env.PROD_URL;
 
-  const app = express();
-  app.use(createCorsMiddleware());
-  app.get("/test", (_req, res) => res.json({ ok: true }));
-
-  // Restore env immediately after building
-  process.env.NODE_ENV = saved.NODE_ENV;
-  if (saved.ALLOWED_ORIGINS !== undefined) {
-    process.env.ALLOWED_ORIGINS = saved.ALLOWED_ORIGINS;
-  } else {
-    delete process.env.ALLOWED_ORIGINS;
+  try {
+    const app = express();
+    app.use(createCorsMiddleware());
+    app.get("/test", (_req, res) => res.json({ ok: true }));
+    return app;
+  } finally {
+    // Restore env immediately after building
+    process.env.NODE_ENV = saved.NODE_ENV;
+    if (saved.ALLOWED_ORIGINS !== undefined) {
+      process.env.ALLOWED_ORIGINS = saved.ALLOWED_ORIGINS;
+    } else {
+      delete process.env.ALLOWED_ORIGINS;
+    }
+    if (saved.DASHBOARD_ORIGIN !== undefined) {
+      process.env.DASHBOARD_ORIGIN = saved.DASHBOARD_ORIGIN;
+    } else {
+      delete process.env.DASHBOARD_ORIGIN;
+    }
+    if (saved.DASHBOARD_URL !== undefined) {
+      process.env.DASHBOARD_URL = saved.DASHBOARD_URL;
+    } else {
+      delete process.env.DASHBOARD_URL;
+    }
+    if (saved.PROD_URL !== undefined) {
+      process.env.PROD_URL = saved.PROD_URL;
+    }
   }
-  if (saved.PROD_URL !== undefined) {
-    process.env.PROD_URL = saved.PROD_URL;
-  }
+}
 
-  return app;
+function withEnv<T>(values: Record<string, string | undefined>, fn: () => T): T {
+  const saved = Object.fromEntries(
+    Object.keys(values).map((key) => [key, process.env[key]]),
+  );
+  try {
+    for (const [key, value] of Object.entries(values)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
 }
 
 describe("createCorsMiddleware — production mode", () => {
@@ -98,6 +137,59 @@ describe("createCorsMiddleware — production mode", () => {
       .set("Access-Control-Request-Method", "GET");
 
     expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("uses DASHBOARD_ORIGIN when ALLOWED_ORIGINS is unset", async () => {
+    const app = withEnv(
+      {
+        NODE_ENV: "production",
+        ALLOWED_ORIGINS: undefined,
+        DASHBOARD_ORIGIN: "https://dashboard.careguard.io",
+        PROD_URL: undefined,
+        DASHBOARD_URL: undefined,
+      },
+      () => {
+        const app = express();
+        app.use(createCorsMiddleware());
+        app.get("/test", (_req, res) => res.json({ ok: true }));
+        return app;
+      },
+    );
+
+    const allowed = await supertest(app)
+      .get("/test")
+      .set("Origin", "https://dashboard.careguard.io");
+    const blocked = await supertest(app)
+      .get("/test")
+      .set("Origin", "https://evil.example.com");
+
+    expect(allowed.headers["access-control-allow-origin"]).toBe(
+      "https://dashboard.careguard.io",
+    );
+    expect(blocked.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("rejects wildcard CORS origins", () => {
+    expect(() => buildApp("production", "*")).toThrow(
+      "CORS wildcard origin '*' is not allowed",
+    );
+
+    expect(() =>
+      withEnv(
+        {
+          NODE_ENV: "production",
+          ALLOWED_ORIGINS: undefined,
+          DASHBOARD_ORIGIN: "*",
+          PROD_URL: undefined,
+          DASHBOARD_URL: undefined,
+        },
+        () => {
+          const app = express();
+          app.use(createCorsMiddleware());
+          return app;
+        },
+      ),
+    ).toThrow("CORS wildcard origin '*' is not allowed");
   });
 
   it("allows requests with no Origin header (server-to-server)", async () => {

--- a/shared/cors.ts
+++ b/shared/cors.ts
@@ -19,17 +19,33 @@ export function createCorsMiddleware(): RequestHandler {
 }
 
 function parseAllowedOrigins(): string[] {
-  const raw = process.env.ALLOWED_ORIGINS ?? "";
-  const fromEnv = raw
-    .split(",")
-    .map((o) => o.trim())
-    .filter(Boolean);
+  const fromAllowlist = parseOriginList(process.env.ALLOWED_ORIGINS);
+  if (fromAllowlist.length > 0) return fromAllowlist;
 
-  if (fromEnv.length > 0) return fromEnv;
+  const fromDashboardOrigin = parseOriginList(process.env.DASHBOARD_ORIGIN);
+  if (fromDashboardOrigin.length > 0) return fromDashboardOrigin;
 
   // Defaults: dashboard local dev + configured prod URLs
   const defaults = ["http://localhost:3000"];
   if (process.env.PROD_URL) defaults.push(process.env.PROD_URL);
   if (process.env.DASHBOARD_URL) defaults.push(process.env.DASHBOARD_URL);
-  return defaults;
+  return validateNoWildcard(defaults);
+}
+
+function parseOriginList(value?: string): string[] {
+  return validateNoWildcard(
+    (value ?? "")
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean),
+  );
+}
+
+function validateNoWildcard(origins: string[]): string[] {
+  if (origins.includes("*")) {
+    throw new Error(
+      "CORS wildcard origin '*' is not allowed. Set DASHBOARD_ORIGIN or ALLOWED_ORIGINS to explicit origins.",
+    );
+  }
+  return origins;
 }


### PR DESCRIPTION
Closes #236.

## Summary
- Add `DASHBOARD_ORIGIN` as the explicit single-dashboard CORS origin fallback when `ALLOWED_ORIGINS` is unset.
- Reject wildcard CORS origins (`*`) at middleware creation so dev and production both require explicit origins.
- Update `.env.example` to document `DASHBOARD_ORIGIN` first and keep `ALLOWED_ORIGINS` for multi-origin deployments.
- Add `docs/security/cors.md` with configuration precedence, local/prod examples, no-wildcard rules, and verification steps.
- Extend CORS tests for `DASHBOARD_ORIGIN`, blocked foreign origins, wildcard rejection, and env restoration after startup failures.

## Validation
- `npm test -- shared/__tests__/cors.test.ts shared/__tests__/security-middleware.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest shared/cors.ts shared/__tests__/cors.test.ts`
- `git diff --check`

## Notes
- This also covers the origin allowlist portion of #267, but does not close #267 because its CSRF/cookie-auth criteria are broader.