### PR TITLE
Fix #777, #782, #785, #793: metrics catalog, SLOs, Prometheus retention, order-restart test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     image: prom/prometheus:v2.55.0
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.retention.time=7d"
+      - "--storage.tsdb.retention.time=35d"
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus

--- a/docs/observability/dashboard-guide.md
+++ b/docs/observability/dashboard-guide.md
@@ -187,3 +187,9 @@ To add a new dashboard:
 3. The dashboard appears automatically in the Grafana UI
 
 > **Note:** The datasource UID must match the Prometheus datasource configured in `docker/grafana/provisioning/datasources/prometheus.yml`. Current UID: `prometheus`.
+
+## Related docs
+
+- [Metrics catalog](./metrics-catalog.md) — every exported metric, its labels, and which panel/alert uses it
+- [SLOs and error budgets](./slo.md) — targets derived from these metrics
+- [Prometheus retention and remote-write strategy](./prometheus-retention.md) — how long this data lives

--- a/docs/observability/metrics-catalog.md
+++ b/docs/observability/metrics-catalog.md
@@ -1,0 +1,68 @@
+# Metrics Catalog
+
+Every metric exported by CareGuard, what it means, and where it's used. All metrics
+are registered on the shared `prom-client` `Registry` in [`shared/metrics.ts`](../../shared/metrics.ts)
+(queue gauges live in [`shared/agent-queue.ts`](../../shared/agent-queue.ts)) and served at `/metrics`.
+See the [Grafana dashboard guide](./dashboard-guide.md) for how these are visualized.
+
+## Agent
+
+| Metric | Type | Labels | Meaning | Used by |
+|---|---|---|---|---|
+| `agent_runs_total` | Counter | `status` | Total agent run attempts, by outcome. | Overview dashboard "Agent Runs" panel |
+| `agent_tool_calls_total` | Counter | `tool`, `status` | Total tool invocations made by the agent, by tool name and outcome. | Agent dashboard |
+| `agent_iteration_limit_total` | Counter | — | Total agent runs that hit the iteration limit before completing. | Agent dashboard / alerting on runaway loops |
+| `agent_llm_tokens_total` | Counter | `kind` (`prompt`/`completion`) | Cumulative LLM tokens consumed. | Overview dashboard "LLM Tokens (24h)" |
+| `agent_llm_iteration_tokens` | Gauge | `kind` | Tokens consumed in the most recent agent iteration. | Agent dashboard, per-run drill-down |
+| `agent_llm_context_usage_ratio` | Gauge | — | Latest iteration's token usage as a fraction of the model's context window. | Agent dashboard; alerts near context exhaustion |
+| `agent_llm_error_total` | Counter | — | Total LLM API errors during agent runs. | Agent dashboard error-rate panel |
+| `agent_llm_latency_ms` | Gauge | `model` | Latest observed LLM API call latency. | Agent dashboard latency panel |
+| `agent_spending_usd` | Gauge | `category` | Running USD spend, broken out by category. | Overview dashboard "LLM Cost (USD)" and budget alerts |
+| `agent_transactions_total` | Counter | — | Total Stellar transactions initiated by the agent. | Agent dashboard |
+
+## Payments / Stellar
+
+| Metric | Type | Labels | Meaning | Used by |
+|---|---|---|---|---|
+| `payments_usdc_total` | Counter | `type` | Total USDC payments made, by payment type. | Payments dashboard |
+| `x402_settlements_total` | Counter | — | Total x402 protocol settlements. | Payments dashboard |
+| `x402_tx_extraction_failed_total` | Counter | — | Total failures extracting a tx reference from an x402 payment response header. | Payments dashboard error panel; flags receipt-parsing regressions |
+| `stellar_tx_submitted_total` | Counter | `result` | Total Stellar transactions submitted, by result (success/failure). | Payments dashboard |
+| `stellar_fee_bumps_total` | Counter | — | Total fee-bump transactions submitted to accelerate a stuck tx. | Payments dashboard |
+| `stellar_tx_bad_seq_retries_total` | Counter | — | Total retries triggered by a `tx_bad_seq` response from Horizon. | Payments dashboard; indicates sequence-number contention |
+| `policy_blocks_total` | Counter | `reason` | Total spending-policy blocks, by reason. | Payments dashboard "Policy Blocks" panel |
+| `payment_rejected_total` | Counter | `reason` | Total payments rejected by spending policy, by reason. | Payments dashboard |
+
+## Pharmacy
+
+| Metric | Type | Labels | Meaning | Used by |
+|---|---|---|---|---|
+| `pharmacy_unknown_drug_total` | Counter | `drug` | Total price lookups for a drug not in the catalog. | Pharmacy panel; flags catalog gaps |
+| `bill_audit_oversized_rejections_total` | Counter | — | Total bill-audit requests rejected for exceeding `BILL_AUDIT_MAX_ITEMS`. | Pharmacy panel; input-size guardrail visibility |
+
+## Agent Queue
+
+| Metric | Type | Labels | Meaning | Used by |
+|---|---|---|---|---|
+| `agent_queue_depth` | Gauge | — | Number of agent runs currently executing. | Overview dashboard concurrency panel |
+| `agent_waiting_jobs` | Gauge | — | Number of agent requests currently waiting in the queue. | Overview dashboard; queue-backup alerting |
+
+## Default Node process metrics
+
+`collectDefaultMetrics({ register: registry })` in `shared/metrics.ts` also exports the
+standard `prom-client` Node.js process metrics (event-loop lag, heap usage, active
+handles/requests, GC duration, process CPU/uptime). These aren't CareGuard-specific
+but are useful for spotting memory leaks, event-loop stalls, or GC pressure ahead of
+symptoms showing up in the app-level metrics above.
+
+## Known gaps
+
+- `agent_tool_calls_total`, `stellar_tx_submitted_total`, and `payment_rejected_total`
+  have no label for which *user/session* triggered them — useful for aggregate rates,
+  but you cannot currently attribute a spike to a specific caller from these metrics
+  alone.
+- `agent_llm_latency_ms` and `agent_llm_iteration_tokens` are Gauges tracking only the
+  *latest* observation, not a distribution — there's no histogram/percentile view of
+  LLM latency or token usage over time.
+- `pharmacy_unknown_drug_total`'s `drug` label is unbounded (any string a client
+  sends), which is a cardinality risk if abused.

--- a/docs/observability/prometheus-retention.md
+++ b/docs/observability/prometheus-retention.md
@@ -1,0 +1,74 @@
+# Prometheus Retention and Remote-Write Strategy
+
+## Current configuration
+
+Prometheus runs as a single container via `docker-compose.yml` (`prometheus` service):
+
+```yaml
+command:
+  - "--config.file=/etc/prometheus/prometheus.yml"
+  - "--storage.tsdb.retention.time=35d"
+volumes:
+  - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  - prometheus-data:/prometheus
+```
+
+- **Retention: 35 days**, set via `--storage.tsdb.retention.time=35d` (raised from the
+  previous `7d` default to cover the 30-day SLO windows below with slack — see
+  "Alignment with SLO windows").
+- Storage is local-only TSDB on the named Docker volume `prometheus-data` — there is no
+  remote-write target configured in [`docker/prometheus/prometheus.yml`](../../docker/prometheus/prometheus.yml).
+- Scrape/evaluation interval is 5s (`docker/prometheus/prometheus.yml`), so retention
+  covers a meaningful amount of raw-resolution data, not just a few samples.
+
+## Data-loss implication
+
+`prometheus-data` is a named Docker volume. Running `docker compose down -v` removes
+named volumes along with the containers, which **deletes all metrics history**,
+including anything within the 7-day retention window. A plain `docker compose down`
+(no `-v`) or `docker compose restart prometheus` does not touch the volume and is safe.
+
+This means:
+- Any SLO/error-budget calculation that needs history older than 7 days, or that
+  spans a `down -v`, has no data to work from.
+- There is currently no backup of `prometheus-data` — see the note in
+  [dashboard-guide.md](./dashboard-guide.md) about Grafana provisioning being
+  code-defined (dashboards survive volume loss); Prometheus's raw metrics do not have
+  an equivalent code-defined backing store.
+
+## Remote-write / long-term storage options considered
+
+| Option | Trade-off |
+|---|---|
+| Increase local `--storage.tsdb.retention.time` (e.g. to 30d+) | Simplest change, no new infra, but still lost entirely on `down -v`; disk usage on the compose host grows with retention × cardinality. |
+| Remote-write to a managed backend (Grafana Cloud, Thanos, Mimir, VictoriaMetrics) | Survives volume loss, enables retention far beyond 7d, but adds an external dependency, network egress, and (for hosted options) cost. |
+| Periodic snapshot/backup of the `prometheus-data` volume | Cheap to add (`docker run --rm -v prometheus-data:/data ... tar`), keeps data local, but requires a backup schedule and restore process that doesn't exist today. |
+
+## Chosen strategy (interim)
+
+**Interim accepted approach:** raise local retention to cover the SLO measurement
+windows and rely on volume durability for now; defer remote-write to a follow-up once
+there's an operational need to retain data beyond what local disk can hold or to
+survive host loss.
+
+Concretely:
+- Retention is set to **`35d`** so the 30-day SLO windows defined in [slo.md](./slo.md)
+  have a full window of history plus slack, even across a mid-window Prometheus restart.
+- `docker compose down -v` remains destructive by design (it's the documented way to
+  reset local dev state) — operators must avoid it on any host being used to track
+  real error-budget burn, and this doc is the reference for why.
+- Remote-write is **not yet configured**. This is an accepted gap for the current
+  single-host deployment; revisit if CareGuard moves to a multi-host or production
+  deployment where host loss must not mean metrics loss.
+
+## Alignment with SLO windows
+
+All SLOs in [slo.md](./slo.md) use a 30-day rolling window. A 35-day local retention
+gives each SLO a full window of history at all times, including right after a
+Prometheus container restart (which does not clear the volume, only `down -v` does).
+
+## Follow-up
+
+If/when remote-write is added, this doc should be updated with the chosen backend,
+the `remote_write` block added to `docker/prometheus/prometheus.yml`, and the retention
+value reconsidered (local retention can usually shrink once a long-term store exists).

--- a/docs/observability/slo.md
+++ b/docs/observability/slo.md
@@ -1,0 +1,61 @@
+# SLOs and Error Budgets
+
+Quantitative targets for CareGuard's core user journeys, derived from the metrics in
+[`shared/metrics.ts`](../../shared/metrics.ts) and cataloged in
+[metrics-catalog.md](./metrics-catalog.md). These targets are the basis for alerting
+thresholds and release-freeze decisions.
+
+## SLIs and SLO targets
+
+| SLI | Definition | Prometheus query | SLO target | Window |
+|---|---|---|---|---|
+| Agent run success rate | Fraction of agent runs that complete without error | `sum(rate(agent_runs_total{status="success"}[30d])) / sum(rate(agent_runs_total[30d]))` | ≥ 99% | 30d rolling |
+| Stellar tx success rate | Fraction of submitted Stellar transactions that succeed | `sum(rate(stellar_tx_submitted_total{result="success"}[30d])) / sum(rate(stellar_tx_submitted_total[30d]))` | ≥ 99.5% | 30d rolling |
+| Payment settlement success rate | Fraction of x402 settlements that complete without a tx-extraction failure | `sum(rate(x402_settlements_total[30d])) / (sum(rate(x402_settlements_total[30d])) + sum(rate(x402_tx_extraction_failed_total[30d])))` | ≥ 99.5% | 30d rolling |
+| LLM error rate | Fraction of agent runs hitting an LLM API error | `sum(rate(agent_llm_error_total[30d])) / sum(rate(agent_runs_total[30d]))` | ≤ 1% | 30d rolling |
+| Agent availability (queue not saturated) | Fraction of time the agent queue has capacity to accept work | derived from `agent_queue_depth` / `agent_waiting_jobs` staying below configured concurrency | ≥ 99.9% | 30d rolling |
+
+## Error budgets
+
+An SLO target implies an error budget — the allowed amount of "bad" events in the
+window before the SLO is breached.
+
+| SLI | SLO | Error budget (30d) |
+|---|---|---|
+| Agent run success rate | 99% | 1% of runs may fail — e.g. ~14.4 min/day equivalent budget if runs were evenly time-weighted |
+| Stellar tx success rate | 99.5% | 0.5% of submitted transactions may fail |
+| Payment settlement success rate | 99.5% | 0.5% of settlements may fail to extract a tx reference |
+| LLM error rate | ≤ 1% error rate | Budget is consumed as errors accrue past 1% of total runs |
+
+## Error-budget policy
+
+- **Budget remaining > 25%**: normal operation. No process changes.
+- **Budget remaining 10–25%**: the on-call engineer is notified (see the alert mapping
+  below); new risky changes to the affected subsystem (agent runtime, payment/Stellar
+  path) should get an extra review pass before merge.
+- **Budget exhausted (0%) within the 30d window**: a release freeze applies to the
+  affected subsystem — no non-critical changes land until either the window rolls
+  forward enough to restore budget, or the root cause is fixed and burn rate returns
+  to baseline. Critical/security fixes are exempt from the freeze.
+- Budget burn is evaluated per-SLI, not globally — e.g. a Stellar tx success-rate
+  budget burn only freezes changes to the Stellar submission path, not unrelated docs
+  or dashboard work.
+
+## SLO → alert mapping
+
+| SLO | Alert | Query basis |
+|---|---|---|
+| Agent run success rate | `AgentRunFailureRateHigh` | `agent_runs_total{status!="success"}` rate vs. total |
+| Stellar tx success rate | `StellarTxFailureRateHigh` | `stellar_tx_submitted_total{result!="success"}` rate vs. total |
+| Payment settlement success rate | `X402SettlementFailureRateHigh` | `x402_tx_extraction_failed_total` rate vs. `x402_settlements_total` |
+| LLM error rate | `AgentLlmErrorRateHigh` | `agent_llm_error_total` rate vs. `agent_runs_total` |
+| Agent availability | `AgentQueueSaturated` | `agent_waiting_jobs` sustained above threshold |
+
+Alert rule definitions live alongside the Prometheus config in `docker/prometheus/`;
+this doc is the source of truth for the *targets* those rules should enforce.
+
+## Retention
+
+Error-budget history needs to persist at least as long as the longest SLO window above
+(30 days). See [prometheus-retention.md](./prometheus-retention.md) for the current
+retention configuration and how it aligns with this requirement.

--- a/services/pharmacy-payment/__tests__/mpp-order-restart.integration.test.ts
+++ b/services/pharmacy-payment/__tests__/mpp-order-restart.integration.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+/**
+ * Integration test (Issue #793): an order placed through the live
+ * POST /pharmacy/order route survives a full server restart.
+ *
+ * Unlike mpp-store-persistence.test.ts (which mocks fs entirely), this test
+ * uses the real filesystem against a temp data directory and re-imports the
+ * server module between "boots" (vi.resetModules) to simulate a process
+ * restart while keeping the same on-disk orders.json.
+ *
+ * Express, the MPP/Stellar SDKs, and file locking are mocked — the goal is
+ * to exercise the route handlers' own read/write logic, not those deps.
+ */
+
+const mockSafeParse = vi.fn();
+const mockApp = {
+  use: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  listen: vi.fn(() => ({ close: vi.fn() })),
+};
+
+vi.mock('express', () => {
+  const express = vi.fn(() => mockApp);
+  (express as any).json = vi.fn(() => vi.fn());
+  return { default: express };
+});
+vi.mock('mppx/server', () => ({
+  Store: { memory: vi.fn(() => ({ type: 'memory' })), fileSystem: vi.fn((p: string) => ({ type: 'fileSystem', path: p })) },
+  Mppx: {
+    create: vi.fn(() => ({
+      charge: () => () =>
+        Promise.resolve({
+          status: 200,
+          withReceipt: (resp: Response) => resp,
+        }),
+    })),
+  },
+}));
+vi.mock('@stellar/mpp/charge/server', () => ({ stellar: { charge: vi.fn(() => ({})) } }));
+vi.mock('@stellar/mpp', () => ({ USDC_SAC_TESTNET: 'USDC_SAC_TESTNET' }));
+vi.mock('dotenv/config', () => ({}));
+vi.mock('../../shared/cors.ts', () => ({ createCorsMiddleware: vi.fn(() => vi.fn()) }));
+vi.mock('../../shared/security-middleware.ts', () => ({ applySecurityMiddleware: vi.fn() }));
+vi.mock('../../shared/logger.ts', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('../../shared/request-context.ts', () => ({ requestContextMiddleware: vi.fn(() => vi.fn()) }));
+vi.mock('../../shared/request-logger.ts', () => ({ requestLoggerMiddleware: vi.fn(() => vi.fn()) }));
+vi.mock('../../shared/sanitize.ts', () => ({ sanitizeUserString: vi.fn((s: string) => s) }));
+vi.mock('../validation.ts', () => ({ MedicationOrderSchema: { safeParse: mockSafeParse } }));
+vi.mock('proper-lockfile', () => ({
+  default: { lock: vi.fn(() => Promise.resolve(() => Promise.resolve())) },
+}));
+
+function fakeRes() {
+  const res: any = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: undefined,
+    status(code: number) { this.statusCode = code; return this; },
+    json(payload: any) { this.body = payload; return this; },
+    send(payload: any) { this.body = payload; return this; },
+    setHeader(k: string, v: string) { this.headers[k] = v; return this; },
+  };
+  return res;
+}
+
+async function bootServer() {
+  vi.resetModules();
+  await import('../server.ts');
+  const postCalls = mockApp.post.mock.calls;
+  const getCalls = mockApp.get.mock.calls;
+  return {
+    orderHandler: postCalls[postCalls.length - 1][1],
+    ordersHandler: getCalls.filter((c) => c[0] === '/pharmacy/orders').pop()![1],
+  };
+}
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(path.join(tmpdir(), 'careguard-mpp-orders-'));
+  process.env.DATA_DIR = dataDir;
+  process.env.PHARMACY_1_PUBLIC_KEY = 'GPUB123TEST';
+  process.env.MPP_SECRET_KEY = 'test-mpp-secret';
+  mockSafeParse.mockReturnValue({
+    success: true,
+    data: { drug: 'Amoxicillin', pharmacy: 'Test Pharmacy', amount: 12.5 },
+  });
+});
+
+afterAll(() => {
+  delete process.env.DATA_DIR;
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('MPP order persistence across a server restart (Issue #793)', () => {
+  it('an order placed via POST /pharmacy/order is present in GET /pharmacy/orders after restart', async () => {
+    const boot1 = await bootServer();
+    const req: any = { body: {}, headers: {}, url: '/pharmacy/order', method: 'POST' };
+    const res1 = fakeRes();
+    await boot1.orderHandler(req, res1);
+
+    expect(res1.statusCode).toBe(200);
+    const placedOrder = res1.body.order;
+    expect(placedOrder.id).toMatch(/^order-/);
+
+    // Simulate a full process restart: fresh module load, same data dir.
+    const boot2 = await bootServer();
+    const res2 = fakeRes();
+    await boot2.ordersHandler({} as any, res2);
+
+    expect(res2.body.orders).toHaveLength(1);
+    expect(res2.body.orders[0].id).toBe(placedOrder.id);
+    expect(res2.body.orders[0].drug).toBe(placedOrder.drug);
+  });
+
+  it('a torn/partial orders.json does not crash boot and is reported as empty', async () => {
+    const ordersFile = path.join(dataDir, 'orders.json');
+    writeFileSync(ordersFile, '{"orders": [ this is not valid json', 'utf-8');
+
+    const boot = await bootServer();
+    const res = fakeRes();
+    expect(() => boot.ordersHandler({} as any, res)).not.toThrow();
+    expect(res.body.orders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- **#777** — Added `docs/observability/metrics-catalog.md` tabling every metric in `shared/metrics.ts` and `shared/agent-queue.ts` (name, type, labels, meaning, dashboard/alert usage), plus default Node process metrics and a "known gaps" section (missing caller labels, gauge-only latency, unbounded `drug` label). Linked from `dashboard-guide.md`.
- **#782** — Added `docs/observability/slo.md` defining 5 SLIs (agent run success rate, Stellar tx success rate, payment settlement success rate, LLM error rate, agent availability) with numeric SLO targets, their Prometheus queries, error budgets, an error-budget policy (release-freeze rules), and an SLO-to-alert mapping.
- **#785** — Added `docs/observability/prometheus-retention.md` documenting the current local-only TSDB storage, the data-loss implication of `docker compose down -v` on the `prometheus-data` volume, and the remote-write/long-term-storage options considered. Raised `--storage.tsdb.retention.time` from `7d` to `35d` in `docker-compose.yml` so it actually covers the 30-day SLO windows from #782 with slack. Remote-write is documented as an accepted interim gap for the current single-host deployment.
- **#793** — Added an integration test (`services/pharmacy-payment/__tests__/mpp-order-restart.integration.test.ts`) that places an order via the live `POST /pharmacy/order` handler, simulates a full process restart (fresh module load via `vi.resetModules()`) against the same on-disk data directory, and asserts the order is readable via `GET /pharmacy/orders` afterward with its id/fields intact. Also covers a torn/partial `orders.json` not crashing boot. Verified the test actually catches a regression by temporarily reverting the `saveOrder()` call and confirming it fails.
Closes #777 
Closes #782 
Closes #785 
Closes #793 

## Test plan

- [x] `npx vitest run services/pharmacy-payment/` — 5 test files, 26 tests, all pass (includes the new integration test alongside existing unit tests)
- [x] Confirmed the new test fails when `saveOrder()` is removed (real regression coverage, not a tautology)
- [x] Docs cross-reference each other and the existing dashboard guide; no unresolved links to files that don't exist in this repo