### PR TITLE
[codex] Tighten bill audit line item validation

### DIFF
--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -2050,7 +2050,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'audit_medical_bill',
     description:
-      'Audit a medical bill for errors (duplicates, upcoding, overcharges). 80% of medical bills contain errors. Pays $0.01 USDC per audit via x402 on Stellar. Pass line_items_json as a JSON string array of line items. Each line item must include description, cptCode, quantity, and chargedAmount. cptCode must match /^(?:\\d{5}|J\\d{4})$/, quantity must be > 0, and chargedAmount must be > 0.',
+      'Audit a medical bill for errors (duplicates, upcoding, overcharges). 80% of medical bills contain errors. Pays $0.01 USDC per audit via x402 on Stellar. Pass line_items_json as a JSON string array of line items. Each line item must include description, cptCode, quantity, and chargedAmount. cptCode must match /^(?:\\d{5}|J\\d{4})$/, quantity must be an integer from 1 to 999, and chargedAmount must be between 0 and 1000000.',
     input_schema: strictInputSchema({
       type: 'object' as const,
       properties: {

--- a/services/bill-audit-api/__tests__/validation.test.ts
+++ b/services/bill-audit-api/__tests__/validation.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { BillAuditValidationError, validateLineItems } from "../../../shared/bill-audit.ts";
+import {
+  BillAuditValidationError,
+  validateBillAuditRequest,
+  validateLineItems,
+} from "../../../shared/bill-audit.ts";
 
 describe("bill audit line item validation", () => {
   it.each([
     ["missing field", [{ description: "Office visit", quantity: 1, chargedAmount: 130 }]],
     ["zero qty", [{ description: "Office visit", cptCode: "99213", quantity: 0, chargedAmount: 130 }]],
+    ["fractional qty", [{ description: "Office visit", cptCode: "99213", quantity: 1.5, chargedAmount: 130 }]],
+    ["too many units", [{ description: "Office visit", cptCode: "99213", quantity: 1000, chargedAmount: 130 }]],
     ["negative amount", [{ description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: -1 }]],
+    ["NaN amount", [{ description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: Number.NaN }]],
+    ["Infinity amount", [{ description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: Number.POSITIVE_INFINITY }]],
+    ["too large amount", [{ description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: 1_000_001 }]],
     ["malformed cpt", [{ description: "Office visit", cptCode: "AB123", quantity: 1, chargedAmount: 130 }]],
     ["too long description", [{ description: "x".repeat(81), cptCode: "99213", quantity: 1, chargedAmount: 130 }]],
   ])("rejects %s", (_label, lineItems) => {
@@ -17,6 +26,36 @@ describe("bill audit line item validation", () => {
       const validationError = error as BillAuditValidationError;
       expect(validationError.code).toBe("INVALID_LINE_ITEMS");
       expect(validationError.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps valid inputs unchanged after validation", () => {
+    const lineItems = [
+      { description: "Office visit", cptCode: "99213", quantity: 1, chargedAmount: 0 },
+      { description: "Injection", cptCode: "J0170", quantity: 999, chargedAmount: 1_000_000 },
+    ];
+
+    expect(validateBillAuditRequest({ lineItems })).toEqual({ lineItems });
+  });
+
+  it("returns field-level issue paths for request validation failures", () => {
+    try {
+      validateBillAuditRequest({
+        lineItems: [
+          { description: "Office visit", cptCode: "99213", quantity: 1000, chargedAmount: Number.POSITIVE_INFINITY },
+        ],
+      });
+      throw new Error("expected validation failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(BillAuditValidationError);
+      const validationError = error as BillAuditValidationError;
+      expect(validationError.code).toBe("INVALID_BILL_AUDIT_REQUEST");
+      expect(validationError.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "lineItems.0.quantity" }),
+          expect.objectContaining({ path: "lineItems.0.chargedAmount" }),
+        ]),
+      );
     }
   });
 });

--- a/shared/bill-audit.ts
+++ b/shared/bill-audit.ts
@@ -7,8 +7,17 @@ export const LineItemSchema = z
     cptCode: z
       .string()
       .regex(/^(?:\d{5}|J\d{4})$/, "cptCode must match /^(?:\\d{5}|J\\d{4})$/"),
-    quantity: z.number().positive("quantity must be positive"),
-    chargedAmount: z.number().positive("chargedAmount must be positive"),
+    quantity: z
+      .number()
+      .finite("quantity must be finite")
+      .int("quantity must be an integer")
+      .min(1, "quantity must be at least 1")
+      .max(999, "quantity must be at most 999"),
+    chargedAmount: z
+      .number()
+      .finite("chargedAmount must be finite")
+      .min(0, "chargedAmount must be at least 0")
+      .max(1_000_000, "chargedAmount must be at most 1000000"),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- tighten bill audit line item validation for numeric bounds and finite values
- require `quantity` to be an integer from 1 to 999
- allow `chargedAmount` from 0 to 1,000,000 while rejecting negative, NaN, Infinity, and oversized values
- preserve the existing CPT/HCPCS pattern and update the agent tool description to match the stricter validator
- expand validation tests for missing cptCode, quantity=0, quantity=1000, NaN, Infinity, negative amounts, and valid boundary inputs

Closes #12

## Validation
- `npm test -- services/bill-audit-api/__tests__/validation.test.ts services/bill-audit-api/__tests__/cpt-validation.test.ts agent/__tests__/tools.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest shared/bill-audit.ts services/bill-audit-api/__tests__/validation.test.ts`
- `git diff --cached --check`