### PR TITLE
chore(infra): add github issue templates and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files in the repository
+* @harystyleseze

--- a/.github/ISSUE_TEMPLATE/01-trivial.yml
+++ b/.github/ISSUE_TEMPLATE/01-trivial.yml
@@ -1,0 +1,40 @@
+name: "01 - Trivial Task"
+description: "Template for small, trivial tasks (e.g. quick adjustments, minor documentation, simple test fixes)"
+title: "trivial: <summary>"
+labels: ["trivial"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the task.
+      placeholder: Describe the task...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions that must be met for this task to be resolved.
+      placeholder: |
+        - Criterion 1
+        - Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: relevant_files
+    attributes:
+      label: Relevant Files
+      description: List files that are relevant to this task.
+      placeholder: |
+        - path/to/file.ts
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: Resources
+      description: Add any links, docs, or resources that might help solve this task.
+      placeholder: Resources...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-medium.yml
+++ b/.github/ISSUE_TEMPLATE/02-medium.yml
@@ -1,0 +1,40 @@
+name: "02 - Medium Task"
+description: "Template for medium-sized tasks (e.g. standard features, refactoring components, complex unit tests)"
+title: "medium: <summary>"
+labels: ["medium"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the task.
+      placeholder: Describe the task...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions that must be met for this task to be resolved.
+      placeholder: |
+        - Criterion 1
+        - Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: relevant_files
+    attributes:
+      label: Relevant Files
+      description: List files that are relevant to this task.
+      placeholder: |
+        - path/to/file.ts
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: Resources
+      description: Add any links, docs, or resources that might help solve this task.
+      placeholder: Resources...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-high.yml
+++ b/.github/ISSUE_TEMPLATE/03-high.yml
@@ -1,0 +1,40 @@
+name: "03 - High Task"
+description: "Template for large, high-priority tasks (e.g. architectural changes, new microservices, critical fixes)"
+title: "high: <summary>"
+labels: ["high"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the task.
+      placeholder: Describe the task...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions that must be met for this task to be resolved.
+      placeholder: |
+        - Criterion 1
+        - Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: relevant_files
+    attributes:
+      label: Relevant Files
+      description: List files that are relevant to this task.
+      placeholder: |
+        - path/to/file.ts
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: Resources
+      description: Add any links, docs, or resources that might help solve this task.
+      placeholder: Resources...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/99-bug.yml
+++ b/.github/ISSUE_TEMPLATE/99-bug.yml
@@ -1,0 +1,39 @@
+name: "99 - Bug Report"
+description: "Template for reporting a bug or unexpected behavior"
+title: "bug: <summary>"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the bug.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions or behavioral fixes that will resolve the bug.
+      placeholder: |
+        - What should happen instead...
+    validations:
+      required: true
+  - type: textarea
+    id: relevant_files
+    attributes:
+      label: Relevant Files
+      description: List files that are relevant to or contain the bug.
+      placeholder: |
+        - path/to/file.ts
+    validations:
+      required: false
+  - type: textarea
+    id: resources
+    attributes:
+      label: Resources
+      description: Add any logs, stack traces, screenshots, or context resources.
+      placeholder: Resources...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
-Fixes #
+Closes #
 
 ## What changed
--
-
-## Why
 -
 
 ## How to test


### PR DESCRIPTION
Fixes #185

## What changed
- **YAML Issue Forms**: Created structured YAML templates under `.github/ISSUE_TEMPLATE/` (`01-trivial.yml`, `02-medium.yml`, `03-high.yml`, `99-bug.yml`) to collect descriptions, criteria, files, and resources.
- **Chooser Config**: Configured `config.yml` to disable blank issues (`blank_issues_enabled: false`).
- **PR Template Update**: Standardized `.github/PULL_REQUEST_TEMPLATE.md` with blocks for closes, changes, testing, and a checklist.
- **CODEOWNERS Setup**: Added `.github/CODEOWNERS` setting `@harystyleseze` as the default owner for all files.

## Why
- Establishing issue templates forces contributors to follow a structured format rather than opening blank or poorly detailed issues.
- The default codeowner routing guarantees that new pull requests are automatically assigned to `@harystyleseze` for review.

## How to test
Verify that the templates are located in their exact target paths:
- `.github/ISSUE_TEMPLATE/` (forms and chooser config)
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/CODEOWNERS`

Check that the files are syntax-compliant.

## Checklist
- [x] CI passes (typecheck, lint, tests)
- [x] No sensitive data files (`data/spending.json`, `data/orders.json`) committed
- [x] PR linked to an issue