### PR TITLE
Fix #780, #781, #786, #791: health-check docs, correlation-ID guide, SLO recording rules, /recipients integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Health checks are enabled on every service. Targets:
 
 Boot time on a warm Docker is ~30s (cold first build is much longer due to npm install). If the dashboard waits forever for `server: healthy`, check `docker compose logs server` — the most common cause is missing/invalid `OZ_FACILITATOR_API_KEY` or `AGENT_SECRET_KEY` in `.env`.
 
+See [docs/observability/health-checks.md](docs/observability/health-checks.md) for the `/health` and `/ready` response schemas and what each dependency check means.
+
 ---
 
 ## Running Tests

--- a/agent/__tests__/care-recipients.test.ts
+++ b/agent/__tests__/care-recipients.test.ts
@@ -40,7 +40,7 @@ describe("CareRecipientsStore", () => {
       insurance: "Medicare",
       caregiver_user_id: null,
     });
-    expect(created.id).toMatch(/^john_doe_\d+$/);
+    expect(created.id).toMatch(/^john_doe_\d+_[0-9a-f]{8}$/);
     expect(created.name).toBe("John Doe");
     expect(created.medications).toEqual(["Aspirin"]);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - "--storage.tsdb.retention.time=35d"
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./docker/prometheus/recording-rules.yml:/etc/prometheus/recording-rules.yml:ro
       - prometheus-data:/prometheus
     ports:
       - "9090:9090"

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 5s
   evaluation_interval: 5s
 
+rule_files:
+  - "recording-rules.yml"
+
 scrape_configs:
   # When running via docker compose, the server is reachable as `server` on
   # the shared bridge network. For host-only Prometheus (no compose), uncomment

--- a/docker/prometheus/recording-rules.yml
+++ b/docker/prometheus/recording-rules.yml
@@ -1,0 +1,141 @@
+# Recording rules pre-aggregating the SLIs defined in docs/observability/slo.md.
+#
+# Naming convention: careguard:<sli>:<kind>_rate<window>
+#   - <sli>   the SLI this series backs (agent_run, stellar_tx, x402_settlement, agent_llm)
+#   - <kind>  "success_ratio" (fraction good) or "error_ratio" (fraction bad, 1 - success_ratio)
+#   - <window> the rate() lookback the ratio was computed over
+#
+# Multi-window pairs follow the Google SRE workbook's multi-window, multi-burn-rate
+# approach: a short window (5m/1h) for fast detection, paired with a longer window
+# (6h/3d) that must also be breached before alerting, to avoid paging on noise.
+# The alert rules that pair these windows and apply burn-rate thresholds are a
+# follow-up (docker/prometheus/alert-rules.yml does not exist yet) — this file only
+# provides the pre-aggregated series so that follow-up (and Grafana panels) can query
+# stable, cheap-to-evaluate metrics instead of the raw counters directly.
+#
+# Validate with: promtool check rules docker/prometheus/recording-rules.yml
+
+groups:
+  - name: careguard-slo-agent-run
+    interval: 30s
+    rules:
+      - record: careguard:agent_run_success:ratio_rate5m
+        expr: |
+          sum(rate(agent_runs_total{status="success"}[5m]))
+          /
+          sum(rate(agent_runs_total[5m]))
+      - record: careguard:agent_run_error:ratio_rate5m
+        expr: 1 - careguard:agent_run_success:ratio_rate5m
+      - record: careguard:agent_run_success:ratio_rate1h
+        expr: |
+          sum(rate(agent_runs_total{status="success"}[1h]))
+          /
+          sum(rate(agent_runs_total[1h]))
+      - record: careguard:agent_run_error:ratio_rate1h
+        expr: 1 - careguard:agent_run_success:ratio_rate1h
+      - record: careguard:agent_run_success:ratio_rate6h
+        expr: |
+          sum(rate(agent_runs_total{status="success"}[6h]))
+          /
+          sum(rate(agent_runs_total[6h]))
+      - record: careguard:agent_run_error:ratio_rate6h
+        expr: 1 - careguard:agent_run_success:ratio_rate6h
+      - record: careguard:agent_run_success:ratio_rate3d
+        expr: |
+          sum(rate(agent_runs_total{status="success"}[3d]))
+          /
+          sum(rate(agent_runs_total[3d]))
+      - record: careguard:agent_run_error:ratio_rate3d
+        expr: 1 - careguard:agent_run_success:ratio_rate3d
+
+  - name: careguard-slo-stellar-tx
+    interval: 30s
+    rules:
+      - record: careguard:stellar_tx_success:ratio_rate5m
+        expr: |
+          sum(rate(stellar_tx_submitted_total{result="success"}[5m]))
+          /
+          sum(rate(stellar_tx_submitted_total[5m]))
+      - record: careguard:stellar_tx_error:ratio_rate5m
+        expr: 1 - careguard:stellar_tx_success:ratio_rate5m
+      - record: careguard:stellar_tx_success:ratio_rate1h
+        expr: |
+          sum(rate(stellar_tx_submitted_total{result="success"}[1h]))
+          /
+          sum(rate(stellar_tx_submitted_total[1h]))
+      - record: careguard:stellar_tx_error:ratio_rate1h
+        expr: 1 - careguard:stellar_tx_success:ratio_rate1h
+      - record: careguard:stellar_tx_success:ratio_rate6h
+        expr: |
+          sum(rate(stellar_tx_submitted_total{result="success"}[6h]))
+          /
+          sum(rate(stellar_tx_submitted_total[6h]))
+      - record: careguard:stellar_tx_error:ratio_rate6h
+        expr: 1 - careguard:stellar_tx_success:ratio_rate6h
+      - record: careguard:stellar_tx_success:ratio_rate3d
+        expr: |
+          sum(rate(stellar_tx_submitted_total{result="success"}[3d]))
+          /
+          sum(rate(stellar_tx_submitted_total[3d]))
+      - record: careguard:stellar_tx_error:ratio_rate3d
+        expr: 1 - careguard:stellar_tx_success:ratio_rate3d
+
+  - name: careguard-slo-x402-settlement
+    interval: 30s
+    rules:
+      - record: careguard:x402_settlement_success:ratio_rate5m
+        expr: |
+          sum(rate(x402_settlements_total[5m]))
+          /
+          (sum(rate(x402_settlements_total[5m])) + sum(rate(x402_tx_extraction_failed_total[5m])))
+      - record: careguard:x402_settlement_error:ratio_rate5m
+        expr: 1 - careguard:x402_settlement_success:ratio_rate5m
+      - record: careguard:x402_settlement_success:ratio_rate1h
+        expr: |
+          sum(rate(x402_settlements_total[1h]))
+          /
+          (sum(rate(x402_settlements_total[1h])) + sum(rate(x402_tx_extraction_failed_total[1h])))
+      - record: careguard:x402_settlement_error:ratio_rate1h
+        expr: 1 - careguard:x402_settlement_success:ratio_rate1h
+      - record: careguard:x402_settlement_success:ratio_rate6h
+        expr: |
+          sum(rate(x402_settlements_total[6h]))
+          /
+          (sum(rate(x402_settlements_total[6h])) + sum(rate(x402_tx_extraction_failed_total[6h])))
+      - record: careguard:x402_settlement_error:ratio_rate6h
+        expr: 1 - careguard:x402_settlement_success:ratio_rate6h
+      - record: careguard:x402_settlement_success:ratio_rate3d
+        expr: |
+          sum(rate(x402_settlements_total[3d]))
+          /
+          (sum(rate(x402_settlements_total[3d])) + sum(rate(x402_tx_extraction_failed_total[3d])))
+      - record: careguard:x402_settlement_error:ratio_rate3d
+        expr: 1 - careguard:x402_settlement_success:ratio_rate3d
+
+  - name: careguard-slo-agent-llm
+    interval: 30s
+    rules:
+      - record: careguard:agent_llm_error:ratio_rate5m
+        expr: |
+          sum(rate(agent_llm_error_total[5m]))
+          /
+          sum(rate(agent_runs_total[5m]))
+      - record: careguard:agent_llm_error:ratio_rate1h
+        expr: |
+          sum(rate(agent_llm_error_total[1h]))
+          /
+          sum(rate(agent_runs_total[1h]))
+      - record: careguard:agent_llm_error:ratio_rate6h
+        expr: |
+          sum(rate(agent_llm_error_total[6h]))
+          /
+          sum(rate(agent_runs_total[6h]))
+      - record: careguard:agent_llm_error:ratio_rate3d
+        expr: |
+          sum(rate(agent_llm_error_total[3d]))
+          /
+          sum(rate(agent_runs_total[3d]))
+
+  # Agent availability (agent_queue_depth / agent_waiting_jobs) is gauge-based, not
+  # a counter ratio, so the rate()-based burn-rate pattern above doesn't apply the
+  # same way. Not recorded here — see docs/observability/slo.md.

--- a/docs/observability/correlation-ids.md
+++ b/docs/observability/correlation-ids.md
@@ -1,0 +1,90 @@
+# Correlation and Trace-ID Guide
+
+How `requestId` and `agentRunId` are generated, propagated, and used to trace a single
+agent run end-to-end across logs.
+
+## The two IDs
+
+| ID | Generated where | Lifetime | Purpose |
+|---|---|---|---|
+| `requestId` | [`shared/request-context.ts`](../../shared/request-context.ts)'s `requestContextMiddleware()` — one per inbound HTTP request | One HTTP request/response cycle | Correlates every log line produced while handling a single request |
+| `agentRunId` | [`agent/runner.ts`](../../agent/runner.ts) (`runId = \`run-${getRequestId() ?? Date.now()}\``), set via `setAgentRunId()` | One agent run (may span multiple tool calls, LLM round-trips, and outbound payment calls) | Correlates every log line produced by one agent invocation, even though it started from a `requestId`-scoped request |
+
+`agentRunId` derives from `requestId` when available (falling back to `Date.now()` only
+if no request context exists, e.g. a script invoking the agent directly outside HTTP).
+So a given agent run's `agentRunId` looks like `run-<requestId>`, making it easy to
+recover the originating request from the run id alone.
+
+## Propagation: AsyncLocalStorage → pino
+
+1. `requestContextMiddleware()` (mounted early in both `server.ts` and `agent/server.ts`)
+   reads an inbound `X-Request-ID` header if present, otherwise generates a UUID via
+   `randomUUID()`. It calls `als.run({ requestId: id }, () => next())`, so every
+   synchronous and awaited-async call made for the rest of that request's lifetime
+   runs inside this `AsyncLocalStorage` context.
+2. It also echoes the id back as an `X-Request-ID` response header — the client always
+   knows the id used, even if it didn't send one.
+3. `runAgent()` in `agent/runner.ts` calls `setAgentRunId(runId)`, which writes into
+   the *same* ALS context (`getAgentRunId`/`setAgentRunId` both read/write the current
+   store) — it does not open a new context, so `requestId` stays available alongside
+   `agentRunId` for the rest of the run.
+4. `shared/logger.ts`'s pino instance uses a `mixin()` callback that calls
+   `getRequestId()`/`getAgentRunId()` on **every** log call and merges whatever is
+   currently in the ALS context into that line's fields. This is why you don't see
+   either id threaded explicitly through most logger calls in the codebase — it's
+   injected automatically as long as the call happens inside the ALS run scope.
+5. `shared/request-logger.ts` logs one structured summary line per HTTP request on
+   `res.on("finish")`, which (via the same mixin) also carries `requestId` /
+   `agentRunId`.
+
+## Where the chain currently breaks
+
+- **Outbound HTTP calls made by agent tools are not correlated.** `agent/tools.ts`
+  makes plain `fetch()` calls (e.g. line ~1260 for pharmacy pricing, and the MPP
+  client's `.fetch()` around line ~1667 for medication payments) without attaching
+  `X-Request-ID` or any run-id header. If you're debugging a specific agent run against
+  a downstream service's own logs (the pharmacy-payment service, an x402 facilitator),
+  there is currently no shared id to `grep` for on both sides — you have to correlate
+  by timestamp instead.
+- **Any code path that escapes the ALS run scope loses both ids silently.** Anything
+  that runs outside the request's async chain — a truly detached background job, a
+  callback registered before `als.run()` started but invoked after, a separate
+  process — will not have `requestId`/`agentRunId` in the ALS store, and the mixin
+  simply omits those fields rather than erroring. Logs from those paths are still
+  valid, just uncorrelated.
+- **`/health` and `/ready`** (see [health-checks.md](./health-checks.md)) are
+  intentionally lightweight probe endpoints; nothing about their handling is unusual
+  here, but don't expect to find `requestId` on their own request-logger line's fields
+  to mean anything beyond "this specific probe call."
+
+## Tracing one agent run end-to-end
+
+1. Get the `agentRunId` from wherever you first observe the run — the agent's HTTP
+   response (if the endpoint returns it), or the `X-Request-ID` response header from
+   the originating request combined with the `run-<requestId>` format.
+2. Search logs for that `agentRunId` value. Every line from `runAgent()`'s tool-call
+   loop, LLM calls, and spending/policy checks carries it via the pino mixin.
+3. To see the full HTTP request that triggered the run (headers, status, duration),
+   search for the same value as `requestId` instead — the `run-` prefix strips off,
+   so `agentRunId = "run-abc123"` corresponds to `requestId = "abc123"`.
+4. For payment/Stellar calls made during the run, cross-reference by timestamp against
+   the `agentRunId`-tagged lines immediately preceding them — see "where the chain
+   currently breaks" above for why this is timestamp-based rather than id-based today.
+
+## Headers to propagate
+
+- **Inbound:** if a caller already has a `requestId` for a logical operation (e.g. a
+  retry, or a request forwarded from another CareGuard service), send it as
+  `X-Request-ID` — `requestContextMiddleware()` will use it instead of generating a
+  new one, letting you correlate across service boundaries.
+- **Outbound (gap):** CareGuard's own outbound calls (pharmacy pricing lookups, MPP
+  payment requests) do not currently send `X-Request-ID` downstream. Closing this gap
+  would mean threading `getRequestId()` into the `fetch()`/`mppClient.fetch()` calls in
+  `agent/tools.ts` as an `X-Request-ID` header — tracked as a follow-up, not done here.
+
+## Related
+
+- [Logging schema](./logging-schema.md) — full log line shapes and examples, including
+  `requestId`/`agentRunId` fields in context
+- [Health checks](./health-checks.md) — the probe endpoints that intentionally sit
+  outside most of this correlation model

--- a/docs/observability/health-checks.md
+++ b/docs/observability/health-checks.md
@@ -1,0 +1,83 @@
+# Health-Check and Readiness Response Schema
+
+CareGuard's unified server (`server.ts`) exposes two probe endpoints with different
+purposes. This doc defines their response shapes, what "degraded" means, and which
+infra consumes each one.
+
+## Liveness — `GET /health`
+
+Answers "is the process up and able to handle HTTP at all?" No I/O, no dependency
+checks — always fast.
+
+```json
+{ "status": "ok" }
+```
+
+- **Status codes:** always `200` as long as the process can respond at all. If the
+  event loop is fully blocked or the process is dead, the request itself times out —
+  there is no "unhealthy" body, because a live process always reports `ok`.
+- **Use for:** container/process restarts (crash-loop detection). Do not use this to
+  gate traffic — a live-but-degraded instance still returns `200` here.
+
+## Readiness — `GET /ready`
+
+Answers "can this instance actually serve requests right now?" Checks dependencies
+and can legitimately return a non-200 while the process itself is healthy.
+
+```json
+{
+  "status": "ok" | "degraded",
+  "checks": {
+    "env": true | "missing: LLM_API_KEY, ...",
+    "horizon": true | false,
+    "ozFacilitator": true | "not yet verified"
+  }
+}
+```
+
+- **Status codes:**
+  - `200` — all checks passed (`status: "ok"`).
+  - `503` — draining (server is mid-shutdown, `isDraining` flag set) or any check
+    failed (`status: "degraded"`).
+- **Degraded representation:** `status` flips to `"degraded"` and the `checks` object
+  shows exactly which dependency failed. A check value is either `true` (passed) or a
+  falsy/string value describing why it failed — e.g. `"missing: LLM_API_KEY"` for env,
+  `false` for a failed Horizon ping.
+
+### Dependency checks
+
+| Check | What it verifies | Failure mode |
+|---|---|---|
+| `env` | Required secrets (`LLM_API_KEY`, `AGENT_SECRET_KEY`, `MPP_SECRET_KEY`, `CAREGIVER_TOKEN`) are present in `process.env` | Missing env in a fresh deploy — surfaces immediately instead of failing on first real request |
+| `horizon` | A 1.5s-timeout `fetch` to `https://horizon-testnet.stellar.org` succeeds (2xx or any non-5xx) | Stellar testnet Horizon is unreachable or overloaded |
+| `ozFacilitator` | The x402 middleware has successfully verified a payment against the OZ facilitator at least once, *or* `OZ_FACILITATOR_API_KEY` isn't configured (in which case this check is trivially `true`) | Facilitator unreachable — this check can stay `"not yet verified"` indefinitely on an instance that has never processed a paid request, which does not by itself mean the facilitator is down |
+
+**Important caveat:** the Horizon check is hardcoded to
+`https://horizon-testnet.stellar.org` regardless of the configured `NETWORK`. On any
+deployment actually meant to run against mainnet, this check verifies the wrong
+network's availability — a testnet outage would mark a mainnet-serving instance
+"degraded" for the wrong reason, and a testnet-only outage on the *real* dependency
+wouldn't be caught if the app were pointed elsewhere. This is a known gap, not
+something this doc's existence fixes.
+
+## Probe → consumer mapping
+
+Per the [README health-check table](../../README.md):
+
+| Consumer | Probe used | Notes |
+|---|---|---|
+| Docker Compose (`server` service healthcheck) | `GET /` (`docker-compose.yml`, checks `statusCode === 200`) | Checks the root info endpoint responds — not `/health` or `/ready` specifically |
+| Render health check | `GET /health` (`render.yaml`: `healthCheckPath: /health`) | Liveness only — Render restarts the instance on repeated failures, but this does **not** check Horizon/env/facilitator, so a "healthy" Render instance can still be dependency-degraded |
+| Manual/operator checks | `GET /ready` | The right endpoint to check *before* routing traffic to a newly deployed instance — neither `GET /` nor `GET /health` checks dependencies |
+
+If you're wiring up a new consumer (a load balancer, an orchestrator) that needs to
+gate traffic on real readiness rather than "process is up," point it at `/ready`, not
+`/` or `/health`.
+
+## Related
+
+- [Correlation IDs](./correlation-ids.md) — `requestId`/`agentRunId` are not present on
+  health/readiness responses; they're unauthenticated, high-frequency probe endpoints
+  and intentionally excluded from the request-context/logging pipeline that the rest
+  of the API uses.
+- [Render deployment](../deployment/render.md) — build/runtime pipeline these probes run against.

--- a/docs/observability/logging-schema.md
+++ b/docs/observability/logging-schema.md
@@ -167,4 +167,5 @@ See [docs/SECURITY.md](../SECURITY.md) for details on log tampering detection an
 ## Related
 
 - [Grafana dashboard guide](./dashboard-guide.md) — metrics and panels
+- [Correlation and trace-ID guide](./correlation-ids.md) — how requestId/agentRunId propagate and how to trace one agent run end-to-end
 - [Correlation ID design](../adr/002-pii-in-persistence.md) — PII and request tracing decisions

--- a/docs/observability/slo.md
+++ b/docs/observability/slo.md
@@ -54,6 +54,11 @@ window before the SLO is breached.
 Alert rule definitions live alongside the Prometheus config in `docker/prometheus/`;
 this doc is the source of truth for the *targets* those rules should enforce.
 
+Pre-aggregated series for these SLIs (success/error ratios at 5m/1h/6h/3d windows,
+so dashboards and alerts don't recompute the raw counters on every query) are defined
+in [`docker/prometheus/recording-rules.yml`](../../docker/prometheus/recording-rules.yml),
+following the `careguard:<sli>:<kind>_rate<window>` naming convention.
+
 ## Retention
 
 Error-budget history needs to persist at least as long as the longest SLO window above

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -27,7 +27,68 @@ components:
           type: 'string'
         details:
           type: 'object'
+    ReadinessResponse:
+      type: 'object'
+      description: 'See docs/observability/health-checks.md for the full schema and check semantics.'
+      properties:
+        status:
+          type: 'string'
+          enum:
+            - 'ok'
+            - 'degraded'
+        checks:
+          type: 'object'
+          properties:
+            env:
+              oneOf:
+                - type: 'boolean'
+                - type: 'string'
+            horizon:
+              type: 'boolean'
+            ozFacilitator:
+              oneOf:
+                - type: 'boolean'
+                - type: 'string'
 paths:
+  /health:
+    get:
+      summary: 'Liveness probe — always fast, no dependency checks'
+      tags:
+        - 'Observability'
+      security:
+[]
+      responses:
+        200:
+          description: 'Process is up'
+          content:
+            application/json:
+              schema:
+                type: 'object'
+                properties:
+                  status:
+                    type: 'string'
+                    enum:
+                      - 'ok'
+  /ready:
+    get:
+      summary: 'Readiness probe — checks required env, Horizon, and OZ facilitator status'
+      tags:
+        - 'Observability'
+      security:
+[]
+      responses:
+        200:
+          description: 'All dependency checks passed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadinessResponse'
+        503:
+          description: 'Draining, or at least one dependency check failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadinessResponse'
   /agent/spending:
     get:
       summary: 'Get agent spending summary'

--- a/scripts/gen-openapi.ts
+++ b/scripts/gen-openapi.ts
@@ -124,9 +124,72 @@ function generateSpec(): OpenAPISpec {
             details: { type: "object" },
           },
         },
+        ReadinessResponse: {
+          type: "object",
+          description:
+            "See docs/observability/health-checks.md for the full schema and check semantics.",
+          properties: {
+            status: { type: "string", enum: ["ok", "degraded"] },
+            checks: {
+              type: "object",
+              properties: {
+                env: { oneOf: [{ type: "boolean" }, { type: "string" }] },
+                horizon: { type: "boolean" },
+                ozFacilitator: { oneOf: [{ type: "boolean" }, { type: "string" }] },
+              },
+            },
+          },
+        },
       },
     },
     paths: {
+      "/health": {
+        get: {
+          summary: "Liveness probe — always fast, no dependency checks",
+          tags: ["Observability"],
+          security: [],
+          responses: {
+            "200": {
+              description: "Process is up",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: { type: "string", enum: ["ok"] },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/ready": {
+        get: {
+          summary: "Readiness probe — checks required env, Horizon, and OZ facilitator status",
+          tags: ["Observability"],
+          security: [],
+          responses: {
+            "200": {
+              description: "All dependency checks passed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ReadinessResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "Draining, or at least one dependency check failed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ReadinessResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/agent/spending": {
         get: {
           summary: "Get agent spending summary",

--- a/server.ts
+++ b/server.ts
@@ -76,7 +76,7 @@ import { resolveRequestedDosage } from "./services/pharmacy-api/dosage.ts";
 import { createPharmacyPricingStore } from "./services/pharmacy-api/db.ts";
 import { PRICING_DATABASE, getAvailableDrugs } from "./shared/pharmacy-pricing.ts";
 import { createCareRecipientsStore } from "./services/care-recipients/db.ts";
-import type { CareRecipient } from "./services/care-recipients/db.ts";
+import { createCareRecipientsRouter } from "./services/care-recipients/routes.ts";
 import {
   buildCompareResponse,
   DrugRecordSchema,
@@ -211,47 +211,6 @@ let _profileData = {
 // --- Express App ---
 const app: Express = express();
 let isDraining = false;
-
-function parseCookies(cookieHeader: string | undefined): Record<string, string> {
-  const list: Record<string, string> = {};
-  if (!cookieHeader) return list;
-  cookieHeader.split(";").forEach((cookie) => {
-    const parts = cookie.split("=");
-    list[parts.shift()!.trim()] = decodeURIComponent(parts.join("="));
-  });
-  return list;
-}
-
-function requireCaregiverToken(req: express.Request, res: express.Response, next: express.NextFunction) {
-  const auth = req.headers.authorization;
-  let token: string | undefined;
-
-  if (auth?.startsWith("Bearer ")) {
-    token = auth.slice("Bearer ".length);
-  } else {
-    const cookies = parseCookies(req.headers.cookie);
-    token = cookies["caregiver_token"];
-    
-    if (token) {
-      const csrfHeader = req.headers["x-csrf-token"];
-      const csrfCookie = cookies["csrf_token"];
-      if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie) {
-        res.status(403).json({ error: "CSRF token mismatch or missing" });
-        return;
-      }
-    }
-  }
-
-  if (!token) {
-    res.status(401).setHeader("WWW-Authenticate", "Bearer").json({ error: "Missing caregiver token" });
-    return;
-  }
-  if (token !== CAREGIVER_TOKEN) {
-    res.status(403).json({ error: "Invalid caregiver token" });
-    return;
-  }
-  next();
-}
 
 app.use("/agent", rateLimiters.agent);
 app.use("/health", rateLimiters.health);
@@ -984,26 +943,7 @@ app.post("/pharmacy/order", perRouteLimiters.pharmacyOrder, concurrentRequestsMi
 // CARE RECIPIENTS API
 // ============================================================
 
-app.get("/recipients", requireCaregiverToken, (_req, res) => {
-  res.json(recipientsStore.list());
-});
-
-app.post("/recipients", requireCaregiverToken, (req, res) => {
-  const body = req.body as Partial<CareRecipient>;
-  if (!body?.name || typeof body.name !== 'string' || !body.name.trim()) {
-    res.status(400).json({ error: 'name is required' });
-    return;
-  }
-  const created = recipientsStore.create({
-    name: body.name.trim(),
-    age: typeof body.age === 'number' ? body.age : null,
-    medications: Array.isArray(body.medications) ? body.medications : [],
-    primary_doctor: typeof body.primary_doctor === 'string' ? body.primary_doctor : null,
-    insurance: typeof body.insurance === 'string' ? body.insurance : null,
-    caregiver_user_id: null,
-  });
-  res.status(201).json(created);
-});
+app.use(createCareRecipientsRouter(recipientsStore, CAREGIVER_TOKEN));
 
 // ============================================================
 // AI AGENT

--- a/services/care-recipients/__tests__/routes.integration.test.ts
+++ b/services/care-recipients/__tests__/routes.integration.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { CareRecipientsStore } from "../db.ts";
+import { createCareRecipientsRouter } from "../routes.ts";
+
+/**
+ * Integration test (Issue #791): exercises the real /recipients GET/POST
+ * routes mounted on server.ts (via createCareRecipientsRouter, extracted
+ * from server.ts so it's testable without booting the full unified server —
+ * that server also wires up Sentry, Stellar, the LLM client, and the agent
+ * runtime, none of which /recipients depends on) against a real, isolated
+ * CareRecipientsStore.
+ */
+
+const CAREGIVER_TOKEN = "test-caregiver-token";
+
+function makeApp() {
+  const store = new CareRecipientsStore(":memory:"); // isolated per test, never touches data/careguard.sqlite
+  const app = express();
+  app.use(express.json());
+  app.use(createCareRecipientsRouter(store, CAREGIVER_TOKEN));
+  return { app, store };
+}
+
+describe("/recipients routes (Issue #791)", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    ({ app } = makeApp());
+  });
+
+  it("rejects requests with no caregiver token", async () => {
+    const res = await request(app).get("/recipients");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests with an invalid caregiver token", async () => {
+    const res = await request(app)
+      .get("/recipients")
+      .set("Authorization", "Bearer wrong-token");
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /recipients creates a recipient and GET /recipients lists it back", async () => {
+    const createRes = await request(app)
+      .post("/recipients")
+      .set("Authorization", `Bearer ${CAREGIVER_TOKEN}`)
+      .send({ name: "John Doe", age: 65, medications: ["Aspirin"], primary_doctor: "Dr. Smith", insurance: "Medicare" });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.name).toBe("John Doe");
+    expect(createRes.body.id).toMatch(/^john_doe_\d+_[0-9a-f]{8}$/);
+
+    const listRes = await request(app)
+      .get("/recipients")
+      .set("Authorization", `Bearer ${CAREGIVER_TOKEN}`);
+
+    expect(listRes.status).toBe(200);
+    const created = listRes.body.find((r: any) => r.id === createRes.body.id);
+    expect(created).toBeDefined();
+    expect(created.name).toBe("John Doe");
+    expect(created.medications).toEqual(["Aspirin"]);
+    expect(created.primary_doctor).toBe("Dr. Smith");
+  });
+
+  it("rejects a malformed payload (missing name) with a structured 400", async () => {
+    const res = await request(app)
+      .post("/recipients")
+      .set("Authorization", `Bearer ${CAREGIVER_TOKEN}`)
+      .send({ age: 40 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("name is required");
+  });
+
+  it("rejects a blank name with a structured 400", async () => {
+    const res = await request(app)
+      .post("/recipients")
+      .set("Authorization", `Bearer ${CAREGIVER_TOKEN}`)
+      .send({ name: "   " });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("concurrent creates with the same name each get a distinct, persisted id", async () => {
+    const requests = Array.from({ length: 5 }, () =>
+      request(app)
+        .post("/recipients")
+        .set("Authorization", `Bearer ${CAREGIVER_TOKEN}`)
+        .send({ name: "Concurrent Person" }),
+    );
+
+    const results = await Promise.all(requests);
+    for (const res of results) {
+      expect(res.status).toBe(201);
+    }
+
+    const ids = results.map((r) => r.body.id);
+    expect(new Set(ids).size).toBe(ids.length); // no id collisions
+
+    const listRes = await request(app)
+      .get("/recipients")
+      .set("Authorization", `Bearer ${CAREGIVER_TOKEN}`);
+    const persisted = listRes.body.filter((r: any) => r.name === "Concurrent Person");
+    expect(persisted).toHaveLength(5); // every create landed, none overwrote another
+  });
+});

--- a/services/care-recipients/db.ts
+++ b/services/care-recipients/db.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from 'fs';
 import { createRequire } from 'module';
+import { randomUUID } from 'crypto';
 import path from 'path';
 import { logger } from '../../shared/logger.ts';
 
@@ -117,8 +118,11 @@ export class CareRecipientsStore {
   }
 
   create(input: Omit<CareRecipient, 'id'>): CareRecipient {
+    // Date.now() alone collides under concurrent creates of the same name within
+    // the same millisecond (duplicate PRIMARY KEY -> insert throws); a short
+    // random suffix keeps ids readable while guaranteeing uniqueness.
     const base = input.name.toLowerCase().replace(/\s+/g, '_');
-    const id = `${base}_${Date.now()}`;
+    const id = `${base}_${Date.now()}_${randomUUID().slice(0, 8)}`;
     this.db.prepare(`
       INSERT INTO care_recipients (id, name, age, medications, primary_doctor, insurance, caregiver_user_id)
       VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/services/care-recipients/routes.ts
+++ b/services/care-recipients/routes.ts
@@ -1,0 +1,78 @@
+import { Router, type Request, type Response, type NextFunction } from "express";
+import type { CareRecipientsStore, CareRecipient } from "./db.ts";
+
+function parseCookies(cookieHeader: string | undefined): Record<string, string> {
+  const list: Record<string, string> = {};
+  if (!cookieHeader) return list;
+  cookieHeader.split(";").forEach((cookie) => {
+    const parts = cookie.split("=");
+    list[parts.shift()!.trim()] = decodeURIComponent(parts.join("="));
+  });
+  return list;
+}
+
+export function requireCaregiverToken(caregiverToken: string) {
+  return function (req: Request, res: Response, next: NextFunction) {
+    const auth = req.headers.authorization;
+    let token: string | undefined;
+
+    if (auth?.startsWith("Bearer ")) {
+      token = auth.slice("Bearer ".length);
+    } else {
+      const cookies = parseCookies(req.headers.cookie);
+      token = cookies["caregiver_token"];
+
+      if (token) {
+        const csrfHeader = req.headers["x-csrf-token"];
+        const csrfCookie = cookies["csrf_token"];
+        if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie) {
+          res.status(403).json({ error: "CSRF token mismatch or missing" });
+          return;
+        }
+      }
+    }
+
+    if (!token) {
+      res.status(401).setHeader("WWW-Authenticate", "Bearer").json({ error: "Missing caregiver token" });
+      return;
+    }
+    if (token !== caregiverToken) {
+      res.status(403).json({ error: "Invalid caregiver token" });
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Care recipients CRUD routes, extracted from server.ts (Issue #791) so they
+ * can be exercised via supertest against a real CareRecipientsStore without
+ * booting the full unified server (Sentry/Stellar/LLM/agent runtime).
+ */
+export function createCareRecipientsRouter(store: CareRecipientsStore, caregiverToken: string): Router {
+  const router = Router();
+  const auth = requireCaregiverToken(caregiverToken);
+
+  router.get("/recipients", auth, (_req, res) => {
+    res.json(store.list());
+  });
+
+  router.post("/recipients", auth, (req, res) => {
+    const body = req.body as Partial<CareRecipient>;
+    if (!body?.name || typeof body.name !== "string" || !body.name.trim()) {
+      res.status(400).json({ error: "name is required" });
+      return;
+    }
+    const created = store.create({
+      name: body.name.trim(),
+      age: typeof body.age === "number" ? body.age : null,
+      medications: Array.isArray(body.medications) ? body.medications : [],
+      primary_doctor: typeof body.primary_doctor === "string" ? body.primary_doctor : null,
+      insurance: typeof body.insurance === "string" ? body.insurance : null,
+      caregiver_user_id: null,
+    });
+    res.status(201).json(created);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
Closes #780 
Closes #781 
Closes #786 
Closes #791 

- **#780** — Added `docs/observability/health-checks.md` documenting the `/health` (liveness) and `/ready` (readiness) response shapes, what each dependency check (`env`, `horizon`, `ozFacilitator`) means, and a flagged caveat that the Horizon check is hardcoded to testnet regardless of configured network. Documents which infra consumes which probe (Compose healthcheck uses `GET /`, Render uses `GET /health`, `GET /ready` is the one to use before routing real traffic). Added `/health` and `/ready` to the OpenAPI spec (via `scripts/gen-openapi.ts`, then regenerated `docs/openapi.yml`) and linked from the README.
- **#781** — Added `docs/observability/correlation-ids.md` explaining `requestId`/`agentRunId` generation and propagation through `AsyncLocalStorage` into pino logs, how to trace one agent run end-to-end, and where the chain currently breaks (outbound pharmacy/MPP `fetch()` calls in `agent/tools.ts` don't propagate `X-Request-ID` downstream — documented as a known gap, not fixed here). Linked from `logging-schema.md`.
- **#786** — Added `docker/prometheus/recording-rules.yml` pre-aggregating the 4 counter-based SLIs from `slo.md` (agent run, Stellar tx, x402 settlement, agent LLM error) as success/error ratios at 5m/1h/6h/3d windows, following a `careguard:<sli>:<kind>_rate<window>` naming convention (multi-window per the SRE workbook's multi-burn-rate approach). Wired into `prometheus.yml` via `rule_files` and mounted in `docker-compose.yml`. `promtool` wasn't available locally to run `promtool check rules`, so I validated the YAML structurally instead — please run `promtool check rules docker/prometheus/recording-rules.yml` in CI/locally if available.
- **#791** — Extracted the `/recipients` GET/POST routes and caregiver-token auth middleware out of `server.ts` into `services/care-recipients/routes.ts` (`createCareRecipientsRouter`), so they're testable via `supertest` against a real, isolated `CareRecipientsStore` without booting the full unified server (Sentry/Stellar/LLM/agent runtime — none of which `/recipients` depends on). Added tests for the create→list round trip, auth rejection (401/403), malformed-payload 400s, and concurrent creates.

  **While writing the concurrency test, found a real bug:** concurrent `POST /recipients` with the same name in the same millisecond collide on `id` (`id = name + Date.now()`), causing a duplicate-PRIMARY-KEY insert failure and a 500. Fixed in `services/care-recipients/db.ts` by appending a short random suffix to the generated id. Updated the existing id-format assertion in `agent/__tests__/care-recipients.test.ts` to match.

  **Note on scope:** the issue's description says `agent/server.ts`'s `PUT /agent/recipients/:recipientId` is "backed by CareRecipientsStore" — it isn't; it's a separate in-memory `recipientProfiles` dict that auto-provisions unknown ids rather than rejecting them with 404. I did not change that behavior (unrelated system, and changing its upsert semantics without a dedicated ticket felt out of scope for a test-coverage issue) — the tests here cover the real CareRecipientsStore-backed `/recipients` API in `server.ts` instead.

## Test plan

- [x] `npx vitest run services/care-recipients/ agent/__tests__/care-recipients.test.ts` — 12 tests pass, including the new integration suite
- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors in any touched file
- [x] `npm run gen-openapi` — regenerates cleanly, valid YAML
- [x] Ran the full `vitest run` suite before and after this branch's changes (via `git stash`) — same 102 pre-existing failures both times (dashboard/unrelated agent tests, environment-dependent), confirming this branch introduces no regressions