### PR TITLE
[codex] Cover persisted MPP order identifiers

### DIFF
--- a/agent/__tests__/pay-for-medication.test.ts
+++ b/agent/__tests__/pay-for-medication.test.ts
@@ -17,7 +17,10 @@ vi.mock("fs", () => ({
   writeFileSync: vi.fn((filePath: string, data: string) => {
     mockFiles.set(String(filePath), String(data));
   }),
-  appendFileSync: vi.fn(),
+  appendFileSync: vi.fn((filePath: string, data: string) => {
+    const key = String(filePath);
+    mockFiles.set(key, (mockFiles.get(key) ?? "") + String(data));
+  }),
   unlinkSync: vi.fn(),
   existsSync: vi.fn((filePath: string) => mockFiles.has(String(filePath))),
   mkdirSync: vi.fn(),
@@ -76,6 +79,17 @@ const DEFAULT_POLICY = {
   billMonthlyBudget: 500,
   approvalThreshold: 75,
 };
+
+function getPersistedTransactions() {
+  const jsonl = [...mockFiles.entries()].find(([filePath]) =>
+    filePath.endsWith("transactions.jsonl"),
+  )?.[1] ?? "";
+
+  return jsonl
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
 
 beforeEach(() => {
   mockFiles.clear();
@@ -209,6 +223,20 @@ describe("payForMedication — success path (Issue #35)", () => {
     const tx = (r as any).transaction;
     expect(tx.mppOrderId).toBe("order-999");
     expect(tx.stellarTxHash).toBeUndefined();
+  });
+
+  it("persists mppOrderId separately from stellarTxHash in the transaction log", async () => {
+    mockMppFetch.mockResolvedValueOnce({
+      json: async () => ({ success: true, order: { id: "order-persisted" } }),
+      headers: { get: () => null },
+    });
+
+    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    expect(r.success).toBe(true);
+
+    const [persistedTx] = getPersistedTransactions();
+    expect(persistedTx.mppOrderId).toBe("order-persisted");
+    expect(persistedTx).not.toHaveProperty("stellarTxHash");
   });
 
   it("sets stellarTxHash from Payment-Receipt header when no progress event fired", async () => {


### PR DESCRIPTION
## Summary
- add transaction-log coverage for the MPP order-id contract
- make the payForMedication test fs mock persist appended JSONL transaction records
- assert a successful MPP payment with no real Stellar hash persists `mppOrderId` and does not persist `stellarTxHash`

Closes #20

## Validation
- `npm test -- agent/__tests__/pay-for-medication.test.ts`
- `git diff --cached --check`

## Notes
- The production path already stores `mppOrderId` separately and normalizes invalid/non-hex receipt values to `stellarTxHash: undefined`; this PR adds the missing persistence-level regression coverage requested by the issue.
- A broader run including `agent/__tests__/mock-network.test.ts` is still blocked in this Windows checkout by an existing path/mock issue (`mkdir 'C:\C:\Users\...'`), unrelated to this PR.
- A focused TypeScript command that imports `agent/tools.ts` is still blocked by existing x402 template literal type errors in `agent/tools.ts:264` and `agent/tools.ts:266`.