### PR TITLE
feat: surface budget context, iteration limit, and policy-change conf…

### DIFF
--- a/agent/__tests__/pay-for-medication.test.ts
+++ b/agent/__tests__/pay-for-medication.test.ts
@@ -138,6 +138,32 @@ describe("payForMedication — policy-blocked (Issue #35)", () => {
     expect(r.error).toContain("BLOCKED BY SPENDING POLICY");
     expect(mockMppFetch).not.toHaveBeenCalled();
   });
+
+  it("includes a budgetContext payload on a budget overrun (Issue #160)", async () => {
+    setSpendingPolicy("rosa", { ...DEFAULT_POLICY, medicationMonthlyBudget: 5 });
+    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    expect(r.success).toBe(false);
+    const ctx = (r as any).budgetContext;
+    expect(ctx).toBeDefined();
+    expect(ctx).toMatchObject({
+      reason: "budget",
+      attempted: 50,
+    });
+    expect(typeof ctx.dailyRemaining).toBe("number");
+    expect(typeof ctx.monthlyRemaining).toBe("number");
+    expect(ctx.monthlyRemaining).toBe(5);
+    expect(typeof ctx.suggestion).toBe("string");
+    expect(ctx.suggestion.toLowerCase()).toContain("caregiver");
+  });
+
+  it("labels the budgetContext reason as daily_limit when the daily cap is the binding constraint (Issue #160)", async () => {
+    setSpendingPolicy("rosa", { ...DEFAULT_POLICY, dailyLimit: 40, approvalThreshold: 40 });
+    const r = await payForMedication("p1", "Pharma", "Drug", 50);
+    expect(r.success).toBe(false);
+    const ctx = (r as any).budgetContext;
+    expect(ctx.reason).toBe("daily_limit");
+    expect(ctx.attempted).toBe(50);
+  });
 });
 
 // --- Approval-required path ---

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -31,6 +31,7 @@ import {
   agentLlmTokensTotal,
   agentLlmIterationTokens,
   agentLlmContextUsageRatio, agentLlmErrorTotal,
+  agentIterationLimitTotal,
 } from "../shared/metrics.ts";
 import {
   comparePharmacyPrices,
@@ -80,6 +81,12 @@ const LLM_MODEL = process.env.LLM_MODEL || "llama-3.3-70b-versatile";
 // - Final summary: temperature 0.3 (slight variance for natural phrasing)
 const LLM_TOOL_TEMPERATURE = parseFloat(process.env.LLM_TOOL_TEMPERATURE || "0");
 const LLM_SUMMARY_TEMPERATURE = parseFloat(process.env.LLM_SUMMARY_TEMPERATURE || "0.3");
+
+// Maximum agentic loop iterations before the run is capped. Configurable via
+// AGENT_MAX_ITERATIONS (default 15). When the cap is hit, the run appends an
+// iteration_limit_reached event so the caller knows the task may be incomplete
+// (Issue #165).
+const MAX_ITERATIONS = Math.max(1, parseInt(process.env.AGENT_MAX_ITERATIONS || "15", 10) || 15);
 
 // LLM max_tokens heuristic (Issue #280)
 // Context-aware token budgeting to reduce wasted budget on simple queries:
@@ -303,14 +310,16 @@ async function runAgent(task: string) {
   let llmUsage: { promptTokens: number; completionTokens: number } = { promptTokens: 0, completionTokens: 0 };
   let runToolCalls = 0;
   let truncated = false;
+  const events: Array<{ kind: string }> = [];
 
-  for (let iteration = 0; iteration < 15; iteration++) {
+  let iteration = 0;
+  for (; iteration < MAX_ITERATIONS; iteration++) {
     let response;
     try {
       // Determine temperature based on whether this is a tool-call round or final summary
       // Tool-call rounds use temperature=0 for deterministic tool selection
       // Final summary (when no tools will be called) uses temperature=0.3 for natural phrasing
-      const isToolCallRound = toolCalls.length > 0 || iteration < 14; // Assume tool calls unless it's the last iteration
+      const isToolCallRound = toolCalls.length > 0 || iteration < MAX_ITERATIONS - 1; // Assume tool calls unless it's the last iteration
       const temperature = isToolCallRound ? LLM_TOOL_TEMPERATURE : LLM_SUMMARY_TEMPERATURE;
       
       // Calculate max_tokens based on iteration context to optimize budget
@@ -448,6 +457,20 @@ async function runAgent(task: string) {
     if (choice.finish_reason === "stop") break;
   }
 
+  // The loop only reaches MAX_ITERATIONS when it never broke out early (no
+  // natural completion, no tool-call cap, no LLM error). Signal that the task
+  // may have been truncated so the caller can warn the user (Issue #165).
+  if (iteration >= MAX_ITERATIONS) {
+    events.push({ kind: "iteration_limit_reached" });
+    agentIterationLimitTotal.inc();
+    appendAuditEntry({
+      event: "agent.iteration_limit_reached",
+      actor: "agent",
+      details: { maxIterations: MAX_ITERATIONS },
+    });
+    logger.warn({ maxIterations: MAX_ITERATIONS }, "agent run hit iteration limit");
+  }
+
   // Track token usage for alerting on sustained high consumption
   const totalRunTokens = llmUsage.promptTokens + llmUsage.completionTokens;
   tokenStats.totalTokens += totalRunTokens;
@@ -468,7 +491,7 @@ async function runAgent(task: string) {
     );
   }
 
-  return { response: finalResponse, toolCalls, spending: getSpendingSummary(), llmUsage, truncated };
+  return { response: finalResponse, toolCalls, spending: getSpendingSummary(), llmUsage, truncated, events };
 }
 
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -76,6 +76,7 @@ import {
   paymentsUsdcTotal,
   stellarTxSubmittedTotal,
   policyBlocksTotal,
+  paymentRejectedTotal,
   agentSpendingUsd,
   agentTransactionsTotal,
   x402TxExtractionFailedTotal,
@@ -1331,28 +1332,9 @@ export function checkSpendingPolicy(
     spendingTracker.serviceFees;
   const globalRemaining = roundBudget(policy.monthlyLimit - totalMonthlySpending);
 
-  if (amount > globalRemaining) {
-    return {
-      allowed: false,
-      reason: `Payment of $${amount.toFixed(2)} would exceed overall monthly limit. Monthly limit: $${policy.monthlyLimit}, spent: $${totalMonthlySpending.toFixed(2)}, remaining: $${globalRemaining.toFixed(2)}`,
-      requiresApproval: false,
-      currentSpending,
-      budgetRemaining: remaining,
-      globalBudgetRemaining: globalRemaining,
-    };
-  }
-
-  if (amount > remaining) {
-    return {
-      allowed: false,
-      reason: `Payment of $${amount.toFixed(2)} exceeds ${category} monthly budget. Budget: $${budget}, spent: $${currentSpending.toFixed(2)}, remaining: $${remaining.toFixed(2)}`,
-      requiresApproval: false,
-      currentSpending,
-      budgetRemaining: remaining,
-    };
-  }
-
-  // Use the policy's per-recipient timezone if set; fall back to the global
+  // Compute today's spend in this category up-front so every return path can
+  // report the remaining daily budget to the caller (Issue #160). Use the
+  // policy's per-recipient timezone if set; fall back to the global
   // SPENDING_TIMEZONE env var so caregivers in non-UTC locales see the correct
   // "today" boundary for their wall clock (Issue #207).
   const effectiveTz = policy.timezone ?? SPENDING_TIMEZONE;
@@ -1372,6 +1354,34 @@ export function checkSpendingPolicy(
       },
     )
     .reduce((sum, t) => sum + t.amount, 0);
+  const dailyRemaining = roundBudget(policy.dailyLimit - totalToday);
+  // monthlyRemaining is the budget still available for this category this month.
+  const monthlyRemaining = remaining;
+
+  if (amount > globalRemaining) {
+    return {
+      allowed: false,
+      reason: `Payment of $${amount.toFixed(2)} would exceed overall monthly limit. Monthly limit: $${policy.monthlyLimit}, spent: $${totalMonthlySpending.toFixed(2)}, remaining: $${globalRemaining.toFixed(2)}`,
+      requiresApproval: false,
+      currentSpending,
+      budgetRemaining: remaining,
+      globalBudgetRemaining: globalRemaining,
+      dailyRemaining,
+      monthlyRemaining,
+    };
+  }
+
+  if (amount > remaining) {
+    return {
+      allowed: false,
+      reason: `Payment of $${amount.toFixed(2)} exceeds ${category} monthly budget. Budget: $${budget}, spent: $${currentSpending.toFixed(2)}, remaining: $${remaining.toFixed(2)}`,
+      requiresApproval: false,
+      currentSpending,
+      budgetRemaining: remaining,
+      dailyRemaining,
+      monthlyRemaining,
+    };
+  }
 
   if (totalToday + amount > policy.dailyLimit) {
     return {
@@ -1380,6 +1390,8 @@ export function checkSpendingPolicy(
       requiresApproval: false,
       currentSpending,
       budgetRemaining: remaining,
+      dailyRemaining,
+      monthlyRemaining,
     };
   }
 
@@ -1388,6 +1400,8 @@ export function checkSpendingPolicy(
     requiresApproval: amount >= policy.approvalThreshold,
     currentSpending,
     budgetRemaining: roundBudget(remaining - amount),
+    dailyRemaining,
+    monthlyRemaining,
   };
 }
 
@@ -1686,9 +1700,12 @@ export async function payForMedication(
     if (!policyCheck.allowed) {
       const reason = policyCheck.reason!.includes('daily')
         ? 'daily_limit'
-        : 'budget';
+        : policyCheck.reason!.includes('overall monthly limit')
+          ? 'monthly_limit'
+          : 'budget';
       policyBlocksTotal.inc({ reason });
-      
+      paymentRejectedTotal.inc({ reason });
+
       const tx = {
         id: `tx-${Date.now()}`,
         timestamp: new Date().toISOString(),
@@ -1702,10 +1719,26 @@ export async function payForMedication(
       spendingTracker.transactions.push(tx);
       appendTransaction(tx as any);
 
+      // Surface the full budget context so the LLM can decide whether to ask
+      // the caregiver for an override or pick a cheaper option (Issue #160).
+      const dailyRemaining = policyCheck.dailyRemaining ?? 0;
+      const monthlyRemaining = policyCheck.monthlyRemaining ?? 0;
+      const budgetContext = {
+        reason,
+        attempted: amount,
+        dailyRemaining,
+        monthlyRemaining,
+        suggestion:
+          `Relay this to the caregiver: the $${amount.toFixed(2)} payment was blocked by the spending policy. ` +
+          `Remaining budget is $${dailyRemaining.toFixed(2)} today and $${monthlyRemaining.toFixed(2)} this month for ${TRANSACTION_CATEGORY.MEDICATIONS}. ` +
+          `Ask them to approve a one-time override, or choose a cheaper option that fits the remaining budget.`,
+      };
+
       return {
         success: false,
         error: `BLOCKED BY SPENDING POLICY: ${policyCheck.reason}`,
         transaction: tx,
+        budgetContext,
       };
     }
     if (policyCheck.requiresApproval && !skipApproval) {
@@ -2341,7 +2374,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'pay_for_medication',
     description:
-      'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits. Amount must be between $0.01 and $10,000.',
+      'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits. Amount must be between $0.01 and $10,000. If the payment is blocked by spending policy, the result includes a budgetContext object { reason, attempted, dailyRemaining, monthlyRemaining, suggestion }: relay it to the caregiver so they can either approve a one-time override or pick a cheaper option within the remaining budget.',
     input_schema: strictInputSchema({
       type: 'object' as const,
       properties: {

--- a/dashboard/src/__tests__/policy-tab.test.tsx
+++ b/dashboard/src/__tests__/policy-tab.test.tsx
@@ -11,8 +11,8 @@
  *  5. Negative value rejected client-side (validatePolicy via form validation)
  */
 
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { PolicyTab } from "../components/tabs/policy-tab";
 import type { PolicyTabProps } from "../components/tabs/policy-tab";
 
@@ -232,6 +232,105 @@ describe("PolicyTab — policySaved prop drives button appearance (Issue #47)", 
     const btn = screen.getByRole("button", { name: /Update Policy/i });
     expect(btn).toBeTruthy();
     expect(btn.className).toContain("bg-sky-500");
+  });
+});
+
+// --- Confirmation for sensitive (limit-raising) policy changes (Issue #216) ---
+
+describe("PolicyTab — limit-increase confirmation (Issue #216)", () => {
+  function withBaseline(
+    formOverrides: Partial<typeof BASE_POLICY>,
+    onUpdatePolicy = vi.fn().mockResolvedValue({ ok: true }),
+  ): PolicyTabProps {
+    return buildProps({
+      policyForm: { ...BASE_POLICY, ...formOverrides },
+      spending: { policy: { ...BASE_POLICY } } as never,
+      onUpdatePolicy,
+    });
+  }
+
+  function submitForm() {
+    const form = screen
+      .getByRole("button", { name: /Update Policy/i })
+      .closest("form")!;
+    fireEvent.submit(form);
+  }
+
+  it("decreasing a limit saves without a confirmation dialog", async () => {
+    const onUpdatePolicy = vi.fn().mockResolvedValue({ ok: true });
+    render(<PolicyTab {...withBaseline({ medicationMonthlyBudget: 200 }, onUpdatePolicy)} />);
+
+    await act(async () => {
+      submitForm();
+    });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onUpdatePolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("raising a limit opens a confirmation dialog with the diff and saves on confirm", async () => {
+    const onUpdatePolicy = vi.fn().mockResolvedValue({ ok: true });
+    render(<PolicyTab {...withBaseline({ dailyLimit: 150 }, onUpdatePolicy)} />);
+
+    await act(async () => {
+      submitForm();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/Confirm policy change/i)).toBeTruthy();
+    expect(within(dialog).getByText(/increases your spending exposure/i)).toBeTruthy();
+    // Diff shows the before and after values.
+    expect(within(dialog).getAllByText(/\$150/).length).toBeGreaterThan(0);
+    expect(onUpdatePolicy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: /Confirm & Save/i }));
+    });
+
+    expect(onUpdatePolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelling the confirmation does not save", async () => {
+    const onUpdatePolicy = vi.fn().mockResolvedValue({ ok: true });
+    render(<PolicyTab {...withBaseline({ dailyLimit: 150 }, onUpdatePolicy)} />);
+
+    await act(async () => {
+      submitForm();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: /^Cancel$/i }));
+    });
+
+    expect(onUpdatePolicy).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("requires typing CONFIRM when a limit more than doubles", async () => {
+    const onUpdatePolicy = vi.fn().mockResolvedValue({ ok: true });
+    render(<PolicyTab {...withBaseline({ dailyLimit: 300 }, onUpdatePolicy)} />);
+
+    await act(async () => {
+      submitForm();
+    });
+
+    const dialog = screen.getByRole("dialog");
+    const confirmBtn = within(dialog).getByRole("button", {
+      name: /Confirm & Save/i,
+    }) as HTMLButtonElement;
+    expect(confirmBtn.disabled).toBe(true);
+
+    const typedInput = within(dialog).getByLabelText(/Type CONFIRM/i);
+    await act(async () => {
+      fireEvent.change(typedInput, { target: { value: "CONFIRM" } });
+    });
+    expect(confirmBtn.disabled).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+    expect(onUpdatePolicy).toHaveBeenCalledTimes(1);
   });
 
   it("policySaved timeout logic: flag goes true then false after 3 s", () => {

--- a/dashboard/src/components/tabs/overview-tab.test.tsx
+++ b/dashboard/src/components/tabs/overview-tab.test.tsx
@@ -72,6 +72,40 @@ describe("OverviewTab Component", () => {
     expect(screen.getByText("I found $10.00 in savings.")).toBeInTheDocument();
   });
 
+  it("shows the iteration-limit banner when the run was capped (Issue #165)", () => {
+    render(
+      <OverviewTab
+        {...mockProps}
+        agentResult={{
+          response: "Partial result.",
+          spending: { spending: { serviceFees: 0.05 } } as any,
+          toolCalls: [],
+          events: [{ kind: "iteration_limit_reached" }],
+        }}
+      />
+    );
+    expect(
+      screen.getByText(/Task may be incomplete — agent ran out of steps/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the iteration-limit banner on a normal run (Issue #165)", () => {
+    render(
+      <OverviewTab
+        {...mockProps}
+        agentResult={{
+          response: "Done.",
+          spending: { spending: { serviceFees: 0.05 } } as any,
+          toolCalls: [],
+          events: [],
+        }}
+      />
+    );
+    expect(
+      screen.queryByText(/agent ran out of steps/i)
+    ).not.toBeInTheDocument();
+  });
+
   it("calls onRunTask when task buttons are clicked", () => {
     render(<OverviewTab {...mockProps} />);
 

--- a/dashboard/src/components/tabs/overview-tab.tsx
+++ b/dashboard/src/components/tabs/overview-tab.tsx
@@ -162,6 +162,15 @@ export function OverviewTab({
         )}
       </div>
 
+      {agentResult?.events?.some((e) => e.kind === "iteration_limit_reached") && (
+        <div
+          role="alert"
+          className="bg-yellow-50 border border-yellow-300 rounded-xl p-4 text-sm text-yellow-800"
+        >
+          Task may be incomplete — agent ran out of steps
+        </div>
+      )}
+
       {agentResult && (
         <div
           className="bg-white rounded-xl border border-slate-200 p-6"

--- a/dashboard/src/components/tabs/policy-tab.tsx
+++ b/dashboard/src/components/tabs/policy-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, type FormEvent } from "react";
 import type { RecipientProfile } from "../../lib/types";
 import {
   validatePolicy,
@@ -31,6 +31,33 @@ const FIELD_CONFIG: Record<
   approvalThreshold:       { min: 1, max: 50000, step: 1 },
   holdTimeSeconds:         { min: 0, max: 86400, step: 1 },
 };
+
+/**
+ * Limit fields whose increase raises the caregiver's spending exposure and
+ * therefore warrants a confirmation step (Issue #216). holdTimeSeconds is
+ * excluded — a longer hold is the safe direction.
+ */
+const LIMIT_FIELDS: Array<keyof SpendingPolicyInput> = [
+  "dailyLimit",
+  "monthlyLimit",
+  "medicationMonthlyBudget",
+  "billMonthlyBudget",
+  "approvalThreshold",
+];
+
+const FIELD_LABELS: Record<string, string> = Object.fromEntries(FIELDS);
+
+/** A confirmation step requires typing this word when a limit more than doubles. */
+const TYPED_CONFIRMATION = "CONFIRM";
+
+interface PolicyChangeRow {
+  key: string;
+  label: string;
+  before: number;
+  after: number;
+  increased: boolean;
+  doubled: boolean;
+}
 
 export interface PolicyTabProps {
   recipient: RecipientProfile;
@@ -64,6 +91,63 @@ export function PolicyTab({
   const validation = useMemo(() => validatePolicy(policyForm), [policyForm]);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [toastFallback, setToastFallback] = useState<string | undefined>(undefined);
+  const [confirmRows, setConfirmRows] = useState<PolicyChangeRow[] | null>(null);
+  const [requiresTyped, setRequiresTyped] = useState(false);
+  const [typedValue, setTypedValue] = useState("");
+
+  const baseline = spending?.policy;
+
+  async function persistPolicy() {
+    const result = await onUpdatePolicy();
+    if (!result.ok) {
+      setToastFallback(result.error || "Failed to update policy");
+      setToastMsg("Policy update failed");
+    }
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!validation.isValid) return;
+
+    // Without a saved baseline to diff against, save directly.
+    if (!baseline) {
+      void persistPolicy();
+      return;
+    }
+
+    const rows: PolicyChangeRow[] = LIMIT_FIELDS.map((key) => {
+      const before = Number(baseline[key]);
+      const after = Number(policyForm[key]);
+      const increased =
+        Number.isFinite(before) && Number.isFinite(after) && after > before;
+      const doubled = increased && before > 0 && after > before * 2;
+      return { key, label: FIELD_LABELS[key] ?? key, before, after, increased, doubled };
+    }).filter((row) => row.before !== row.after);
+
+    const increases = rows.filter((row) => row.increased);
+    // Decreases (and unchanged limits) are the safe direction — save silently.
+    if (increases.length === 0) {
+      void persistPolicy();
+      return;
+    }
+
+    setTypedValue("");
+    setRequiresTyped(increases.some((row) => row.doubled));
+    setConfirmRows(rows);
+  }
+
+  function cancelConfirm() {
+    setConfirmRows(null);
+    setRequiresTyped(false);
+    setTypedValue("");
+  }
+
+  async function confirmSave() {
+    setConfirmRows(null);
+    setRequiresTyped(false);
+    setTypedValue("");
+    await persistPolicy();
+  }
 
   return (
     <div
@@ -80,19 +164,7 @@ export function PolicyTab({
         These limits are enforced by Soroban smart contracts on Stellar. The
         agent cannot exceed them.
       </p>
-      <form
-        noValidate
-        onSubmit={async (e) => {
-          e.preventDefault();
-          if (!validation.isValid) return;
-          const result = await onUpdatePolicy();
-          if (!result.ok) {
-            setToastFallback(result.error || "Failed to update policy");
-            setToastMsg("Policy update failed");
-          }
-        }}
-        className="space-y-4"
-      >
+      <form noValidate onSubmit={handleSubmit} className="space-y-4">
         {FIELDS.map(([key, label]) => {
           const errMsg = errorFor(key, validation.errors);
           const warnMsg = errorFor(key, validation.warnings);
@@ -172,6 +244,97 @@ export function PolicyTab({
           {policySaved ? "Policy Saved" : "Update Policy"}
         </button>
       </form>
+      {confirmRows && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="policy-confirm-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={cancelConfirm}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3
+              id="policy-confirm-title"
+              className="text-sm font-semibold text-slate-800 mb-1"
+            >
+              Confirm policy change
+            </h3>
+            <p className="text-xs text-amber-700 mb-4">
+              You are raising one or more limits. This increases your spending
+              exposure — please review before saving.
+            </p>
+
+            <ul className="space-y-2 mb-4">
+              {confirmRows.map((row) => (
+                <li
+                  key={row.key}
+                  className="flex items-center justify-between text-xs"
+                >
+                  <span className="text-slate-600">{row.label}</span>
+                  <span className="font-mono">
+                    <span className="text-slate-500">${row.before}</span>
+                    <span className="mx-1 text-slate-400">&rarr;</span>
+                    <span
+                      className={
+                        row.increased
+                          ? "text-red-600 font-semibold"
+                          : "text-green-600"
+                      }
+                    >
+                      ${row.after}
+                    </span>
+                    {row.doubled && (
+                      <span className="ml-1 text-red-600">(more than 2&times;)</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            {requiresTyped && (
+              <div className="mb-4">
+                <label
+                  htmlFor="policy-confirm-typed"
+                  className="block text-xs font-medium text-slate-600 mb-1"
+                >
+                  This more than doubles a limit. Type {TYPED_CONFIRMATION} to
+                  confirm.
+                </label>
+                <input
+                  id="policy-confirm-typed"
+                  type="text"
+                  value={typedValue}
+                  onChange={(e) => setTypedValue(e.target.value)}
+                  className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                  autoComplete="off"
+                />
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={cancelConfirm}
+                className="flex-1 py-2 rounded-lg text-sm font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmSave}
+                disabled={requiresTyped && typedValue !== TYPED_CONFIRMATION}
+                className="flex-1 py-2 rounded-lg text-sm font-medium bg-sky-500 text-white hover:bg-sky-600 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                Confirm &amp; Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <Toast
         message={toastMsg}
         fallbackText={toastFallback}

--- a/dashboard/src/components/types.ts
+++ b/dashboard/src/components/types.ts
@@ -2,6 +2,10 @@ import type { SpendingData, Transaction, AuditLogEvent } from "../lib/types";
 
 export type { SpendingData, Transaction, AuditLogEvent };
 
+export interface AgentEvent {
+  kind: string;
+}
+
 export interface AgentResult {
   response: string;
   toolCalls: Array<{ tool: string; input: unknown; result: any }>;
@@ -10,6 +14,7 @@ export interface AgentResult {
     promptTokens: number;
     completionTokens: number;
   };
+  events?: AgentEvent[];
 }
 
 export interface AgentInfo {

--- a/shared/metrics.ts
+++ b/shared/metrics.ts
@@ -57,6 +57,19 @@ export const policyBlocksTotal = new Counter({
   registers: [registry],
 });
 
+export const paymentRejectedTotal = new Counter({
+  name: "payment_rejected_total",
+  help: "Total payments rejected by spending policy, labeled by reason",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+export const agentIterationLimitTotal = new Counter({
+  name: "agent_iteration_limit_total",
+  help: "Total agent runs that hit the iteration limit before completing",
+  registers: [registry],
+});
+
 export const agentLlmTokensTotal = new Counter({
   name: "agent_llm_tokens_total",
   help: "Total LLM tokens consumed",


### PR DESCRIPTION
# Summary
## #160 payForMedication rejection now carries budget context

- On a spending-policy block, payForMedication returns a budgetContext object { reason, attempted, dailyRemaining, monthlyRemaining, suggestion } so the LLM can decide whether to ask the caregiver for an override or pick a cheaper option.
- checkSpendingPolicy now computes the daily total up-front and returns dailyRemaining and monthlyRemaining on every path.
- The pay_for_medication tool description tells the LLM to relay the budget context to the caregiver.
- New metric payment_rejected_total{reason} (reason: daily_limit | monthly_limit | budget).
- Vitest: a budget overrun asserts the budgetContext payload shape and the daily_limit reason label.

## #165 Agent loop cap is no longer silent

- MAX_ITERATIONS is configurable via AGENT_MAX_ITERATIONS (default 15).
- When the loop hits the cap, the run appends an { kind: "iteration_limit_reached" } event to the response, increments agent_iteration_limit_total, and writes an audit entry.
- The dashboard renders a yellow banner "Task may be incomplete â agent ran out of steps" when that event is present.
- Vitest: the banner shows when the event is present and is hidden on a normal run.

## #216 Policy form confirms sensitive (limit-raising) changes

- Raising any spending limit opens a confirmation dialog showing the before/after diff and a spending-exposure warning.
- Decreases (the safe direction) save without a prompt.
- A limit that more than doubles additionally requires typing CONFIRM.
- Vitest: increase + confirm, increase + cancel, decrease, and the typed-confirmation gate.


## Verification

- vitest: all new tests pass. The agent suite still has 8 pre-existing failures in the older Issue #35 tests (an approvalThreshold<=dailyLimit validation and an MPP mock were changed after those tests were written); they are unrelated to these changes and fail on main.
- tsc -b: the agent changes are type-clean.

- The dashboard renders a yellow banner "Task may be incomplete â agent ran out of steps" when that event is present.
- Vitest: the banner shows when the event is present and is hidden on a normal run.

Closes #160 
Closes #165 
Closes #216
