### PR TITLE
[codex] Stream dashboard agent state over SSE

### DIFF
--- a/agent/__tests__/stream.test.ts
+++ b/agent/__tests__/stream.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAgentStreamSignature,
+  createAgentStreamSnapshot,
+  formatSseEvent,
+  formatSseRetry,
+} from "../stream.ts";
+
+const spending = {
+  policy: {
+    dailyLimit: 100,
+    monthlyLimit: 800,
+    medicationMonthlyBudget: 300,
+    billMonthlyBudget: 500,
+    approvalThreshold: 75,
+  },
+  spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+  budgetRemaining: { medications: 300, bills: 500 },
+  transactionCount: 3,
+  recentTransactions: [],
+};
+
+describe("agent stream helpers", () => {
+  it("builds a paginated snapshot with agent status, spending, and transactions", () => {
+    const snapshot = createAgentStreamSnapshot({
+      agent: { paused: false },
+      spending,
+      tracker: {
+        transactions: [
+          { id: "tx-1" },
+          { id: "tx-2" },
+          { id: "tx-3" },
+        ],
+      },
+      limit: "2",
+      offset: "1",
+    });
+
+    expect(snapshot.agent.paused).toBe(false);
+    expect(snapshot.spending).toBe(spending);
+    expect(snapshot.transactions).toEqual([{ id: "tx-2" }, { id: "tx-3" }]);
+    expect(snapshot.pagination).toEqual({
+      total: 3,
+      limit: 2,
+      offset: 1,
+      hasMore: false,
+      hasPrevious: true,
+    });
+  });
+
+  it("formats retry and named SSE events", () => {
+    expect(formatSseRetry(3000)).toBe("retry: 3000\n\n");
+    expect(formatSseEvent("snapshot", { ok: true })).toBe(
+      'event: snapshot\ndata: {"ok":true}\n\n',
+    );
+  });
+
+  it("changes signatures when streamed state changes", () => {
+    const active = createAgentStreamSnapshot({
+      agent: { paused: false },
+      spending,
+      tracker: { transactions: [] },
+    });
+    const paused = createAgentStreamSnapshot({
+      agent: { paused: true },
+      spending,
+      tracker: { transactions: [] },
+    });
+
+    expect(createAgentStreamSignature(active)).not.toEqual(
+      createAgentStreamSignature(paused),
+    );
+  });
+});

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -58,6 +58,12 @@ import {
   fetchToolResult,
   serializeToolResultForPrompt,
 } from "./tool-result.ts";
+import {
+  createAgentStreamSignature,
+  createAgentStreamSnapshot,
+  formatSseEvent,
+  formatSseRetry,
+} from "./stream.ts";
 import { getPendingAdherences } from "../shared/adherence.ts";
 import { notify } from "../shared/notifications.ts";
 import { resolveStellarNetwork, validateSignerKeyForNetwork } from "../shared/stellar-network.ts";
@@ -484,6 +490,59 @@ let toolCallCapHitsTotal = 0;
 
 let agentPaused = false;
 
+interface AgentStreamClient {
+  res: express.Response;
+  recipientId: string;
+  limit: unknown;
+  offset: unknown;
+  lastSignature: string | null;
+  heartbeat?: ReturnType<typeof setInterval>;
+}
+
+const agentStreamClients = new Set<AgentStreamClient>();
+
+function buildAgentStreamSnapshotForClient(client: AgentStreamClient) {
+  setCurrentRecipient(client.recipientId);
+  return createAgentStreamSnapshot({
+    agent: { paused: agentPaused },
+    spending: getSpendingSummary(),
+    tracker: getSpendingTracker(),
+    limit: client.limit,
+    offset: client.offset,
+  });
+}
+
+function writeAgentStreamEvent(
+  client: AgentStreamClient,
+  event: string,
+  data: unknown,
+): boolean {
+  if (client.res.destroyed || client.res.writableEnded) return false;
+  try {
+    client.res.write(formatSseEvent(event, data));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sendAgentStreamSnapshot(
+  client: AgentStreamClient,
+  force = false,
+): void {
+  const snapshot = buildAgentStreamSnapshotForClient(client);
+  const signature = createAgentStreamSignature(snapshot);
+  if (!force && signature === client.lastSignature) return;
+  client.lastSignature = signature;
+  writeAgentStreamEvent(client, "snapshot", snapshot);
+}
+
+function broadcastAgentStreamSnapshot(): void {
+  for (const client of agentStreamClients) {
+    sendAgentStreamSnapshot(client);
+  }
+}
+
 // In-memory cache for wallet balances (5s TTL)
 interface WalletCacheEntry {
   data: { usdc: string; xlm: string; address: string };
@@ -539,6 +598,7 @@ app.post("/agent/approvals/:txId", async (req, res) => {
   if (!approve) {
     (tx as any).status = "rejected";
     saveSpending(tracker);
+    broadcastAgentStreamSnapshot();
     return res.json({ success: true, status: "rejected" });
   }
 
@@ -565,10 +625,12 @@ app.post("/agent/approvals/:txId", async (req, res) => {
       tx.stellarTxHash = result.transaction?.stellarTxHash;
       tracker.transactions[txIndex] = tx;
       saveSpending(tracker);
+      broadcastAgentStreamSnapshot();
       return res.json({ success: true, status: "completed", transaction: result.transaction });
     } else {
       (tx as any).status = "rejected";
       saveSpending(tracker);
+      broadcastAgentStreamSnapshot();
       return res.status(400).json({ success: false, error: result.error, status: "rejected" });
     }
   } catch (err: any) {
@@ -589,17 +651,58 @@ app.get("/", (_req, res) => {
   });
 });
 
+app.get("/agent/stream", (req, res) => {
+  const client: AgentStreamClient = {
+    res,
+    recipientId: (req.query.recipient_id as string) || "rosa",
+    limit: req.query.limit,
+    offset: req.query.offset,
+    lastSignature: null,
+  };
+
+  req.socket.setTimeout(0);
+  req.socket.setNoDelay(true);
+  req.socket.setKeepAlive(true);
+  res.status(200);
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
+  res.flushHeaders?.();
+
+  agentStreamClients.add(client);
+  res.write(formatSseRetry(3000));
+  sendAgentStreamSnapshot(client, true);
+
+  client.heartbeat = setInterval(() => {
+    const ok = writeAgentStreamEvent(client, "heartbeat", {
+      timestamp: new Date().toISOString(),
+    });
+    if (!ok) {
+      agentStreamClients.delete(client);
+      if (client.heartbeat) clearInterval(client.heartbeat);
+    }
+  }, 25000);
+
+  req.on("close", () => {
+    agentStreamClients.delete(client);
+    if (client.heartbeat) clearInterval(client.heartbeat);
+  });
+});
+
 app.get("/agent/status", (_req, res) => { res.json({ paused: agentPaused }); });
 app.post("/agent/pause", (_req, res) => {
   agentPaused = true;
   logger.info("agent paused by caregiver");
   notify({ level: "warning", title: "Agent Paused", description: "CareGuard agent has been paused by the caregiver. No payments or actions will be processed until resumed." });
+  broadcastAgentStreamSnapshot();
   res.json({ paused: true });
 });
 app.post("/agent/resume", (_req, res) => {
   agentPaused = false;
   logger.info("agent resumed by caregiver");
   notify({ level: "info", title: "Agent Resumed", description: "CareGuard agent has been resumed and is now processing actions." });
+  broadcastAgentStreamSnapshot();
   res.json({ paused: false });
 });
 
@@ -615,6 +718,7 @@ app.post("/agent/run", async (req, res) => {
     const result = await agentQueue.enqueue(() => runAgent(task));
     agentRunsTotal.inc({ status: "success" });
     logger.info({ toolCalls: result.toolCalls.length, truncated: result.truncated, promptTokens: result.llmUsage.promptTokens, completionTokens: result.llmUsage.completionTokens }, "agent task complete");
+    broadcastAgentStreamSnapshot();
     res.json(result);
   } catch (err: any) {
     if (err.status === 429) {
@@ -671,12 +775,14 @@ app.post("/agent/policy", (req, res) => {
   const recipientId = (req.query.recipient_id as string) || "rosa";
   setCurrentRecipient(recipientId);
   setSpendingPolicy(result.policy);
+  broadcastAgentStreamSnapshot();
   res.json({ success: true, policy: result.policy, recipientId });
 });
 app.post("/agent/reset", (req, res) => {
   const recipientId = (req.query.recipient_id as string) || "rosa";
   setCurrentRecipient(recipientId);
   resetSpendingTracker();
+  broadcastAgentStreamSnapshot();
   res.json({ success: true, recipientId });
 });
 

--- a/agent/stream.ts
+++ b/agent/stream.ts
@@ -1,0 +1,95 @@
+export interface AgentStreamStatus {
+  paused: boolean;
+  pausedReason?: string | null;
+  pausedAt?: string | null;
+}
+
+export interface AgentStreamPagination {
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  hasPrevious: boolean;
+}
+
+export interface AgentStreamSnapshot {
+  agent: AgentStreamStatus;
+  spending: unknown;
+  transactions: unknown[];
+  pagination: AgentStreamPagination;
+}
+
+export interface AgentStreamSnapshotInput {
+  agent: AgentStreamStatus;
+  spending: unknown;
+  tracker: {
+    transactions?: unknown[];
+  };
+  limit?: unknown;
+  offset?: unknown;
+}
+
+function coerceBoundedInteger(
+  value: unknown,
+  fallback: number,
+  options: { min: number; max: number },
+): number {
+  const parsed =
+    typeof value === "string" || typeof value === "number"
+      ? Number(value)
+      : NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(options.max, Math.max(options.min, Math.floor(parsed)));
+}
+
+export function createAgentStreamSnapshot({
+  agent,
+  spending,
+  tracker,
+  limit,
+  offset,
+}: AgentStreamSnapshotInput): AgentStreamSnapshot {
+  const transactions = Array.isArray(tracker.transactions)
+    ? tracker.transactions
+    : [];
+  const pageLimit = coerceBoundedInteger(limit, 25, { min: 1, max: 100 });
+  const pageOffset = coerceBoundedInteger(offset, 0, {
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+  });
+  const pagedTransactions = transactions.slice(
+    pageOffset,
+    pageOffset + pageLimit,
+  );
+
+  return {
+    agent,
+    spending,
+    transactions: pagedTransactions,
+    pagination: {
+      total: transactions.length,
+      limit: pageLimit,
+      offset: pageOffset,
+      hasMore: pageOffset + pageLimit < transactions.length,
+      hasPrevious: pageOffset > 0,
+    },
+  };
+}
+
+export function createAgentStreamSignature(
+  snapshot: AgentStreamSnapshot,
+): string {
+  return JSON.stringify(snapshot);
+}
+
+export function formatSseEvent(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export function formatSseRetry(milliseconds: number): string {
+  const retryMs = coerceBoundedInteger(milliseconds, 3000, {
+    min: 1000,
+    max: 30000,
+  });
+  return `retry: ${retryMs}\n\n`;
+}

--- a/dashboard/src/__tests__/agent-stream-schema.test.ts
+++ b/dashboard/src/__tests__/agent-stream-schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { AgentStreamSnapshotSchema } from "../lib/types";
+
+const transaction = {
+  id: "tx-1",
+  timestamp: "2026-06-26T00:00:00.000Z",
+  type: "medication",
+  description: "Medication order",
+  amount: 12.5,
+  recipient: "rosa",
+  status: "completed",
+  category: "medications",
+};
+
+const spending = {
+  policy: {
+    dailyLimit: 100,
+    monthlyLimit: 800,
+    medicationMonthlyBudget: 300,
+    billMonthlyBudget: 500,
+    approvalThreshold: 75,
+  },
+  spending: { medications: 12.5, bills: 0, serviceFees: 0, total: 12.5 },
+  budgetRemaining: { medications: 287.5, bills: 500 },
+  transactionCount: 1,
+  recentTransactions: [transaction],
+};
+
+describe("AgentStreamSnapshotSchema", () => {
+  it("accepts the SSE snapshot shape used by the dashboard", () => {
+    const parsed = AgentStreamSnapshotSchema.parse({
+      agent: { paused: false },
+      spending,
+      transactions: [transaction],
+      pagination: {
+        total: 1,
+        limit: 25,
+        offset: 0,
+        hasMore: false,
+        hasPrevious: false,
+      },
+    });
+
+    expect(parsed.agent.paused).toBe(false);
+    expect(parsed.transactions).toHaveLength(1);
+  });
+
+  it("rejects snapshots without pagination metadata", () => {
+    expect(() =>
+      AgentStreamSnapshotSchema.parse({
+        agent: { paused: false },
+        spending,
+        transactions: [transaction],
+      }),
+    ).toThrow();
+  });
+});

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
+  AgentStreamSnapshotSchema,
   SpendingDataSchema,
   TransactionSchema,
   AuditLogSchema,
@@ -59,6 +60,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   const [policyForm, setPolicyForm] = useState<PolicyForm>(DEFAULT_POLICY);
   const [policyDirty, setPolicyDirty] = useState(false);
   const [policySaved, setPolicySaved] = useState(false);
+  const [streamFallbackEnabled, setStreamFallbackEnabled] = useState(false);
   const [abortController, setAbortController] = useState<AbortController | null>(null);
 
   // Individual loading states for each data source (Issue #283)
@@ -104,7 +106,26 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     });
   }, []);
 
+  const syncSpending = useCallback(
+    (data: SpendingData, opts?: { forcePolicySync?: boolean }) => {
+      setSpending(data);
+      const forcePolicySync = Boolean(opts?.forcePolicySync);
+      const shouldSyncPolicy =
+        forcePolicySync ||
+        (activeTabRef.current !== 'policy' && !policyDirtyRef.current);
+      if (shouldSyncPolicy) {
+        setPolicyForm(data.policy);
+        setPolicyDirty(false);
+      }
+    },
+    [],
+  );
+
   const fetchAgentInfo = useCallback(async () => {
+    if (!AGENT_URL) {
+      setAgentConnected(false);
+      return;
+    }
     setLoadingAgentInfo(true);
     try {
       const res = await fetch(`${AGENT_URL}/`);
@@ -140,6 +161,10 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
 
   const fetchSpending = useCallback(
     async (opts?: { forcePolicySync?: boolean }) => {
+      if (!AGENT_URL) {
+        setLoadingSpending(false);
+        return;
+      }
       setLoadingSpending(true);
       try {
         const res = await fetch(`${AGENT_URL}/agent/spending`);
@@ -148,24 +173,20 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
           return;
         }
         const data = SpendingDataSchema.parse(await res.json());
-        setSpending(data);
-        const forcePolicySync = Boolean(opts?.forcePolicySync);
-        const shouldSyncPolicy =
-          forcePolicySync ||
-          (activeTabRef.current !== 'policy' && !policyDirtyRef.current);
-        if (shouldSyncPolicy) {
-          setPolicyForm(data.policy);
-          setPolicyDirty(false);
-        }
+        syncSpending(data, opts);
       } catch {} finally {
         setLoadingSpending(false);
       }
     },
-    [],
+    [syncSpending],
   );
 
   const fetchTransactions = useCallback(
     async (limit?: number, offset?: number) => {
+      if (!AGENT_URL) {
+        setLoadingTransactions(false);
+        return;
+      }
       setLoadingTransactions(true);
       try {
         const params = new URLSearchParams();
@@ -199,10 +220,82 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     [],
   );
 
-  // Poll spending and transactions every 3s with backoff
-  const spendingPoll = usePoll({
+  useEffect(() => {
+    if (
+      !AGENT_URL ||
+      typeof window === 'undefined' ||
+      typeof window.EventSource === 'undefined'
+    ) {
+      setStreamFallbackEnabled(true);
+      return;
+    }
+
+    let opened = false;
+    let closed = false;
+    const streamUrl = new URL(`${AGENT_URL.replace(/\/$/, '')}/agent/stream`);
+    streamUrl.searchParams.set('limit', String(pageSize));
+    streamUrl.searchParams.set('offset', String(currentPage * pageSize));
+    const source = new window.EventSource(streamUrl.toString());
+    const openTimeout = window.setTimeout(() => {
+      if (opened || closed) return;
+      closed = true;
+      source.close();
+      setAgentConnected(false);
+      setStreamFallbackEnabled(true);
+    }, 5000);
+
+    source.onopen = () => {
+      opened = true;
+      setAgentConnected(true);
+      setStreamFallbackEnabled(false);
+      window.clearTimeout(openTimeout);
+    };
+
+    source.addEventListener('snapshot', (event) => {
+      try {
+        const payload = JSON.parse((event as MessageEvent).data);
+        const snapshot = AgentStreamSnapshotSchema.parse(payload);
+        syncSpending(snapshot.spending);
+        setAllTransactions(snapshot.transactions);
+        setPagination(snapshot.pagination);
+        setAgentConnected(true);
+        setAgentPaused(snapshot.agent.paused);
+        setAgentPausedReason(
+          typeof snapshot.agent.pausedReason === 'string'
+            ? snapshot.agent.pausedReason
+            : null,
+        );
+        setLoadingSpending(false);
+        setLoadingTransactions(false);
+      } catch (error) {
+        console.error('[AgentStream] Invalid stream snapshot:', error);
+        closed = true;
+        source.close();
+        setStreamFallbackEnabled(true);
+      }
+    });
+
+    source.onerror = () => {
+      if (!opened) {
+        closed = true;
+        source.close();
+        setAgentConnected(false);
+        setStreamFallbackEnabled(true);
+        window.clearTimeout(openTimeout);
+      }
+    };
+
+    return () => {
+      closed = true;
+      source.close();
+      window.clearTimeout(openTimeout);
+    };
+  }, [currentPage, pageSize, syncSpending]);
+
+  // Poll spending and transactions only when SSE is unavailable.
+  usePoll({
     intervalMs: 3000,
-    enabled: true,
+    enabled: streamFallbackEnabled,
     onPoll: async () => {
       await fetchSpending();
       await fetchTransactions(pageSize, currentPage * pageSize);
@@ -213,9 +306,9 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   });
 
   // Poll agent info every 10s with backoff
-  const agentInfoPoll = usePoll({
+  usePoll({
     intervalMs: 10000,
-    enabled: true,
+    enabled: streamFallbackEnabled,
     onPoll: fetchAgentInfo,
     onError: (error) => {
       console.error('[Poll] Agent info poll error:', error.message);
@@ -273,7 +366,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         }
         const data: AgentResult = await res.json();
         setAgentResult(data);
-        setSpending(data.spending);
+        syncSpending(data.spending);
         setLiveMessage(`Task complete — ${data.toolCalls.length} tool calls`);
         for (const tc of data.toolCalls) {
           const resultPreview = tc.result?.error
@@ -306,7 +399,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         setAbortController(null);
       }
     },
-    [agentConnected, addLogEntry, fetchAgentInfo, fetchTransactions, pageSize],
+    [agentConnected, addLogEntry, fetchAgentInfo, fetchTransactions, pageSize, syncSpending],
   );
 
   const cancelAgentTask = useCallback(() => {
@@ -335,9 +428,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       const spendingRes = await fetch(`${AGENT_URL}/agent/spending`);
       if (spendingRes.ok) {
         const data = SpendingDataSchema.parse(await spendingRes.json());
-        setSpending(data);
-        setPolicyForm(data.policy);
-        setPolicyDirty(false);
+        syncSpending(data, { forcePolicySync: true });
       }
       addLogEntry(
         `[${new Date().toLocaleTimeString()}] Policy updated: daily=$${policyForm.dailyLimit}, monthly=$${policyForm.monthlyLimit}, meds=$${policyForm.medicationMonthlyBudget}, bills=$${policyForm.billMonthlyBudget}, approval=$${policyForm.approvalThreshold}`,
@@ -352,7 +443,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       );
       return { ok: false, error: err.message };
     }
-  }, [addLogEntry, policyForm]);
+  }, [addLogEntry, policyForm, syncSpending]);
 
   const resetAgent = useCallback(async () => {
     await fetch(`${AGENT_URL}/agent/reset`, { method: 'POST' });

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -104,6 +104,27 @@ export const SpendingDataSchema = z.object({
 
 export type SpendingData = z.infer<typeof SpendingDataSchema>;
 
+export const PaginationDataSchema = z.object({
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+  hasMore: z.boolean(),
+  hasPrevious: z.boolean(),
+});
+
+export const AgentStreamSnapshotSchema = z.object({
+  agent: z.object({
+    paused: z.boolean(),
+    pausedReason: z.string().nullable().optional(),
+    pausedAt: z.string().nullable().optional(),
+  }),
+  spending: SpendingDataSchema,
+  transactions: z.array(TransactionSchema),
+  pagination: PaginationDataSchema,
+});
+
+export type AgentStreamSnapshot = z.infer<typeof AgentStreamSnapshotSchema>;
+
 export type RecipientProfile = {
   name: string;
   age?: number;

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,6 +1,7 @@
 # Load Testing
 
-This document covers the load test for concurrent `/agent/run` requests (Issue #55).
+This document covers the load tests for concurrent `/agent/run` requests (Issue #55)
+and dashboard Server-Sent Events (SSE) streams (Issue #274).
 
 ## Goal
 
@@ -37,7 +38,31 @@ To target a different server:
 BASE_URL=https://your-app.onrender.com k6 run load/agent-run.js
 ```
 
+### Dashboard SSE streams
+
+Issue #274 replaces the dashboard's repeated spending and transaction polling
+with a long-lived `GET /agent/stream` connection. Use the stream load smoke test
+to verify the agent can hold dashboard-scale concurrency without reopening HTTP
+poll requests:
+
+```bash
+# From the careguard/ root
+BASE_URL=http://localhost:3004 CONNECTIONS=1000 HOLD_MS=30000 npm run load:stream
+```
+
+For a quick local smoke test:
+
+```bash
+BASE_URL=http://localhost:3004 CONNECTIONS=50 HOLD_MS=3000 npm run load:stream
+```
+
+The script opens `CONNECTIONS` SSE connections, waits until every connection
+receives the initial `snapshot` event, holds them open for `HOLD_MS`, and exits
+non-zero if any stream fails to open or misses its snapshot.
+
 ## What it checks
+
+### `/agent/run`
 
 | Check | Threshold |
 |---|---|
@@ -51,6 +76,18 @@ After all runs complete, the script fetches `/agent/spending` and compares:
 - **Actual** service fees from the tracker
 
 A mismatch indicates a lost write or double-count from a race condition.
+
+### `/agent/stream`
+
+| Check | Threshold |
+|---|---|
+| Opened SSE connections | equals `CONNECTIONS` |
+| Initial `snapshot` events | equals `CONNECTIONS` |
+| Stream failures | `0` |
+
+Because `/agent/stream` only broadcasts snapshots when state changes, an idle
+dashboard population should settle at open sockets plus periodic heartbeat
+events rather than repeated spending/transaction HTTP polling.
 
 ## CI
 

--- a/load/agent-stream.js
+++ b/load/agent-stream.js
@@ -1,0 +1,118 @@
+/**
+ * SSE load smoke test for /agent/stream (Issue #274).
+ *
+ * Opens many long-lived dashboard streams and verifies that each connection
+ * receives the initial snapshot event without repeatedly polling HTTP routes.
+ *
+ * Usage:
+ *   BASE_URL=http://localhost:3004 CONNECTIONS=1000 HOLD_MS=30000 npm run load:stream
+ */
+
+import http from "http";
+import https from "https";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:3004";
+const CONNECTIONS = Number(process.env.CONNECTIONS || "1000");
+const HOLD_MS = Number(process.env.HOLD_MS || "30000");
+const RAMP_MS = Number(process.env.RAMP_MS || "5000");
+const SNAPSHOT_TIMEOUT_MS = Number(process.env.SNAPSHOT_TIMEOUT_MS || "15000");
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let opened = 0;
+let snapshots = 0;
+let failures = 0;
+const requests = new Set();
+
+function openStream(index) {
+  return new Promise((resolve) => {
+    const url = new URL("/agent/stream", BASE_URL);
+    url.searchParams.set("limit", "1");
+    url.searchParams.set("offset", "0");
+
+    const client = url.protocol === "https:" ? https : http;
+    let receivedSnapshot = false;
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (!ok) failures += 1;
+      resolve(ok);
+    };
+    const req = client.get(
+      url,
+      { headers: { Accept: "text/event-stream" } },
+      (res) => {
+        const contentType = String(res.headers["content-type"] || "");
+        if (res.statusCode !== 200 || !contentType.includes("text/event-stream")) {
+          finish(false);
+          res.resume();
+          return;
+        }
+
+        opened += 1;
+        res.setEncoding("utf8");
+        let buffer = "";
+        res.on("data", (chunk) => {
+          buffer = `${buffer}${chunk}`.slice(-4096);
+          if (!receivedSnapshot && buffer.includes("event: snapshot")) {
+            receivedSnapshot = true;
+            snapshots += 1;
+            finish(true);
+          }
+        });
+        res.on("error", () => {
+          finish(receivedSnapshot);
+        });
+      },
+    );
+
+    requests.add(req);
+    req.setTimeout(HOLD_MS + SNAPSHOT_TIMEOUT_MS, () => {
+      req.destroy(new Error("stream timed out"));
+    });
+    req.on("error", () => {
+      finish(receivedSnapshot);
+    });
+
+    if (index === CONNECTIONS - 1) {
+      process.stdout.write("\n");
+    }
+  });
+}
+
+const rampDelayMs = CONNECTIONS > 0 ? Math.floor(RAMP_MS / CONNECTIONS) : 0;
+const attempts = [];
+
+for (let i = 0; i < CONNECTIONS; i += 1) {
+  attempts.push(openStream(i));
+  if (rampDelayMs > 0) {
+    await sleep(rampDelayMs);
+  }
+  if ((i + 1) % 100 === 0) {
+    process.stdout.write(".");
+  }
+}
+
+await Promise.race([
+  Promise.all(attempts),
+  sleep(SNAPSHOT_TIMEOUT_MS),
+]);
+
+await sleep(HOLD_MS);
+for (const req of requests) {
+  req.destroy();
+}
+
+const ok = opened === CONNECTIONS && snapshots === CONNECTIONS && failures === 0;
+
+console.log(`=== CareGuard SSE Stream Load Summary ===
+Target:      ${BASE_URL}/agent/stream
+Connections: ${CONNECTIONS}
+Opened:      ${opened}
+Snapshots:   ${snapshots}
+Failures:    ${failures}
+Held for:    ${HOLD_MS}ms
+Result:      ${ok ? "PASS" : "FAIL"}`);
+
+process.exit(ok ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "load": "k6 run load/agent-run.js",
+    "load:stream": "node load/agent-stream.js",
     "check:env-vars": "tsx scripts/check-env-vars.ts"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary

Closes #274.

Replaces the dashboard's repeated spending/transaction polling path with a Server-Sent Events stream:

- adds `GET /agent/stream` on the agent server with initial snapshots, retry hints, heartbeat events, and a connection pool
- broadcasts fresh snapshots after agent state changes: pause/resume, policy update, reset, approvals, and completed runs
- moves dashboard spending, transactions, pagination, and agent paused state onto `EventSource`
- keeps the existing polling code as a fallback when SSE is unsupported or the stream cannot open
- adds a reusable `npm run load:stream` script for 1000 dashboard stream smoke tests

## Validation

- `npm test -- agent/__tests__/stream.test.ts dashboard/src/__tests__/agent-stream-schema.test.ts`
- `node --check load/agent-stream.js`
- `git diff --check`

Notes:

- `npm run build` is currently blocked by existing repository-wide type errors unrelated to this change, including missing Playwright/Next typings and existing test typing issues.
- `npm test -- dashboard/src/__tests__/copy-button.test.tsx` is also blocked in this checkout by missing `next/navigation` resolution.
