### PR TITLE
[codex] Reject oversized bill audit requests before settlement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,8 @@ SLACK_WEBHOOK_URL=
 JSON_BODY_LIMIT=20kb
 # Bill-audit routes handle up to 500 line items; allow larger payloads.
 BILL_AUDIT_BODY_LIMIT=256kb
+# Max bill-audit line items accepted before x402 settlement.
+BILL_AUDIT_MAX_ITEMS=500
 
 # --- LLM PHI scrubbing (issue #97) ---
 # Set to false ONLY for LLM providers with a signed BAA (e.g., enterprise OpenAI).

--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,7 @@ import { validateTask, getSuspiciousTaskCount } from "./shared/task-validation.t
 import { buildScrubSession, scrubText } from "./shared/prompt-scrub.ts";
 import {
   BillAuditValidationError,
+  createBillAuditMaxItemsMiddleware,
   validateBillAuditRequest,
 } from "./shared/bill-audit.ts";
 import { sanitizeUserString } from "./shared/sanitize.ts";
@@ -42,6 +43,7 @@ import {
   metricsHandler,
   agentRunsTotal,
   agentToolCallsTotal,
+  billAuditOversizedRejectionsTotal,
 } from "./shared/metrics.ts";
 
 // Shared agent pause state + wallet low-balance scheduler
@@ -682,6 +684,13 @@ app.get("/bill/sample", (_req, res) => {
     ],
   });
 });
+
+const billAuditMaxItemsMiddleware = createBillAuditMaxItemsMiddleware({
+  onReject: () => billAuditOversizedRejectionsTotal.inc(),
+});
+
+// Reject oversized bill audits before x402 settlement.
+app.post("/bill/audit", billAuditMaxItemsMiddleware);
 
 // x402 for bill audit
 applyX402Middleware(app, {

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -17,6 +17,7 @@ import express from "express";
 import { readFileSync } from "fs";
 import {
   BillAuditValidationError,
+  createBillAuditMaxItemsMiddleware,
   type LineItem,
   validateBillAuditRequest,
 } from "../../shared/bill-audit.ts";
@@ -27,6 +28,7 @@ import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
 import { sanitizeUserString } from "../../shared/sanitize.ts";
+import { billAuditOversizedRejectionsTotal } from "../../shared/metrics.ts";
 
 const PORT = parseInt(process.env.BILL_AUDIT_API_PORT || "3002");
 const PAY_TO = process.env.BILL_PROVIDER_PUBLIC_KEY;
@@ -217,6 +219,13 @@ app.get("/bill/sample", (_req, res) => {
     ],
   });
 });
+
+const billAuditMaxItemsMiddleware = createBillAuditMaxItemsMiddleware({
+  onReject: () => billAuditOversizedRejectionsTotal.inc(),
+});
+
+// Reject oversized bill audits before x402 settlement.
+app.post("/bill/audit", billAuditMaxItemsMiddleware);
 
 // x402 payment middleware
 applyX402Middleware(app, {

--- a/shared/__tests__/bill-audit-max-items.test.ts
+++ b/shared/__tests__/bill-audit-max-items.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBillAuditMaxItemsMiddleware,
+  getBillAuditMaxItems,
+  validateBillAuditRequest,
+} from "../bill-audit.ts";
+
+function makeItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    description: `Office visit ${index}`,
+    cptCode: "99213",
+    quantity: 1,
+    chargedAmount: 130,
+  }));
+}
+
+function runMiddleware(lineItems: unknown[], max = "500") {
+  const status = vi.fn().mockReturnThis();
+  const json = vi.fn().mockReturnThis();
+  const next = vi.fn();
+  const onReject = vi.fn();
+
+  const middleware = createBillAuditMaxItemsMiddleware({
+    env: { BILL_AUDIT_MAX_ITEMS: max } as NodeJS.ProcessEnv,
+    onReject,
+  });
+
+  middleware({ body: { lineItems } } as any, { status, json } as any, next);
+
+  return { status, json, next, onReject };
+}
+
+describe("bill audit max line item guard", () => {
+  it("defaults to 500 items when BILL_AUDIT_MAX_ITEMS is unset or invalid", () => {
+    expect(getBillAuditMaxItems({} as NodeJS.ProcessEnv)).toBe(500);
+    expect(getBillAuditMaxItems({ BILL_AUDIT_MAX_ITEMS: "nope" } as NodeJS.ProcessEnv)).toBe(500);
+  });
+
+  it("rejects a 501-item body before downstream middleware", () => {
+    const result = runMiddleware(makeItems(501));
+
+    expect(result.status).toHaveBeenCalledWith(400);
+    expect(result.json).toHaveBeenCalledWith({ error: "lineItems exceeds max (500)" });
+    expect(result.next).not.toHaveBeenCalled();
+    expect(result.onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a 500-item body to continue", () => {
+    const result = runMiddleware(makeItems(500));
+
+    expect(result.status).not.toHaveBeenCalled();
+    expect(result.json).not.toHaveBeenCalled();
+    expect(result.next).toHaveBeenCalledTimes(1);
+    expect(result.onReject).not.toHaveBeenCalled();
+  });
+
+  it("keeps the same cap as a validation fallback", () => {
+    expect(() => validateBillAuditRequest({ lineItems: makeItems(501) }))
+      .toThrow("lineItems exceeds max (500)");
+  });
+});

--- a/shared/bill-audit.ts
+++ b/shared/bill-audit.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
+import type { RequestHandler } from "express";
 import { freeTextSchema } from "./free-text.ts";
+
+export const DEFAULT_BILL_AUDIT_MAX_ITEMS = 500;
 
 export const LineItemSchema = z
   .object({
@@ -44,6 +47,51 @@ export class BillAuditValidationError extends Error {
   }
 }
 
+export function getBillAuditMaxItems(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number(env.BILL_AUDIT_MAX_ITEMS);
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_BILL_AUDIT_MAX_ITEMS;
+}
+
+export function validateBillAuditMaxItems(
+  body: unknown,
+  maxItems = getBillAuditMaxItems(),
+): void {
+  const lineItems = body && typeof body === "object"
+    ? (body as { lineItems?: unknown }).lineItems
+    : undefined;
+
+  if (Array.isArray(lineItems) && lineItems.length > maxItems) {
+    throw new BillAuditValidationError(
+      "LINE_ITEMS_TOO_LARGE",
+      `lineItems exceeds max (${maxItems})`,
+      [{ path: "lineItems", message: `lineItems exceeds max (${maxItems})` }],
+    );
+  }
+}
+
+export function createBillAuditMaxItemsMiddleware(options: {
+  env?: NodeJS.ProcessEnv;
+  onReject?: () => void;
+} = {}): RequestHandler {
+  return (req, res, next) => {
+    const maxItems = getBillAuditMaxItems(options.env);
+
+    try {
+      validateBillAuditMaxItems(req.body, maxItems);
+      next();
+    } catch (error) {
+      if (error instanceof BillAuditValidationError) {
+        options.onReject?.();
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  };
+}
+
 export function validateLineItems(lineItems: unknown): LineItem[] {
   const result = z.array(LineItemSchema).min(1, "lineItems must contain at least one item").safeParse(lineItems);
   if (result.success) {
@@ -58,6 +106,8 @@ export function validateLineItems(lineItems: unknown): LineItem[] {
 }
 
 export function validateBillAuditRequest(body: unknown): { lineItems: LineItem[] } {
+  validateBillAuditMaxItems(body);
+
   const result = BillAuditRequestSchema.safeParse(body);
   if (result.success) {
     return result.data;

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -97,6 +97,12 @@ export const agentLlmErrorTotal = new Counter({
   registers: [registry],
 });
 
+export const billAuditOversizedRejectionsTotal = new Counter({
+  name: "bill_audit_oversized_rejections_total",
+  help: "Total bill audit requests rejected for exceeding the line item cap",
+  registers: [registry],
+});
+
 export function metricsHandler(): RequestHandler {
   return async (req, res) => {
     const token = process.env.METRICS_TOKEN;


### PR DESCRIPTION
## Summary
- add `BILL_AUDIT_MAX_ITEMS` with a default of 500 and document it in `.env.example`
- reject oversized `/bill/audit` requests before x402 settlement in both the unified server and standalone bill-audit service
- keep the same max-item guard as a validation fallback inside `validateBillAuditRequest`
- add `bill_audit_oversized_rejections_total` for oversized rejection observability
- add focused tests for 501-item rejection, 500-item pass-through, default/env parsing, and validation fallback

Closes #13

## Validation
- `npm test -- shared/__tests__/bill-audit-max-items.test.ts services/bill-audit-api/__tests__/validation.test.ts shared/__tests__/metrics.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest shared/bill-audit.ts shared/metrics.ts shared/__tests__/bill-audit-max-items.test.ts`
- `git diff --cached --check`