### PR TITLE
[codex] Handle agent task timeouts distinctly

### DIFF
--- a/dashboard/src/__tests__/agent-task-timeout.test.ts
+++ b/dashboard/src/__tests__/agent-task-timeout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_TASK_CANCELLED_MESSAGE,
+  AGENT_TASK_TIMEOUT_MESSAGE,
+  AGENT_TASK_TIMEOUT_MS,
+  getAgentTaskAbortMessage,
+} from "../hooks/agent-task-timeout";
+
+describe("agent task timeout helpers", () => {
+  it("uses a 90 second frontend timeout", () => {
+    expect(AGENT_TASK_TIMEOUT_MS).toBe(90_000);
+  });
+
+  it("returns the timeout message for timeout-triggered aborts", () => {
+    expect(getAgentTaskAbortMessage(true)).toBe(
+      AGENT_TASK_TIMEOUT_MESSAGE,
+    );
+    expect(AGENT_TASK_TIMEOUT_MESSAGE).toBe(
+      "Agent didn't respond — try again or check status",
+    );
+  });
+
+  it("keeps user cancellation distinct from timeout aborts", () => {
+    expect(getAgentTaskAbortMessage(false)).toBe(
+      AGENT_TASK_CANCELLED_MESSAGE,
+    );
+  });
+});

--- a/dashboard/src/hooks/agent-task-timeout.ts
+++ b/dashboard/src/hooks/agent-task-timeout.ts
@@ -1,0 +1,9 @@
+export const AGENT_TASK_TIMEOUT_MS = 90_000;
+export const AGENT_TASK_TIMEOUT_MESSAGE =
+  "Agent didn't respond — try again or check status";
+export const AGENT_TASK_CANCELLED_MESSAGE = "Cancelled";
+export const AGENT_TASK_CANCELLED_TOAST = "Agent task cancelled";
+
+export function getAgentTaskAbortMessage(timedOut: boolean): string {
+  return timedOut ? AGENT_TASK_TIMEOUT_MESSAGE : AGENT_TASK_CANCELLED_MESSAGE;
+}

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -19,6 +19,12 @@ import type {
 } from '../components/types';
 import { usePoll } from './use-poll';
 import { AGENT_URL } from '../lib/agent-url';
+import {
+  AGENT_TASK_CANCELLED_TOAST,
+  AGENT_TASK_TIMEOUT_MESSAGE,
+  AGENT_TASK_TIMEOUT_MS,
+  getAgentTaskAbortMessage,
+} from './agent-task-timeout';
 
 
 const DEFAULT_POLICY = {
@@ -243,11 +249,12 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
       
       const controller = new AbortController();
       setAbortController(controller);
+      let timedOut = false;
       
       const timeoutId = setTimeout(() => {
+        timedOut = true;
         controller.abort();
-        addLogEntry(`[${new Date().toLocaleTimeString()}] Agent task timed out`);
-      }, 60000);
+      }, AGENT_TASK_TIMEOUT_MS);
       
       try {
         const res = await fetch(`${AGENT_URL}/agent/run`, {
@@ -288,10 +295,14 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
         fetchAgentInfo();
       } catch (err: any) {
         if (err.name === 'AbortError') {
+          const message = getAgentTaskAbortMessage(timedOut);
           addLogEntry(
-            `[${new Date().toLocaleTimeString()}] Cancelled`,
+            `[${new Date().toLocaleTimeString()}] ${message}`,
           );
-          toast.error('Agent task cancelled');
+          setLiveMessage(message);
+          toast.error(
+            timedOut ? AGENT_TASK_TIMEOUT_MESSAGE : AGENT_TASK_CANCELLED_TOAST,
+          );
         } else {
           addLogEntry(
             `[${new Date().toLocaleTimeString()}] Connection error: ${err.message}`,


### PR DESCRIPTION
## Summary

Closes #214.

Completes the dashboard's hung-agent handling:

- moves the frontend agent task timeout into a shared helper and sets it to 90 seconds
- distinguishes timeout-triggered aborts from user-triggered cancel actions
- shows the required timeout message: `Agent didn't respond — try again or check status`
- preserves the existing Cancel button next to the loading spinner
- adds Vitest coverage for the timeout and cancel abort branches

## Validation

- `npm test -- dashboard/src/__tests__/agent-task-timeout.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest dashboard/src/hooks/agent-task-timeout.ts dashboard/src/__tests__/agent-task-timeout.test.ts`
- `git diff --check`
