### PR TITLE
[codex] Enforce dashboard security headers

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,19 +1,65 @@
-import type { NextConfig } from "next";
+const DEFAULT_AGENT_ORIGIN = "http://localhost:3004";
+type SecurityHeader = { key: string; value: string };
+type DashboardNextConfig = {
+  output: "standalone";
+  headers(): Promise<Array<{ source: string; headers: SecurityHeader[] }>>;
+};
 
-const cspDirectives = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "frame-ancestors 'none'",
-  "object-src 'none'",
-  "connect-src 'self' https://horizon-testnet.stellar.org http://localhost:3004",
-  "img-src 'self' data: blob: https://*.amazonaws.com https://*.minio.io",
-  "style-src 'self' 'unsafe-inline'",
-  "font-src 'self' https://fonts.gstatic.com",
-  "script-src 'self'",
-].join("; ");
+function originFromUrl(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
 
-const nextConfig: NextConfig = {
+export function buildCspDirectives(agentUrl = process.env.NEXT_PUBLIC_API_URL) {
+  const agentOrigin = originFromUrl(agentUrl) ?? DEFAULT_AGENT_ORIGIN;
+  const connectSrc = [
+    "'self'",
+    "https://horizon-testnet.stellar.org",
+    "https://stellar.expert",
+    agentOrigin,
+  ].join(" ");
+
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    `connect-src ${connectSrc}`,
+    "img-src 'self' data: blob: https://*.amazonaws.com https://*.minio.io",
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self' https://fonts.gstatic.com",
+    "script-src 'self'",
+  ].join("; ");
+}
+
+export function buildSecurityHeaders(
+  nodeEnv = process.env.NODE_ENV,
+  agentUrl = process.env.NEXT_PUBLIC_API_URL,
+): SecurityHeader[] {
+  const headers = [
+    { key: "Content-Security-Policy", value: buildCspDirectives(agentUrl) },
+    { key: "X-Frame-Options", value: "DENY" },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  ];
+
+  if (nodeEnv === "production") {
+    headers.push({
+      key: "Strict-Transport-Security",
+      value: "max-age=31536000; includeSubDomains",
+    });
+  }
+
+  return headers;
+}
+
+const nextConfig: DashboardNextConfig = {
   // Self-contained output for Docker (issue #111). `next build` produces
   // .next/standalone/ with a minimal server.js. The dev server is unaffected.
   output: "standalone",
@@ -21,19 +67,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/(.*)",
-        headers: [
-          {
-            // Roll out report-only CSP first to avoid breaking existing inline/theme scripts.
-            // After all inline scripts are moved to nonce/hash, move this policy to Content-Security-Policy.
-            key: "Content-Security-Policy-Report-Only",
-            value: cspDirectives,
-          },
-          { key: "X-Frame-Options", value: "DENY" },
-          { key: "X-Content-Type-Options", value: "nosniff" },
-          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
-          { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
-        ],
+        headers: buildSecurityHeaders(),
       },
     ];
   },

--- a/dashboard/tests/__tests__/next-config.test.ts
+++ b/dashboard/tests/__tests__/next-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildCspDirectives, buildSecurityHeaders } from "../../next.config";
+
+function headerMap(headers: Array<{ key: string; value: string }>) {
+  return Object.fromEntries(headers.map((header) => [header.key, header.value]));
+}
+
+describe("dashboard security headers (#94)", () => {
+  it("builds an enforcing CSP with Stellar and agent connect origins", () => {
+    const csp = buildCspDirectives("https://api.careguard.example/v1");
+
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("https://horizon-testnet.stellar.org");
+    expect(csp).toContain("https://stellar.expert");
+    expect(csp).toContain("https://api.careguard.example");
+    expect(csp).not.toContain("https://example.com");
+  });
+
+  it("falls back to the local agent origin when NEXT_PUBLIC_API_URL is unset", () => {
+    const csp = buildCspDirectives(undefined);
+
+    expect(csp).toContain("http://localhost:3004");
+  });
+
+  it("adds HSTS only in production", () => {
+    const prodHeaders = headerMap(buildSecurityHeaders("production"));
+    const devHeaders = headerMap(buildSecurityHeaders("development"));
+
+    expect(prodHeaders["Strict-Transport-Security"]).toBe(
+      "max-age=31536000; includeSubDomains",
+    );
+    expect(devHeaders["Strict-Transport-Security"]).toBeUndefined();
+  });
+
+  it("sets the expected browser hardening headers", () => {
+    const headers = headerMap(buildSecurityHeaders("production"));
+
+    expect(headers["Content-Security-Policy"]).toContain("connect-src");
+    expect(headers["Content-Security-Policy-Report-Only"]).toBeUndefined();
+    expect(headers["X-Frame-Options"]).toBe("DENY");
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+    expect(headers["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+    expect(headers["Permissions-Policy"]).toContain("camera=()");
+  });
+});

--- a/dashboard/tests/e2e/security-headers.spec.ts
+++ b/dashboard/tests/e2e/security-headers.spec.ts
@@ -10,5 +10,8 @@ test("security headers are present", async ({ page }) => {
   expect(headers["x-content-type-options"]).toBe("nosniff");
   expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
   expect(headers["permissions-policy"]).toContain("camera=()");
-  expect(headers["content-security-policy-report-only"]).toContain("default-src 'self'");
+  expect(headers["content-security-policy"]).toContain("default-src 'self'");
+  expect(headers["content-security-policy"]).toContain("https://horizon-testnet.stellar.org");
+  expect(headers["content-security-policy"]).toContain("https://stellar.expert");
+  expect(headers["content-security-policy-report-only"]).toBeUndefined();
 });


### PR DESCRIPTION
Closes #94.

## Summary
- Switch dashboard CSP from report-only to enforcing `Content-Security-Policy`.
- Build `connect-src` from `NEXT_PUBLIC_API_URL` with a local fallback, while allowing `self`, Horizon testnet, and `stellar.expert`.
- Keep `script-src` restricted to `self` and avoid `unsafe-inline` for scripts.
- Emit HSTS only in production while retaining `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy`.
- Add focused Vitest coverage for CSP contents, disallowed-origin exclusion, local fallback, prod-only HSTS, and hardening headers.
- Update the existing Playwright header assertion from report-only CSP to enforcing CSP.

## Validation
- `npm test -- dashboard/tests/__tests__/next-config.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest next.config.ts tests/__tests__/next-config.test.ts` (run from `dashboard/`)
- `git diff --check`

## Notes
- I did not run the full Playwright suite locally because it requires starting the dashboard/server stack, but the updated E2E assertion is covered structurally and the new unit tests exercise the generated headers directly.