### PR TITLE
[codex] Title-case drug interaction responses

### DIFF
--- a/services/drug-interaction-api/__tests__/check-interactions.test.ts
+++ b/services/drug-interaction-api/__tests__/check-interactions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { checkInteractions } from "../logic.ts";
+
+describe("checkInteractions", () => {
+  it.each([
+    ["all lowercase", ["lisinopril", "ibuprofen", "metformin"]],
+    ["all uppercase", ["LISINOPRIL", "IBUPROFEN", "METFORMIN"]],
+    ["mixed case", ["lIsInOpRiL", "Ibuprofen", "MetFORMIN"]],
+  ])("returns the same title-cased output for %s input", (_label, medications) => {
+    const result = checkInteractions(medications);
+
+    expect(result.medications).toEqual(["Lisinopril", "Ibuprofen", "Metformin"]);
+    expect(result.interactions).toHaveLength(1);
+    expect(result.interactions[0]).toMatchObject({
+      drug1: "Lisinopril",
+      drug2: "Ibuprofen",
+      severity: "moderate",
+    });
+  });
+
+  it("title-cases medications even when no interaction is found", () => {
+    const result = checkInteractions(["  aToRvAsTaTiN  ", "unknown drug"]);
+
+    expect(result.medications).toEqual(["Atorvastatin", "Unknown Drug"]);
+    expect(result.interactions).toEqual([]);
+  });
+});

--- a/services/drug-interaction-api/logic.ts
+++ b/services/drug-interaction-api/logic.ts
@@ -116,10 +116,18 @@ function sortPairsBySeverity(pairs: any[]) {
   });
 }
 
+function titleCaseDrugName(drug: string): string {
+  return drug
+    .trim()
+    .toLowerCase()
+    .replace(/\b[a-z]/g, (letter) => letter.toUpperCase());
+}
+
 export function checkInteractions(medications: string[]) {
   const normalizedMedications = medications.map((medication) =>
     medication.toLowerCase().trim(),
   );
+  const titleCasedMedications = medications.map(titleCaseDrugName);
   const found: Array<{
     drug1: string;
     drug2: string;
@@ -139,8 +147,8 @@ export function checkInteractions(medications: string[]) {
             normalizedMedications[right] === first)
         ) {
           found.push({
-            drug1: medications[left],
-            drug2: medications[right],
+            drug1: titleCasedMedications[left],
+            drug2: titleCasedMedications[right],
             severity: interaction.severity,
             description: interaction.description,
             recommendation: interaction.recommendation,
@@ -158,7 +166,7 @@ export function checkInteractions(medications: string[]) {
   ).length;
 
   return {
-    medications,
+    medications: titleCasedMedications,
     interactionCount: found.length,
     severeCount,
     moderateCount,


### PR DESCRIPTION
## Summary
- normalize drug interaction response names to Title Case while keeping lowercase matching internally
- return the response `medications` array in Title Case for matched and no-interaction results
- return interaction `drug1` and `drug2` fields in Title Case regardless of input casing
- add Vitest coverage for all-lowercase, ALL-UPPERCASE, and MixedCase inputs producing identical output

Closes #14

## Validation
- `npm test -- services/drug-interaction-api/__tests__/check-interactions.test.ts services/drug-interaction-api/__tests__/drug-normalization.test.ts services/drug-interaction-api/__tests__/sort-pairs.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest services/drug-interaction-api/logic.ts services/drug-interaction-api/__tests__/check-interactions.test.ts`
- `git diff --cached --check`

## Notes
- Both the unified server and the standalone drug interaction service call `services/drug-interaction-api/logic.ts`, so this keeps their behavior in sync.