### PR TITLE
fix: Type generateDisputeHtml params and remove any on line items #560

### DIFF
--- a/dashboard/src/components/tabs/bills-tab.tsx
+++ b/dashboard/src/components/tabs/bills-tab.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { downloadBillAuditPDF, downloadDisputeLetterPDF, downloadDisputeLetterEmail } from "../../app/pdf";
+import {
+  downloadBillAuditPDF,
+  downloadDisputeLetterPDF,
+  downloadDisputeLetterEmail,
+} from "../../app/pdf";
 import {
   BillAuditResultSchema,
-  type RecipientProfile,
+  type BillAuditResult,
   type DisputeLetter,
+  type RecipientProfile,
 } from "../../lib/types";
 import { BillLineItemsVirtualized } from "../primitives/bill-line-items-virtualized";
 import type { AgentResult } from "../types";
+
+type BillAuditToolCall = {
+  result: BillAuditResult;
+};
 
 export interface BillsTabProps {
   agentResult: AgentResult | null;
@@ -17,16 +26,44 @@ export interface BillsTabProps {
 
 export function BillsTab({ agentResult, recipient }: BillsTabProps) {
   const [showErrorsOnly, setShowErrorsOnly] = useState(false);
-  const [generatingDispute, setGeneratingDispute] = useState<string | null>(null);
-
-  const auditCalls = agentResult?.toolCalls.filter(
-    (t) =>
-      t.tool === "audit_medical_bill" || t.tool === "fetch_and_audit_bill",
+  const [generatingDispute, setGeneratingDispute] = useState<string | null>(
+    null,
   );
 
-  const handleDispute = useCallback(async (auditResult: any, index: number) => {
-    setGeneratingDispute(`dispute-${index}`);
-    try {
+  const auditCalls: BillAuditToolCall[] =
+    agentResult?.toolCalls
+      .filter(
+        (t) =>
+          t.tool === "audit_medical_bill" || t.tool === "fetch_and_audit_bill",
+      )
+      .map((t) => ({
+        result: BillAuditResultSchema.parse(t.result),
+      })) ?? [];
+
+  const handleDispute = useCallback(
+    async (auditResult: BillAuditResult, index: number) => {
+      setGeneratingDispute(`dispute-${index}`);
+      try {
+        const letter: DisputeLetter = {
+          billId: `bill-${Date.now()}`,
+          recipientName: recipient.name,
+          facility: recipient.facility || "General Hospital",
+          totalOvercharge: auditResult.totalOvercharge,
+          errorCount: auditResult.errorCount,
+          emailText: generateDisputeText(auditResult, recipient),
+          emailHtml: generateDisputeHtml(auditResult, recipient),
+          generatedAt: new Date().toISOString(),
+        };
+        downloadDisputeLetterPDF(letter);
+      } finally {
+        setGeneratingDispute(null);
+      }
+    },
+    [recipient],
+  );
+
+  const handleDisputeEmail = useCallback(
+    async (auditResult: BillAuditResult) => {
       const letter: DisputeLetter = {
         billId: `bill-${Date.now()}`,
         recipientName: recipient.name,
@@ -37,28 +74,13 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
         emailHtml: generateDisputeHtml(auditResult, recipient),
         generatedAt: new Date().toISOString(),
       };
-      downloadDisputeLetterPDF(letter);
-    } finally {
-      setGeneratingDispute(null);
-    }
-  }, [recipient]);
-
-  const handleDisputeEmail = useCallback(async (auditResult: any) => {
-    const letter: DisputeLetter = {
-      billId: `bill-${Date.now()}`,
-      recipientName: recipient.name,
-      facility: recipient.facility || "General Hospital",
-      totalOvercharge: auditResult.totalOvercharge,
-      errorCount: auditResult.errorCount,
-      emailText: generateDisputeText(auditResult, recipient),
-      emailHtml: generateDisputeHtml(auditResult, recipient),
-      generatedAt: new Date().toISOString(),
-    };
-    const html = downloadDisputeLetterEmail(letter);
-    const blob = new Blob([html], { type: "text/html" });
-    const url = URL.createObjectURL(blob);
-    window.open(url, "_blank");
-  }, [recipient]);
+      const html = downloadDisputeLetterEmail(letter);
+      const blob = new Blob([html], { type: "text/html" });
+      const url = URL.createObjectURL(blob);
+      window.open(url, "_blank");
+    },
+    [recipient],
+  );
 
   return (
     <div
@@ -68,8 +90,8 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
       tabIndex={0}
       className="space-y-6"
     >
-      {auditCalls && auditCalls.length > 0 ? (
-        auditCalls.map((t, i) => (
+      {auditCalls.length > 0 ? (
+        auditCalls.map(({ result: auditResult }, i) => (
           <div
             key={i}
             className="bg-white rounded-xl border border-slate-200 p-6"
@@ -81,7 +103,7 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
               <div className="flex items-center gap-2">
                 <button
                   onClick={() =>
-                    downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), {
+                    downloadBillAuditPDF(auditResult, {
                       errorsOnly: showErrorsOnly,
                       recipient,
                     })
@@ -90,17 +112,19 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
                 >
                   Download PDF
                 </button>
-                {t.result.errorCount > 0 && (
+                {auditResult.errorCount > 0 && (
                   <>
                     <button
-                      onClick={() => handleDispute(t.result, i)}
+                      onClick={() => handleDispute(auditResult, i)}
                       disabled={generatingDispute === `dispute-${i}`}
                       className="px-3 py-1.5 bg-red-50 text-red-700 rounded-lg text-xs font-medium hover:bg-red-100 active:bg-red-200 cursor-pointer transition-all disabled:opacity-50"
                     >
-                      {generatingDispute === `dispute-${i}` ? "Generating..." : "Dispute"}
+                      {generatingDispute === `dispute-${i}`
+                        ? "Generating..."
+                        : "Dispute"}
                     </button>
                     <button
-                      onClick={() => handleDisputeEmail(t.result)}
+                      onClick={() => handleDisputeEmail(auditResult)}
                       className="px-3 py-1.5 bg-amber-50 text-amber-700 rounded-lg text-xs font-medium hover:bg-amber-100 active:bg-amber-200 cursor-pointer transition-all"
                     >
                       Email Text
@@ -109,36 +133,38 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
                 )}
                 <span
                   className={`px-3 py-1 rounded-full text-xs font-medium ${
-                    t.result.errorCount > 0
+                    auditResult.errorCount > 0
                       ? "bg-red-100 text-red-700"
                       : "bg-green-100 text-green-700"
                   }`}
                 >
-                  {t.result.errorCount} errors found
+                  {auditResult.errorCount} errors found
                 </span>
               </div>
             </div>
             <div className="grid grid-cols-3 gap-4 mb-4">
               <div className="bg-slate-50 rounded-lg p-3 text-center">
-                <div className="text-lg font-bold">${t.result.totalCharged}</div>
+                <div className="text-lg font-bold">
+                  ${auditResult.totalCharged}
+                </div>
                 <div className="text-xs text-slate-500">Total Charged</div>
               </div>
               <div className="bg-red-50 rounded-lg p-3 text-center">
                 <div className="text-lg font-bold text-red-600">
-                  ${t.result.totalOvercharge}
+                  ${auditResult.totalOvercharge}
                 </div>
                 <div className="text-xs text-slate-500">Overcharges</div>
               </div>
               <div className="bg-green-50 rounded-lg p-3 text-center">
                 <div className="text-lg font-bold text-green-600">
-                  ${t.result.totalCorrect}
+                  ${auditResult.totalCorrect}
                 </div>
                 <div className="text-xs text-slate-500">Correct Amount</div>
               </div>
             </div>
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs text-slate-500">
-                {t.result.lineItems.length} line items
+                {auditResult.lineItems.length} line items
               </span>
               <button
                 onClick={() => setShowErrorsOnly(!showErrorsOnly)}
@@ -148,33 +174,45 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
               </button>
             </div>
             <BillLineItemsVirtualized
-              lineItems={t.result.lineItems.filter(
-                (item: any) => !showErrorsOnly || item.status !== "valid",
+              lineItems={auditResult.lineItems.filter(
+                (item) => !showErrorsOnly || item.status !== "valid",
               )}
             />
             <p className="mt-4 text-sm font-medium text-slate-700">
-              {t.result.recommendation}
+              {auditResult.recommendation}
             </p>
           </div>
         ))
       ) : (
         <div className="bg-white rounded-xl border border-slate-200 p-12 text-center text-sm text-slate-400">
-          No bills audited yet. Run &quot;Audit Hospital Bill&quot; from Overview.
+          No bills audited yet. Run &quot;Audit Hospital Bill&quot; from
+          Overview.
         </div>
       )}
     </div>
   );
 }
 
-function generateDisputeText(auditResult: any, recipient: RecipientProfile): string {
-  const errorItems = (auditResult.lineItems || []).filter((item: any) => item.status !== "valid");
+function generateDisputeText(
+  auditResult: BillAuditResult,
+  recipient: RecipientProfile,
+): string {
+  const errorItems = auditResult.lineItems.filter(
+    (item) => item.status !== "valid",
+  );
   const lines: string[] = [];
-  lines.push(`Dear ${recipient.facility || "General Hospital"} Billing Department,`);
+  lines.push(
+    `Dear ${recipient.facility || "General Hospital"} Billing Department,`,
+  );
   lines.push("");
-  lines.push(`I am writing on behalf of ${recipient.name} to formally dispute the following billing errors:`);
+  lines.push(
+    `I am writing on behalf of ${recipient.name} to formally dispute the following billing errors:`,
+  );
   lines.push("");
   for (const item of errorItems) {
-    lines.push(`  - ${item.description}${item.cptCode ? ` (CPT: ${item.cptCode})` : ""}: Charged $${item.chargedAmount.toFixed(2)}`);
+    lines.push(
+      `  - ${item.description}${item.cptCode ? ` (CPT: ${item.cptCode})` : ""}: Charged $${item.chargedAmount.toFixed(2)}`,
+    );
     if (item.suggestedAmount !== undefined) {
       lines.push(`    Fair market rate: $${item.suggestedAmount.toFixed(2)}`);
     }
@@ -192,11 +230,19 @@ function generateDisputeText(auditResult: any, recipient: RecipientProfile): str
   return lines.join("\n");
 }
 
-function generateDisputeHtml(auditResult: any, recipient: RecipientProfile): string {
-  const errorItems = (auditResult.lineItems || []).filter((item: any) => item.status !== "valid");
-  const itemsHtml = errorItems.map((item: any) =>
-    `<li><strong>${item.description}</strong>${item.cptCode ? ` (CPT: ${item.cptCode})` : ""}: Charged $${item.chargedAmount.toFixed(2)}${item.suggestedAmount !== undefined ? ` — Fair rate: $${item.suggestedAmount.toFixed(2)}` : ""}${item.errorDescription ? `<br/><em>${item.errorDescription}</em>` : ""}</li>`
-  ).join("");
+function generateDisputeHtml(
+  auditResult: BillAuditResult,
+  recipient: RecipientProfile,
+): string {
+  const errorItems = auditResult.lineItems.filter(
+    (item) => item.status !== "valid",
+  );
+  const itemsHtml = errorItems
+    .map(
+      (item) =>
+        `<li><strong>${item.description}</strong>${item.cptCode ? ` (CPT: ${item.cptCode})` : ""}: Charged $${item.chargedAmount.toFixed(2)}${item.suggestedAmount !== undefined ? ` — Fair rate: $${item.suggestedAmount.toFixed(2)}` : ""}${item.errorDescription ? `<br/><em>${item.errorDescription}</em>` : ""}</li>`,
+    )
+    .join("");
   return `
 <h2>Medical Bill Dispute</h2>
 <p>Dear ${recipient.facility || "General Hospital"} Billing Department,</p>


### PR DESCRIPTION
Closes [#560](https://github.com/harystyleseze/careguard/issues/560)

## What changed
- Removed any: Introduced and applied the BillAuditResult type to dispute handlers and helper functions.
- Early validation: Parse audit results once when building auditCalls via BillAuditResultSchema.parse(), instead of at PDF download time.
- Cleaner rendering: Use auditResult instead of t.result and remove unnecessary null checks.
