### PR TITLE
[codex] Redact tool call log arguments

### DIFF
--- a/agent/__tests__/tool-log-redaction.test.ts
+++ b/agent/__tests__/tool-log-redaction.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  SAFE_TOOL_LOG_FIELDS,
+  buildToolCallLogFields,
+  redactToolCallInput,
+} from "../tool-log-redaction.ts";
+
+const TOOL_INPUTS: Record<keyof typeof SAFE_TOOL_LOG_FIELDS, Record<string, unknown>> = {
+  compare_pharmacy_prices: {
+    drug_name: "Lisinopril",
+    dosage: "10mg",
+    zip_code: "90210",
+    recipient_id: "rosa",
+  },
+  audit_medical_bill: {
+    line_items_json: '[{"chargedAmount":999}]',
+    recipient_id: "rosa",
+  },
+  check_drug_interactions: {
+    medications: ["Lisinopril", "Metformin"],
+    recipient_id: "rosa",
+  },
+  fetch_tool_result: {
+    result_id: "result-123",
+    offset: 0,
+    limit: 10,
+  },
+  pay_for_medication: {
+    pharmacy_id: "pharm-1",
+    pharmacy_name: "Downtown Pharmacy",
+    drug_name: "Lisinopril",
+    amount: 42.5,
+    days_supply: 30,
+    recipient_id: "rosa",
+  },
+  pay_bill: {
+    provider_id: "provider-1",
+    provider_name: "General Hospital",
+    description: "Surgery follow-up",
+    amount: 600,
+    recipient_id: "rosa",
+  },
+  check_spending_policy: {
+    amount: 600,
+    category: "bills",
+    recipient_id: "rosa",
+  },
+  fetch_rosa_bill: {
+    recipient_id: "rosa",
+  },
+  fetch_and_audit_bill: {
+    recipient_id: "rosa",
+  },
+  get_spending_summary: {
+    recipient_id: "rosa",
+  },
+  get_wallet_balance: {
+    address: "GSECRET",
+  },
+  generate_dispute_letter: {
+    bill_id: "bill-1",
+    audit_result_json: '{"totalOvercharge":500}',
+    error_descriptions: ["Duplicate charge"],
+    recipient_name: "Rosa Garcia",
+    facility: "General Hospital",
+    caregiver_name: "Maria Garcia",
+    caregiver_email: "maria@example.com",
+    recipient_id: "rosa",
+  },
+  get_adherence_status: {
+    recipient_id: "rosa",
+  },
+  confirm_adherence: {
+    record_id: "adh-1",
+    recipient_id: "rosa",
+  },
+};
+
+describe("tool call log redaction", () => {
+  it("has a test input for every allowlisted tool", () => {
+    expect(Object.keys(TOOL_INPUTS).sort()).toEqual(
+      Object.keys(SAFE_TOOL_LOG_FIELDS).sort(),
+    );
+  });
+
+  for (const [tool, input] of Object.entries(TOOL_INPUTS)) {
+    it(`redacts non-allowlisted ${tool} fields`, () => {
+      const redacted = redactToolCallInput(tool, input);
+      const safeFields: ReadonlySet<string> = new Set(
+        SAFE_TOOL_LOG_FIELDS[tool as keyof typeof SAFE_TOOL_LOG_FIELDS],
+      );
+
+      for (const [field, value] of Object.entries(input)) {
+        if (safeFields.has(field)) {
+          expect(redacted[field]).toEqual(value);
+        } else {
+          expect(redacted[field]).toBe(`<redacted: ${field}>`);
+        }
+      }
+    });
+  }
+
+  it("logs tool calls as structured args instead of a truncated string", () => {
+    const fields = buildToolCallLogFields("pay_bill", TOOL_INPUTS.pay_bill);
+
+    expect(fields.tool).toBe("pay_bill");
+    expect(typeof fields.args).toBe("object");
+    expect(fields.args.provider_name).toBe("General Hospital");
+    expect(fields.args.amount).toBe("<redacted: amount>");
+    expect(fields.args.recipient_id).toBe("<redacted: recipient_id>");
+  });
+
+  it("redacts every field for unknown tools", () => {
+    expect(redactToolCallInput("unknown_tool", { amount: 10, foo: "bar" })).toEqual({
+      amount: "<redacted: amount>",
+      foo: "<redacted: foo>",
+    });
+  });
+});

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -58,6 +58,7 @@ import {
   fetchToolResult,
   serializeToolResultForPrompt,
 } from "./tool-result.ts";
+import { buildToolCallLogFields } from "./tool-log-redaction.ts";
 import { getPendingAdherences } from "../shared/adherence.ts";
 import { notify } from "../shared/notifications.ts";
 import { resolveStellarNetwork, validateSignerKeyForNetwork } from "../shared/stellar-network.ts";
@@ -407,7 +408,7 @@ async function runAgent(task: string) {
         fnArgs = {};
       }
 
-      logger.info({ tool: fnName, args: JSON.stringify(fnArgs).slice(0, 100) }, "tool call");
+      logger.info(buildToolCallLogFields(fnName, fnArgs), "tool call");
 
       let result: ToolResult;
       try {

--- a/agent/tool-log-redaction.ts
+++ b/agent/tool-log-redaction.ts
@@ -1,0 +1,52 @@
+type ToolLogAllowlist = Record<string, readonly string[]>;
+
+export const SAFE_TOOL_LOG_FIELDS = {
+  compare_pharmacy_prices: ["drug_name", "dosage"],
+  audit_medical_bill: [],
+  check_drug_interactions: [],
+  fetch_tool_result: ["result_id", "offset", "limit"],
+  pay_for_medication: ["pharmacy_id", "pharmacy_name", "drug_name", "days_supply"],
+  pay_bill: ["provider_id", "provider_name"],
+  check_spending_policy: ["category"],
+  fetch_rosa_bill: [],
+  fetch_and_audit_bill: [],
+  get_spending_summary: [],
+  get_wallet_balance: [],
+  generate_dispute_letter: ["bill_id", "facility"],
+  get_adherence_status: [],
+  confirm_adherence: ["record_id"],
+} as const satisfies ToolLogAllowlist;
+
+function summarizeAllowedValue(value: unknown): unknown {
+  if (Array.isArray(value)) return `<array: ${value.length} items>`;
+  if (value && typeof value === "object") return "<object>";
+  return value;
+}
+
+export function redactToolCallInput(
+  toolName: string,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const allowedFields: ReadonlySet<string> = new Set(
+    SAFE_TOOL_LOG_FIELDS[toolName as keyof typeof SAFE_TOOL_LOG_FIELDS] ?? [],
+  );
+
+  return Object.fromEntries(
+    Object.entries(input).map(([field, value]) => [
+      field,
+      allowedFields.has(field)
+        ? summarizeAllowedValue(value)
+        : `<redacted: ${field}>`,
+    ]),
+  );
+}
+
+export function buildToolCallLogFields(
+  toolName: string,
+  input: Record<string, unknown>,
+): { tool: string; args: Record<string, unknown> } {
+  return {
+    tool: toolName,
+    args: redactToolCallInput(toolName, input),
+  };
+}

--- a/docs/observability/redaction.md
+++ b/docs/observability/redaction.md
@@ -1,0 +1,40 @@
+# Tool Call Log Redaction
+
+CareGuard logs agent tool calls as structured fields, but tool inputs can contain
+care recipient identifiers, billing details, payment amounts, line items,
+locations, medication lists, and caregiver contact details.
+
+## Convention
+
+Tool-call logs must use an explicit per-tool allowlist. Any input field that is
+not allowlisted is logged as:
+
+```text
+<redacted: field_name>
+```
+
+Do not truncate raw JSON strings as a privacy control. Truncation can still leak
+sensitive values depending on object field order.
+
+## Implementation
+
+The allowlist lives in `agent/tool-log-redaction.ts`:
+
+- `SAFE_TOOL_LOG_FIELDS` defines fields that are safe to include for each tool.
+- `redactToolCallInput(toolName, input)` applies the allowlist.
+- `buildToolCallLogFields(toolName, input)` returns the structured logger
+  payload used by `agent/server.ts`.
+
+Unknown tool names default to redacting every input field.
+
+## Adding Or Changing Tools
+
+When adding a new tool input:
+
+1. Add the tool name to `SAFE_TOOL_LOG_FIELDS`.
+2. Allowlist only fields that are operationally useful and not sensitive.
+3. Add or update the representative input in
+   `agent/__tests__/tool-log-redaction.test.ts`.
+4. Keep payment amounts, care recipient IDs, billing line items, caregiver
+   contact details, free-text descriptions, and raw JSON payloads redacted by
+   default.


### PR DESCRIPTION
## Summary

Closes #242.

Replaces arbitrary 100-character tool argument truncation with explicit structured redaction:

- adds `SAFE_TOOL_LOG_FIELDS` with a per-tool allowlist
- redacts all non-allowlisted fields as `<redacted: field_name>`
- defaults unknown tools to redact every input field
- updates `agent/server.ts` to log structured redacted args instead of sliced JSON
- documents the convention in `docs/observability/redaction.md`
- adds Vitest coverage for every allowlisted tool shape, structured logger output, and unknown-tool defaults

## Validation

- `npm test -- agent/__tests__/tool-log-redaction.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest agent/tool-log-redaction.ts agent/__tests__/tool-log-redaction.test.ts`
- `git diff --check`
