### PR TITLE
[codex] Add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,30 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan for leaked secrets
+        uses: zricethezav/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_COMMENTS: "false"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,51 @@
+title = "CareGuard gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "stellar-secret-seed"
+description = "Stellar secret seed"
+regex = '''\bS[A-Z2-7]{55}\b'''
+keywords = ["S"]
+
+[[rules.allowlists]]
+description = "Deterministic fake Stellar seeds used by tests"
+regexes = [
+  '''SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD''',
+  '''SBZVMB74Z76QZ3ZZW2JXWLRVDVUUTWB4OJ5BNQSQVZYCWPVXFZ5GMQKJ''',
+]
+
+[[rules]]
+id = "groq-api-key"
+description = "Groq API key"
+regex = '''\bgsk_[A-Za-z0-9_-]{20,}\b'''
+keywords = ["gsk_"]
+
+[[rules]]
+id = "openai-api-key"
+description = "OpenAI API key"
+regex = '''\bsk-[A-Za-z0-9_-]{20,}\b'''
+keywords = ["sk-"]
+
+[[rules]]
+id = "careguard-env-secret"
+description = "CareGuard sensitive environment variable assignment"
+regex = '''(?im)^\s*(?:export\s+)?(AGENT_SECRET_KEY|OZ_FACILITATOR_API_KEY|LLM_API_KEY|MPP_SECRET_KEY)\s*=\s*["']?[^\s"'#]{8,}'''
+keywords = [
+  "AGENT_SECRET_KEY",
+  "OZ_FACILITATOR_API_KEY",
+  "LLM_API_KEY",
+  "MPP_SECRET_KEY",
+]
+
+[[rules.allowlists]]
+description = "Documented placeholder env values"
+regexes = [
+  '''LLM_API_KEY=gsk_\.\.\.''',
+  '''LLM_API_KEY=sk-or-\.\.\.''',
+  '''LLM_API_KEY=sk-\.\.\.''',
+  '''LLM_API_KEY=<your-api-key>''',
+  '''AGENT_SECRET_KEY=\.\.\.''',
+  '''MPP_SECRET_KEY=\.\.\.''',
+]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+if command -v pre-commit >/dev/null 2>&1; then
+  pre-commit run gitleaks --hook-stage pre-commit
+elif command -v gitleaks >/dev/null 2>&1; then
+  gitleaks git --pre-commit --staged --redact --verbose --config .gitleaks.toml
+else
+  echo "gitleaks or pre-commit is required for CareGuard secret scanning."
+  echo "Install gitleaks: https://github.com/gitleaks/gitleaks#installing"
+  echo "Or install pre-commit and run: pre-commit install"
+  exit 1
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        args: ["--config", ".gitleaks.toml"]

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -10,6 +10,7 @@ Operational runbooks for on-call engineers. Each runbook follows the template:
 | Runbook | Summary |
 |---------|---------|
 | [rotate-secrets.md](rotate-secrets.md) | Quarterly and emergency rotation of all secrets (agent wallet, OZ API key, LLM key, MPP secret) |
+| [leaked-secret.md](leaked-secret.md) | Emergency response when gitleaks or review finds a committed secret |
 | [wallet-low.md](wallet-low.md) | Agent auto-paused due to low USDC or XLM balance — how to fund and resume |
 | [csp-changes.md](csp-changes.md) | Content-Security-Policy changes — how to update without breaking the dashboard |
 | [oz-facilitator-outage.md](oz-facilitator-outage.md) | OZ facilitator unreachable — recognise, communicate, fail-open vs fail-closed decision |

--- a/docs/runbooks/leaked-secret.md
+++ b/docs/runbooks/leaked-secret.md
@@ -1,0 +1,52 @@
+# Runbook: Leaked Secret
+
+**Symptom**
+
+Gitleaks fails in CI, a local pre-commit hook blocks a commit, or a maintainer reports that a Stellar seed/API key appears in git history.
+
+**Impact**
+
+Treat every leaked `AGENT_SECRET_KEY`, `OZ_FACILITATOR_API_KEY`, `LLM_API_KEY`, `MPP_SECRET_KEY`, and Stellar `S...` seed as compromised. An exposed agent wallet can authorize payments; exposed API keys can incur provider cost or let an attacker impersonate the service.
+
+**Diagnosis**
+
+1. Open the failed Secret Scan job and identify the rule id, file path, and commit SHA.
+2. Confirm whether the value is a real secret or one of the test-only fake keys allowlisted in `.gitleaks.toml`.
+3. Search the branch for additional copies:
+
+```sh
+gitleaks detect --source . --config .gitleaks.toml --redact --verbose
+```
+
+4. Check whether the leaked commit reached `main` or only exists on an unmerged branch.
+
+**Mitigation**
+
+1. Revoke or rotate the exposed credential immediately. Do not wait for a code cleanup PR.
+2. If a Stellar secret seed leaked, move funds to a newly generated wallet and update the matching public key.
+3. Disable affected deploys or pause agent payment actions if the leaked key could authorize spending.
+4. Notify maintainers in the incident channel with the affected secret type, first bad commit, and rotation status. Do not paste the secret value.
+
+**Remediation**
+
+1. Remove the secret from code, docs, logs, fixtures, and generated artifacts.
+2. Replace real-looking fixtures with deterministic fake placeholders or generated-at-test-runtime values.
+3. Run the local scanner:
+
+```sh
+gitleaks detect --source . --config .gitleaks.toml --redact --verbose
+```
+
+4. If the secret reached a shared branch, coordinate a history rewrite with maintainers using `git filter-repo` or GitHub secret-scanning remediation guidance.
+5. After history cleanup, force all contributors to re-clone or hard-reset from the cleaned branch.
+
+**Post-mortem template**
+
+- Date / duration:
+- Secret type:
+- First bad commit:
+- Where it propagated:
+- Detection source:
+- Rotation completed at:
+- History cleanup required:
+- Action items:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/supertest": "^7.2.0",
         "@vitejs/plugin-react": "^4.3.0",
         "concurrently": "^9.2.1",
+        "husky": "9.1.7",
         "ioredis-mock": "^8.9.0",
         "jsdom": "^25.0.0",
         "pino-pretty": "^13.1.3",
@@ -4500,6 +4501,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "load": "k6 run load/agent-run.js",
-    "check:env-vars": "tsx scripts/check-env-vars.ts"
+    "check:env-vars": "tsx scripts/check-env-vars.ts",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",
@@ -63,6 +64,7 @@
     "@types/supertest": "^7.2.0",
     "@vitejs/plugin-react": "^4.3.0",
     "concurrently": "^9.2.1",
+    "husky": "9.1.7",
     "ioredis-mock": "^8.9.0",
     "jsdom": "^25.0.0",
     "pino-pretty": "^13.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
       ioredis-mock:
         specifier: ^8.9.0
         version: 8.13.1(@types/ioredis-mock@8.2.7(ioredis@5.10.1))(ioredis@5.10.1)
@@ -1729,6 +1732,11 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4300,6 +4308,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
Closes #64.

## Summary
- Add a weekly + PR/push Secret Scan workflow using `zricethezav/gitleaks-action@v3` with full git history checkout.
- Add `.gitleaks.toml` with CareGuard-specific rules for Stellar secret seeds, Groq keys, OpenAI keys, and sensitive env assignments.
- Add exact allowlists for the repository's existing deterministic fake Stellar test seeds and documented placeholder env values.
- Add pre-commit and Husky hooks that run the same gitleaks config locally before commits.
- Add a leaked-secret incident runbook and index it from the runbook README.
- Add `husky` to npm and pnpm lockfiles with no unrelated dependency upgrades.

## Validation
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('package.json','utf8')); JSON.parse(fs.readFileSync('package-lock.json','utf8')); console.log('package json ok')"`
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`
- `npm test -- shared/__tests__/logger.test.ts shared/__tests__/redact.test.ts`
- `git diff --check`
- `git ls-files --stage .husky/pre-commit` shows mode `100755`.

## Notes
- `gitleaks` and `pre-commit` are not installed in this local environment, so the actual gitleaks binary scan is expected to run in GitHub Actions.