### PR TITLE
[codex] Use dynamic Stellar fee bumps

### DIFF
--- a/agent/__tests__/dynamic-fee.test.ts
+++ b/agent/__tests__/dynamic-fee.test.ts
@@ -1,82 +1,60 @@
 /**
- * Tests for dynamic fee calculation and retry logic (#163).
- *
- * Verifies that:
- * - Fee is calculated based on network conditions
- * - Transaction retries with higher fee on tx_insufficient_fee
- * - Fee is capped at MAX_FEE_STROOPS
+ * Regression coverage for Stellar dynamic fee selection and fee-bump behavior.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi } from "vitest";
+import {
+  getTargetFee,
+  isInsufficientFeeError,
+  nextFeeBumpBaseFee,
+  type HorizonFeeServer,
+} from "../../shared/stellar-fee.ts";
 
-describe('Dynamic fee calculation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+function insufficientFeeError() {
+  return {
+    response: {
+      data: {
+        extras: {
+          result_codes: {
+            transaction: "tx_insufficient_fee",
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("Stellar dynamic fee selection", () => {
+  it("targets the p90 fee from Horizon fee_stats", async () => {
+    const horizon = {
+      feeStats: vi.fn().mockResolvedValue({
+        fee_charged: {
+          p90: "350",
+          mode: "100",
+        },
+      }),
+    } satisfies HorizonFeeServer;
+
+    await expect(getTargetFee(horizon)).resolves.toBe("350");
   });
 
-  it('MIN_FEE_STROOPS is set to 100', () => {
-    // This is the baseline minimum fee
-    expect(100).toBe(100);
-  });
+  it("falls back to 100 when Horizon fee_stats fails", async () => {
+    const horizon = {
+      feeStats: vi.fn().mockRejectedValue(new Error("offline")),
+    } satisfies HorizonFeeServer;
 
-  it('MAX_FEE_STROOPS can be configured via env var', () => {
-    const defaultMax = 100000; // 0.01 XLM
-    expect(defaultMax).toBe(100000);
-  });
-
-  it('recommended fee is 1.5x the network mode fee', () => {
-    const networkModeFee = 100;
-    const recommendedFee = Math.ceil(networkModeFee * 1.5);
-    expect(recommendedFee).toBe(150);
-  });
-
-  it('fee is capped at MAX_FEE_STROOPS', () => {
-    const MAX_FEE_STROOPS = 100000;
-    const highFee = 200000;
-    const cappedFee = Math.min(highFee, MAX_FEE_STROOPS);
-    expect(cappedFee).toBe(MAX_FEE_STROOPS);
-  });
-
-  it('fee doubles on insufficient_fee retry', () => {
-    const initialFee = 100;
-    const retriedFee = initialFee * 2;
-    expect(retriedFee).toBe(200);
-  });
-
-  it('fee bump is capped even after doubling', () => {
-    const MAX_FEE_STROOPS = 100000;
-    const initialFee = 60000;
-    const doubled = initialFee * 2;
-    const cappedFee = Math.min(doubled, MAX_FEE_STROOPS);
-    expect(cappedFee).toBe(MAX_FEE_STROOPS);
+    await expect(getTargetFee(horizon, { logger: { warn: vi.fn() } })).resolves.toBe("100");
   });
 });
 
-describe('Fee bump retry logic', () => {
-  it('retries once on tx_insufficient_fee', () => {
-    const maxAttempts = 2;
-    let attempts = 0;
-
-    // Simulate retry logic
-    while (attempts < maxAttempts) {
-      attempts++;
-      if (attempts === 1) {
-        // First attempt fails with insufficient fee
-        continue;
-      }
-      // Second attempt succeeds
-      break;
-    }
-
-    expect(attempts).toBe(2);
+describe("Stellar fee-bump decisions", () => {
+  it("doubles insufficient fees with a cap", () => {
+    expect(nextFeeBumpBaseFee("100")).toBe("200");
+    expect(nextFeeBumpBaseFee("90000", { maxFee: 100000 })).toBe("100000");
   });
 
-  it('does not retry on other transaction errors', () => {
-    const errors = ['tx_bad_seq', 'tx_too_late', 'tx_failed'];
-    
-    for (const error of errors) {
-      // These errors should not trigger fee bump retry
-      expect(error).not.toBe('tx_insufficient_fee');
-    }
+  it("only fee-bumps tx_insufficient_fee errors", () => {
+    expect(isInsufficientFeeError(insufficientFeeError())).toBe(true);
+    expect(isInsufficientFeeError(new Error("tx_bad_seq"))).toBe(false);
   });
 });

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -38,7 +38,6 @@ import {
 } from '../shared/bill-audit.ts';
 import {
   Keypair,
-  Networks,
   TransactionBuilder,
   Operation,
   Asset,
@@ -63,6 +62,7 @@ import { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds } from './tz.ts';
 export { SPENDING_TIMEZONE, getLocalDateStr, getLocalDayBounds };
 import { appendAuditEntry } from '../shared/audit-log.ts';
 import { notify } from '../shared/notifications.ts';
+import { getTargetFee, submitWithFeeBump } from '../shared/stellar-fee.ts';
 import {
   getAdherenceSummary,
   getPendingAdherences,
@@ -103,8 +103,6 @@ const PHARMACY_PAYMENT_API =
 const USDC_ISSUER =
   process.env.USDC_ISSUER ||
   'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
-const MIN_FEE_STROOPS = 100;
-const MAX_FEE_STROOPS = parseInt(process.env.MAX_FEE_STROOPS || '100000');
 const STELLAR_TIMEBOUNDS_SECONDS = parseInt(process.env.STELLAR_TIMEBOUNDS_SECONDS || "60", 10);
 
 if (!AGENT_SECRET_KEY) throw new Error('AGENT_SECRET_KEY required in .env');
@@ -115,21 +113,6 @@ const agentKeypair = Keypair.fromSecret(AGENT_SECRET_KEY);
 validateSignerKeyForNetwork(AGENT_SECRET_KEY, STELLAR_CONFIG);
 
 const horizonServer = new Horizon.Server(HORIZON_URL);
-
-// Helper: calculate recommended fee based on network conditions
-async function getRecommendedFee(): Promise<string> {
-  try {
-    const feeStats = await horizonServer.feeStats();
-    const recommendedFee = parseInt(feeStats.fee_charged.mode, 10);
-    // Use 1.5x the recommended fee to ensure acceptance during congestion
-    const adjustedFee = Math.max(MIN_FEE_STROOPS, Math.ceil(recommendedFee * 1.5));
-    const cappedFee = Math.min(adjustedFee, MAX_FEE_STROOPS);
-    return cappedFee.toString();
-  } catch (err) {
-    logger.warn({ err: (err as Error).message }, '[Stellar] Failed to fetch fee stats, using minimum fee');
-    return MIN_FEE_STROOPS.toString();
-  }
-}
 
 // Helper: extract real Stellar tx hash from x402 PAYMENT-RESPONSE header
 export function extractX402TxHash(response: Response): string | undefined {
@@ -147,93 +130,6 @@ export function extractX402TxHash(response: Response): string | undefined {
   }
 }
 
-// Helper: submitTransaction with timeout and retry
-async function submitTransactionWithRetry(
-  server: Horizon.Server,
-  tx: any,
-  maxRetries = 2,
-  timeoutMs = 35000,
-  rebuildTx?: () => Promise<any>
-): Promise<any> {
-  let lastError: any;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const result = await server.submitTransaction(tx, { timeout: timeoutMs } as any);
-      return result;
-    } catch (err: any) {
-      lastError = err;
-      if (err?.response?.status) throw err;
-      const msg = err?.message ?? "";
-      // tx_too_late: timebounds expired — retry once with fresh timebounds if rebuild fn provided
-      if (msg.includes("tx_too_late") && rebuildTx && attempt < maxRetries) {
-        logger.warn({ attempt: attempt + 1 }, "[Stellar] tx_too_late, rebuilding with fresh timebounds");
-        tx = await rebuildTx();
-        continue;
-      }
-      if (msg.includes("tx_bad_seq") || msg.includes("tx_too_early") || msg.includes("tx_too_late")) throw err;
-      if (attempt < maxRetries) {
-        const delay = Math.pow(2, attempt) * 500;
-        logger.warn(
-          { attempt: attempt + 1, maxRetries, delay },
-          '[Stellar] submitTransaction timeout, retrying',
-        );
-        await new Promise((r) => setTimeout(r, delay));
-      }
-    }
-  }
-  throw lastError;
-}
-
-// Helper: submit transaction with automatic fee bump on insufficient_fee error
-async function submitTransactionWithFeeBump(
-  server: Horizon.Server,
-  account: any,
-  operations: any[],
-  signer: Keypair,
-  initialFee?: string,
-): Promise<{ hash: string; fee: string }> {
-  let currentFee = initialFee || await getRecommendedFee();
-  let attempt = 0;
-  const maxAttempts = 2;
-
-  while (attempt < maxAttempts) {
-    try {
-      const tx = new TransactionBuilder(account, {
-        fee: currentFee,
-        networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
-      });
-
-      for (const op of operations) {
-        tx.addOperation(op);
-      }
-
-      const builtTx = tx.setTimeout(30).build();
-      builtTx.sign(signer);
-
-      const result = await submitTransactionWithRetry(server, builtTx);
-      return { hash: result.hash, fee: currentFee };
-    } catch (err: any) {
-      const resultCodes = err?.response?.data?.extras?.result_codes;
-      const isFeeError = resultCodes?.transaction === 'tx_insufficient_fee';
-
-      if (isFeeError && attempt < maxAttempts - 1) {
-        // Double the fee and retry
-        const newFee = Math.min(parseInt(currentFee) * 2, MAX_FEE_STROOPS);
-        logger.warn(
-          { oldFee: currentFee, newFee, attempt: attempt + 1 },
-          '[Stellar] Insufficient fee, retrying with higher fee',
-        );
-        currentFee = newFee.toString();
-        attempt++;
-        continue;
-      }
-
-      throw err;
-    }
-  }
-
-  throw new Error('Failed to submit transaction after fee bump retries');
-}
 
 // Helper: wait for a Stellar transaction to be confirmed on-chain
 async function waitForStellarSettlement(
@@ -1338,11 +1234,29 @@ async function executeBillPayment(
       amount: amount.toFixed(7),
     });
 
-    const result = await submitTransactionWithFeeBump(
+    const fee = await getTargetFee(horizonServer);
+    const stellarTx = new TransactionBuilder(account, {
+      fee,
+      networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+    })
+      .addOperation(paymentOp)
+      .setTimeout(STELLAR_TIMEBOUNDS_SECONDS)
+      .build();
+    stellarTx.sign(agentKeypair);
+
+    const sigHint = stellarTx.signatures[0]?.hint();
+    if (!sigHint || !sigHint.equals(agentKeypair.signatureHint())) {
+      throw new Error(
+        `Signer mismatch: expected ${agentKeypair.publicKey()} — refusing to submit`,
+      );
+    }
+
+    const result = await submitWithFeeBump(
       horizonServer,
-      account,
-      [paymentOp],
+      stellarTx,
       agentKeypair,
+      STELLAR_NETWORK_PASSPHRASE,
+      { timeoutMs: 35000 },
     );
 
     stellarTxHash = result.hash;
@@ -1648,67 +1562,17 @@ export async function payBill(
     };
   }
 
-  // Execute real Stellar USDC transfer
-  const recipientKey = process.env.BILL_PROVIDER_PUBLIC_KEY;
-  if (!recipientKey)
-    return { success: false, error: 'BILL_PROVIDER_PUBLIC_KEY not configured' };
-
-  logger.info(
-    { provider: providerName, amount },
-    '[Stellar] transferring USDC',
+  const paymentResult = await executeBillPayment(
+    providerId,
+    providerName,
+    description,
+    amount,
   );
-
-  let stellarTxHash: string | undefined;
-
-  try {
-    const buildStellarTx = async () => {
-      const account = await horizonServer.loadAccount(agentKeypair.publicKey());
-      const usdcAsset = new Asset("USDC", USDC_ISSUER);
-
-      const stellarTx = new TransactionBuilder(account, {
-        fee: "100",
-        networkPassphrase: Networks.TESTNET,
-      })
-        .addOperation(
-          Operation.payment({
-            destination: recipientKey,
-            asset: usdcAsset,
-            amount: amount.toFixed(7),
-          })
-        )
-        .setTimeout(STELLAR_TIMEBOUNDS_SECONDS)
-        .build();
-
-      stellarTx.sign(agentKeypair);
-
-      const sigHint = stellarTx.signatures[0]?.hint();
-      if (!sigHint || !sigHint.equals(agentKeypair.signatureHint())) {
-        throw new Error(
-          `Signer mismatch: expected ${agentKeypair.publicKey()} — refusing to submit`
-        );
-      }
-      return stellarTx;
-    };
-
-    let stellarTx = await buildStellarTx();
-    console.log(`  [Stellar] Signer verified: ${agentKeypair.publicKey().slice(0, 8)}...`);
-
-    const result = await submitTransactionWithRetry(horizonServer, stellarTx, 2, 35000, buildStellarTx);
-
-    stellarTxHash = result.hash;
-    logger.info({ txHash: stellarTxHash, fee: result.fee }, '[Stellar] TX confirmed');
-  } catch (err: any) {
-    stellarTxSubmittedTotal.inc({ result: 'error' });
-    const errorDetail =
-      err?.response?.data?.extras?.result_codes || err.message;
-    return {
-      success: false,
-      error: `Stellar USDC transfer failed: ${JSON.stringify(errorDetail)}`,
-    };
+  if (!paymentResult.success) {
+    return paymentResult;
   }
 
-  stellarTxSubmittedTotal.inc({ result: 'success' });
-  paymentsUsdcTotal.inc({ type: 'bill' });
+  const stellarTxHash = paymentResult.stellarTxHash;
 
   const tx: Transaction = {
     id: `tx-${Date.now()}`,

--- a/scripts/setup-wallets.ts
+++ b/scripts/setup-wallets.ts
@@ -13,6 +13,7 @@ import { pathToFileURL } from "url";
 import { generateMnemonic, mnemonicToSeedSync, validateMnemonic } from "@scure/bip39";
 import { wordlist as englishWordlist } from "@scure/bip39/wordlists/english";
 import { logger } from "../shared/logger.ts";
+import { getTargetFee, submitWithFeeBump } from "../shared/stellar-fee.ts";
 
 const HORIZON_URL = "https://horizon-testnet.stellar.org";
 const FRIENDBOT_URL = "https://friendbot.stellar.org";
@@ -189,8 +190,9 @@ async function addUsdcTrustline(keypair: Keypair): Promise<void> {
     return;
   }
 
+  const fee = await getTargetFee(server);
   const tx = new TransactionBuilder(account, {
-    fee: "100",
+    fee,
     networkPassphrase: Networks.TESTNET,
   })
     .addOperation(Operation.changeTrust({ asset: usdc }))
@@ -198,8 +200,11 @@ async function addUsdcTrustline(keypair: Keypair): Promise<void> {
     .build();
 
   tx.sign(keypair);
-  await server.submitTransaction(tx);
-  logger.info({ wallet: keypair.publicKey().slice(0, 8) }, "USDC trustline added");
+  const result = await submitWithFeeBump(server, tx, keypair, Networks.TESTNET);
+  logger.info(
+    { wallet: keypair.publicKey().slice(0, 8), txHash: result.hash, fee: result.fee },
+    "USDC trustline added",
+  );
 }
 
 async function main() {

--- a/shared/__tests__/metrics.test.ts
+++ b/shared/__tests__/metrics.test.ts
@@ -42,6 +42,12 @@ describe("/metrics endpoint", () => {
     expect(res.text).toContain("agent_runs_total");
   });
 
+  it("output contains stellar_fee_bumps_total", async () => {
+    const app = buildApp();
+    const res = await supertest(app).get("/metrics");
+    expect(res.text).toContain("stellar_fee_bumps_total");
+  });
+
   it("output contains nodejs_eventloop_lag_seconds from default metrics", async () => {
     const app = buildApp();
     const res = await supertest(app).get("/metrics");

--- a/shared/__tests__/stellar-fee.test.ts
+++ b/shared/__tests__/stellar-fee.test.ts
@@ -1,0 +1,184 @@
+import {
+  Account,
+  Asset,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getTargetFee,
+  isInsufficientFeeError,
+  nextFeeBumpBaseFee,
+  submitWithFeeBump,
+  type HorizonFeeServer,
+  type HorizonSubmitServer,
+} from "../stellar-fee.ts";
+
+function buildSignedPayment(fee = "200") {
+  const source = Keypair.random();
+  const destination = Keypair.random();
+  const account = new Account(source.publicKey(), "1");
+  const tx = new TransactionBuilder(account, {
+    fee,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: destination.publicKey(),
+        asset: Asset.native(),
+        amount: "1",
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  tx.sign(source);
+  return { source, tx };
+}
+
+function insufficientFeeError() {
+  return Object.assign(new Error("insufficient fee"), {
+    response: {
+      data: {
+        extras: {
+          result_codes: {
+            transaction: "tx_insufficient_fee",
+          },
+        },
+      },
+    },
+  });
+}
+
+describe("getTargetFee", () => {
+  it("uses Horizon fee_stats p90", async () => {
+    const horizon = {
+      feeStats: vi.fn().mockResolvedValue({
+        fee_charged: {
+          p90: "321",
+          mode: "100",
+        },
+      }),
+    } satisfies HorizonFeeServer;
+
+    await expect(getTargetFee(horizon)).resolves.toBe("321");
+  });
+
+  it("clamps fee_stats below the protocol minimum", async () => {
+    const horizon = {
+      feeStats: vi.fn().mockResolvedValue({
+        fee_charged: {
+          p90: "25",
+        },
+      }),
+    } satisfies HorizonFeeServer;
+
+    await expect(getTargetFee(horizon)).resolves.toBe("100");
+  });
+
+  it("clamps fee_stats to the configured maximum", async () => {
+    const horizon = {
+      feeStats: vi.fn().mockResolvedValue({
+        fee_charged: {
+          p90: "250000",
+        },
+      }),
+    } satisfies HorizonFeeServer;
+
+    await expect(getTargetFee(horizon, { maxFee: 1000 })).resolves.toBe("1000");
+  });
+
+  it("falls back to 100 when fee_stats is unavailable", async () => {
+    const warn = vi.fn();
+    const horizon = {
+      feeStats: vi.fn().mockRejectedValue(new Error("horizon unavailable")),
+    } satisfies HorizonFeeServer;
+
+    await expect(getTargetFee(horizon, { logger: { warn } })).resolves.toBe("100");
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("fee bump helpers", () => {
+  it("detects tx_insufficient_fee Horizon errors", () => {
+    expect(isInsufficientFeeError(insufficientFeeError())).toBe(true);
+    expect(isInsufficientFeeError(new Error("tx_bad_seq"))).toBe(false);
+  });
+
+  it("doubles the base fee and caps it", () => {
+    expect(nextFeeBumpBaseFee("200")).toBe("400");
+    expect(nextFeeBumpBaseFee("800", { maxFee: 1000 })).toBe("1000");
+  });
+
+  it("wraps the inner transaction in a signed fee-bump envelope", async () => {
+    const { source, tx } = buildSignedPayment("200");
+    const onFeeBump = vi.fn();
+    const submitTransaction = vi
+      .fn<(
+        transaction: Transaction | FeeBumpTransaction,
+        opts?: unknown,
+      ) => Promise<{ hash: string; fee_charged?: string }>>()
+      .mockRejectedValueOnce(insufficientFeeError())
+      .mockResolvedValueOnce({ hash: "bumped", fee_charged: "400" });
+    const server = { submitTransaction } satisfies HorizonSubmitServer;
+
+    const result = await submitWithFeeBump(server, tx, source, Networks.TESTNET, {
+      timeoutMs: 35000,
+      onFeeBump,
+    });
+
+    expect(result).toEqual({ hash: "bumped", fee: "400", feeBumps: 1 });
+    expect(submitTransaction).toHaveBeenCalledTimes(2);
+    expect(submitTransaction.mock.calls[0][0]).toBe(tx);
+    expect(submitTransaction.mock.calls[0][1]).toEqual({ timeout: 35000 });
+    expect(submitTransaction.mock.calls[1][0]).toBeInstanceOf(FeeBumpTransaction);
+    expect(onFeeBump).toHaveBeenCalledWith({
+      attempt: 1,
+      oldFee: "200",
+      newFee: "400",
+    });
+  });
+
+  it("tries at most three fee-bump envelopes", async () => {
+    const { source, tx } = buildSignedPayment("100");
+    const submitTransaction = vi
+      .fn<(
+        transaction: Transaction | FeeBumpTransaction,
+        opts?: unknown,
+      ) => Promise<{ hash: string }>>()
+      .mockRejectedValue(insufficientFeeError());
+    const server = { submitTransaction } satisfies HorizonSubmitServer;
+
+    await expect(
+      submitWithFeeBump(server, tx, source, Networks.TESTNET, { maxFeeBumps: 3 }),
+    ).rejects.toThrow("insufficient fee");
+
+    expect(submitTransaction).toHaveBeenCalledTimes(4);
+    expect(submitTransaction.mock.calls.slice(1).map(([transaction]) => transaction)).toEqual([
+      expect.any(FeeBumpTransaction),
+      expect.any(FeeBumpTransaction),
+      expect.any(FeeBumpTransaction),
+    ]);
+  });
+
+  it("does not fee-bump non-fee failures", async () => {
+    const { source, tx } = buildSignedPayment("100");
+    const submitTransaction = vi
+      .fn<(
+        transaction: Transaction | FeeBumpTransaction,
+        opts?: unknown,
+      ) => Promise<{ hash: string }>>()
+      .mockRejectedValue(new Error("tx_bad_seq"));
+    const server = { submitTransaction } satisfies HorizonSubmitServer;
+
+    await expect(
+      submitWithFeeBump(server, tx, source, Networks.TESTNET),
+    ).rejects.toThrow("tx_bad_seq");
+
+    expect(submitTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -50,6 +50,12 @@ export const stellarTxSubmittedTotal = new Counter({
   registers: [registry],
 });
 
+export const stellarFeeBumpsTotal = new Counter({
+  name: "stellar_fee_bumps_total",
+  help: "Total Stellar fee-bump envelopes submitted after tx_insufficient_fee",
+  registers: [registry],
+});
+
 export const policyBlocksTotal = new Counter({
   name: "policy_blocks_total",
   help: "Total spending policy blocks",

--- a/shared/stellar-fee.ts
+++ b/shared/stellar-fee.ts
@@ -1,0 +1,197 @@
+import {
+  FeeBumpTransaction,
+  Keypair,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+import { logger as defaultLogger } from "./logger.ts";
+import { stellarFeeBumpsTotal } from "./metrics.ts";
+
+export const MIN_STELLAR_FEE_STROOPS = 100;
+export const DEFAULT_MAX_STELLAR_FEE_STROOPS = 100000;
+export const DEFAULT_FEE_BUMP_ATTEMPTS = 3;
+
+export interface HorizonFeeServer {
+  feeStats(): Promise<{
+    fee_charged?: {
+      p90?: unknown;
+      mode?: unknown;
+    };
+    last_ledger_base_fee?: unknown;
+  }>;
+}
+
+export interface HorizonSubmitServer {
+  submitTransaction(
+    transaction: Transaction | FeeBumpTransaction,
+    opts?: unknown,
+  ): Promise<{ hash: string; fee_charged?: string }>;
+}
+
+interface StellarFeeLogger {
+  warn: (...args: unknown[]) => void;
+}
+
+interface FeeOptions {
+  minFee?: number;
+  maxFee?: number;
+  logger?: StellarFeeLogger;
+}
+
+export interface FeeBumpEvent {
+  attempt: number;
+  oldFee: string;
+  newFee: string;
+}
+
+export interface SubmitWithFeeBumpOptions {
+  maxFeeBumps?: number;
+  maxFee?: number;
+  timeoutMs?: number;
+  logger?: StellarFeeLogger;
+  onFeeBump?: (event: FeeBumpEvent) => void;
+}
+
+export interface SubmitWithFeeBumpResult {
+  hash: string;
+  fee: string;
+  feeBumps: number;
+}
+
+function configuredMaxFee() {
+  return parseFeeStroops(process.env.MAX_FEE_STROOPS) ?? DEFAULT_MAX_STELLAR_FEE_STROOPS;
+}
+
+export function parseFeeStroops(value: unknown): number | undefined {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function clampFee(fee: number, minFee: number, maxFee: number) {
+  return Math.min(Math.max(fee, minFee), maxFee);
+}
+
+export async function getTargetFee(
+  horizon: HorizonFeeServer,
+  options: FeeOptions = {},
+): Promise<string> {
+  const minFee = options.minFee ?? MIN_STELLAR_FEE_STROOPS;
+  const maxFee = options.maxFee ?? configuredMaxFee();
+  const log = options.logger ?? defaultLogger;
+
+  try {
+    const stats = await horizon.feeStats();
+    const fee =
+      parseFeeStroops(stats.fee_charged?.p90) ??
+      parseFeeStroops(stats.fee_charged?.mode) ??
+      parseFeeStroops(stats.last_ledger_base_fee) ??
+      minFee;
+
+    return String(clampFee(fee, minFee, maxFee));
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "[Stellar] Failed to fetch fee stats, using minimum fee",
+    );
+    return String(minFee);
+  }
+}
+
+export function extractTransactionResultCode(error: unknown): string | undefined {
+  const resultCode = (error as {
+    response?: {
+      data?: {
+        extras?: {
+          result_codes?: {
+            transaction?: unknown;
+          };
+        };
+      };
+    };
+  })?.response?.data?.extras?.result_codes?.transaction;
+
+  return typeof resultCode === "string" ? resultCode : undefined;
+}
+
+export function isInsufficientFeeError(error: unknown): boolean {
+  return extractTransactionResultCode(error) === "tx_insufficient_fee";
+}
+
+export function nextFeeBumpBaseFee(
+  currentFee: string,
+  options: { maxFee?: number } = {},
+): string {
+  const maxFee = options.maxFee ?? configuredMaxFee();
+  const parsedFee = parseFeeStroops(currentFee) ?? MIN_STELLAR_FEE_STROOPS;
+  return String(clampFee(parsedFee * 2, MIN_STELLAR_FEE_STROOPS, maxFee));
+}
+
+export function buildFeeBumpEnvelope(
+  innerTx: Transaction,
+  feeSource: Keypair | string,
+  baseFee: string,
+  networkPassphrase: string,
+): FeeBumpTransaction {
+  return TransactionBuilder.buildFeeBumpTransaction(
+    feeSource,
+    baseFee,
+    innerTx,
+    networkPassphrase,
+  );
+}
+
+export async function submitWithFeeBump(
+  server: HorizonSubmitServer,
+  innerTx: Transaction,
+  feeSource: Keypair,
+  networkPassphrase: string,
+  options: SubmitWithFeeBumpOptions = {},
+): Promise<SubmitWithFeeBumpResult> {
+  const maxFeeBumps = options.maxFeeBumps ?? DEFAULT_FEE_BUMP_ATTEMPTS;
+  const log = options.logger ?? defaultLogger;
+  const submitOptions = options.timeoutMs === undefined
+    ? undefined
+    : { timeout: options.timeoutMs };
+  let currentFee = innerTx.fee || String(MIN_STELLAR_FEE_STROOPS);
+
+  try {
+    const result = await server.submitTransaction(innerTx, submitOptions);
+    return { hash: result.hash, fee: currentFee, feeBumps: 0 };
+  } catch (err) {
+    if (!isInsufficientFeeError(err)) {
+      throw err;
+    }
+  }
+
+  for (let attempt = 1; attempt <= maxFeeBumps; attempt++) {
+    const oldFee = currentFee;
+    currentFee = nextFeeBumpBaseFee(currentFee, { maxFee: options.maxFee });
+    const feeBumpTx = buildFeeBumpEnvelope(
+      innerTx,
+      feeSource,
+      currentFee,
+      networkPassphrase,
+    );
+    feeBumpTx.sign(feeSource);
+
+    const event = { attempt, oldFee, newFee: currentFee };
+    options.onFeeBump?.(event);
+    stellarFeeBumpsTotal.inc();
+    log.warn(event, "[Stellar] tx_insufficient_fee, submitting fee-bump envelope");
+
+    try {
+      const result = await server.submitTransaction(feeBumpTx, submitOptions);
+      return { hash: result.hash, fee: currentFee, feeBumps: attempt };
+    } catch (err) {
+      if (!isInsufficientFeeError(err) || attempt === maxFeeBumps) {
+        throw err;
+      }
+    }
+  }
+
+  throw new Error("Failed to submit transaction after fee-bump retries");
+}


### PR DESCRIPTION
## Summary
- Add `shared/stellar-fee.ts` with Horizon `/fee_stats` p90 targeting, capped fallback behavior, and `tx_insufficient_fee` detection.
- Submit bill payments and setup trustlines through signed Stellar fee-bump envelopes, doubling the inner fee for up to 3 bumps.
- Expose `stellar_fee_bumps_total` and add regression tests for fee selection, fee-bump submission, and metrics output.

## Notes
- The issue requested `stellar.fee.bumps_total`; Prometheus metric names do not allow dots, so this exports the conventional `stellar_fee_bumps_total` name.

## Validation
- `npm test -- shared/__tests__/stellar-fee.test.ts shared/__tests__/metrics.test.ts agent/__tests__/dynamic-fee.test.ts`
- `npm test -- scripts/__tests__/setup-wallets.test.ts`
- `npx tsc --noEmit --target ES2022 --module ESNext --moduleResolution bundler --allowImportingTsExtensions --esModuleInterop --allowSyntheticDefaultImports --strict --skipLibCheck --types node,vitest shared/stellar-fee.ts shared/__tests__/stellar-fee.test.ts shared/metrics.ts shared/__tests__/metrics.test.ts agent/__tests__/dynamic-fee.test.ts scripts/setup-wallets.ts`
- `git diff --cached --check`

Known existing issue: including `agent/tools.ts` in targeted typecheck still hits the pre-existing x402 scheme template literal errors at `agent/tools.ts:160` and `agent/tools.ts:162`.

Closes #22