### PR TITLE
Fix #789, #790, #798, #800: drug-interaction & pharmacy-payment HTTP tests, fee edge cases, bill-audit load test

### DIFF
--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,6 +1,12 @@
 # Load Testing
 
-This document covers the load test for concurrent `/agent/run` requests (Issue #55).
+This document covers the load tests in `load/`:
+- `load/agent-run.js` — concurrent `/agent/run` requests (Issue #55)
+- `load/bill-audit.js` — ramping-VU load on `POST /bill/audit` (Issue #800)
+
+## `load/agent-run.js`
+
+This test covers concurrent `/agent/run` requests (Issue #55).
 
 ## Goal
 
@@ -52,10 +58,6 @@ After all runs complete, the script fetches `/agent/spending` and compares:
 
 A mismatch indicates a lost write or double-count from a race condition.
 
-## CI
-
-This test is **not** included in the default CI pipeline — it is slow and requires a running server. Run it manually before releases or when changing `agent/tools.ts` state management.
-
 ## Interpreting results
 
 ```
@@ -71,3 +73,47 @@ p95 duration: 1234ms
 ```
 
 If you see a mismatch, the module-level `spendingTracker` object has a race. The fix is to move state into a per-request context or use atomic file writes with a lock.
+
+## `load/bill-audit.js`
+
+Ramps virtual users against `POST /bill/audit` (`services/bill-audit-api/server.ts`),
+since audit work is CPU-bound on line-item count — `auditBill()` loops over every
+line item doing rate lookups and duplicate detection.
+
+### Prerequisites
+
+1. k6 installed.
+2. **`POST /bill/audit` is x402-payment-protected.** This script does not perform a
+   real Stellar payment, so against a server with a live `OZ_FACILITATOR_API_KEY` it
+   will get 402/500 responses instead of exercising the audit computation — the same
+   as an unauthenticated `curl` request would. There is currently no in-repo mock
+   facilitator (unlike `agent-run.js`'s mocked-LLM prerequisite, which is a config
+   flag away), so to load test the actual audit path you need a facilitator/network
+   setup that accepts test payments. The script still enforces its thresholds either
+   way (no 5xx, latency budget) — a 402 is treated as an expected "payment gate is on"
+   response, not a failure.
+
+### Running
+
+```bash
+pnpm load:bill-audit
+# or:
+k6 run load/bill-audit.js
+BASE_URL=https://your-app.onrender.com k6 run load/bill-audit.js
+```
+
+### What it checks
+
+| Scenario | What it does | Thresholds |
+|---|---|---|
+| `ramping_audits` | Ramps 1→10→30→0 VUs over 2 minutes, each posting a realistic 10-line-item bill (mirrors `GET /bill/sample`, including one intentional duplicate CPT code) | `errors_5xx == 0`, `bill_audit_duration_ms` p95 `< 2000ms`, `success_rate > 0.99` |
+| `large_lineitems` | 3 constant VUs for 1 minute alternating between a 480-item bill (under the `BILL_AUDIT_MAX_ITEMS=500` default) and a 600-item bill (over it) | Large-but-valid bills get 200/402 (never 5xx or a timeout); oversized bills get a bounded 400 |
+
+A custom `audit_findings_total` counter sums `errorCount` from every `200` response,
+to confirm audit work was actually performed under load rather than short-circuiting.
+
+## CI (both scripts)
+
+Neither load test is included in the default CI pipeline — both are slow and require
+a running server. Run them manually before releases or when changing
+`agent/tools.ts` state management or `services/bill-audit-api/server.ts`'s audit logic.

--- a/load/bill-audit.js
+++ b/load/bill-audit.js
@@ -1,0 +1,193 @@
+/**
+ * k6 load test — POST /bill/audit under ramping load (Issue #800)
+ *
+ * Bill audit work is CPU-bound on line-item count (services/bill-audit-api/server.ts's
+ * auditBill() loops over every line item doing rate lookups and duplicate detection),
+ * so this specifically ramps VUs against realistic multi-line-item bills rather than
+ * reusing load/agent-run.js's single-request pattern.
+ *
+ * Usage:
+ *   pnpm load:bill-audit
+ *   # or directly:
+ *   k6 run load/bill-audit.js
+ *   BASE_URL=https://your-app.onrender.com k6 run load/bill-audit.js
+ *
+ * Requires: k6 installed (https://k6.io/docs/getting-started/installation/)
+ *
+ * IMPORTANT — x402 payment gate: POST /bill/audit is x402-payment-protected
+ * (applyX402Middleware in server.ts). This script does not perform a real Stellar
+ * payment, so it will get 402/500 responses against a server with a live
+ * OZ_FACILITATOR_API_KEY configured, the same way an unauthenticated curl request
+ * would. To load test the actual audit computation path, run the target server
+ * against a facilitator/network configuration that accepts test payments (a sandbox
+ * facilitator or a testnet-funded flow), matching the "mocked LLM" prerequisite
+ * documented for load/agent-run.js in docs/load-testing.md — there is currently no
+ * in-repo mock facilitator, so this is an environment setup step, not something this
+ * script can do on its own.
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+
+// --- Metrics ---
+const errors5xx = new Counter("errors_5xx");
+const successRate = new Rate("success_rate");
+const auditDuration = new Trend("bill_audit_duration_ms", true);
+const auditFindingsTotal = new Counter("audit_findings_total");
+
+// --- Config ---
+export const options = {
+  scenarios: {
+    ramping_audits: {
+      executor: "ramping-vus",
+      startVUs: 1,
+      stages: [
+        { duration: "30s", target: 10 },
+        { duration: "1m", target: 30 },
+        { duration: "30s", target: 0 },
+      ],
+      exec: "auditRealisticBill",
+    },
+    large_lineitems: {
+      executor: "constant-vus",
+      vus: 3,
+      duration: "1m",
+      exec: "auditLargeBill",
+      startTime: "30s", // overlap with the ramp-up, not the cooldown
+    },
+  },
+  thresholds: {
+    errors_5xx: ["count==0"],
+    bill_audit_duration_ms: ["p(95)<2000"],
+    success_rate: ["rate>0.99"],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3002";
+
+// A representative 10-line-item bill (mirrors GET /bill/sample), including one
+// intentional duplicate CPT code so audits always find at least one real issue.
+const REALISTIC_BILL = {
+  lineItems: [
+    { description: "Hospital care, high complexity", cptCode: "99233", quantity: 3, chargedAmount: 630 },
+    { description: "Comprehensive metabolic panel", cptCode: "80053", quantity: 1, chargedAmount: 95 },
+    { description: "Complete blood count (CBC)", cptCode: "85025", quantity: 1, chargedAmount: 45 },
+    { description: "Complete blood count (CBC)", cptCode: "85025", quantity: 1, chargedAmount: 45 },
+    { description: "Venipuncture (blood draw)", cptCode: "36415", quantity: 1, chargedAmount: 10 },
+    { description: "Chest X-ray, 2 views", cptCode: "71046", quantity: 1, chargedAmount: 180 },
+    { description: "Electrocardiogram (ECG)", cptCode: "93000", quantity: 1, chargedAmount: 35 },
+    { description: "Office visit, complex", cptCode: "99215", quantity: 1, chargedAmount: 1250 },
+    { description: "Hospital discharge day", cptCode: "99238", quantity: 1, chargedAmount: 160 },
+    { description: "Injection, subcutaneous", cptCode: "96372", quantity: 2, chargedAmount: 50 },
+  ],
+};
+
+// A large bill near the server's BILL_AUDIT_MAX_ITEMS default (500) — used by the
+// large_lineitems scenario to verify the endpoint either audits it within budget or
+// returns the bounded 400 rejection, never a 5xx or an unbounded hang.
+const CPT_POOL = ["99233", "80053", "85025", "36415", "71046", "93000", "99215", "99238", "96372", "71045"];
+function buildLargeBill(count) {
+  const lineItems = [];
+  for (let i = 0; i < count; i++) {
+    lineItems.push({
+      description: `Line item ${i}`,
+      cptCode: CPT_POOL[i % CPT_POOL.length],
+      quantity: 1,
+      chargedAmount: 50 + (i % 200),
+    });
+  }
+  return { lineItems };
+}
+const LARGE_BILL = buildLargeBill(480); // under the 500 default cap
+const OVERSIZED_BILL = buildLargeBill(600); // over the 500 default cap — expect a bounded 400
+
+const params = {
+  headers: { "Content-Type": "application/json" },
+  timeout: "10s",
+};
+
+function recordResult(res, ok) {
+  if (res.status >= 500) {
+    errors5xx.add(1);
+    console.error(`5xx response: ${res.status} — ${res.body.slice(0, 200)}`);
+  }
+  successRate.add(ok ? 1 : 0);
+}
+
+export function auditRealisticBill() {
+  const start = Date.now();
+  const res = http.post(`${BASE_URL}/bill/audit`, JSON.stringify(REALISTIC_BILL), params);
+  auditDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    "status is not 5xx": (r) => r.status < 500,
+    "status is 200 or 402 (payment gate)": (r) => r.status === 200 || r.status === 402,
+    "200 response has errorCount": (r) => {
+      if (r.status !== 200) return true; // payment-gated env — see script header
+      try {
+        return typeof JSON.parse(r.body).errorCount === "number";
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  if (res.status === 200) {
+    try {
+      const body = JSON.parse(res.body);
+      auditFindingsTotal.add(body.errorCount ?? 0);
+    } catch {
+      // ignore parse failure — already flagged by the check above
+    }
+  }
+
+  recordResult(res, ok);
+  sleep(0.2);
+}
+
+export function auditLargeBill() {
+  const useOversized = Math.random() < 0.5;
+  const payload = useOversized ? OVERSIZED_BILL : LARGE_BILL;
+
+  const start = Date.now();
+  const res = http.post(`${BASE_URL}/bill/audit`, JSON.stringify(payload), params);
+  auditDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    "status is not 5xx": (r) => r.status < 500,
+    "oversized bill gets bounded 400, large-but-valid gets 200/402": (r) => {
+      if (useOversized) return r.status === 400;
+      return r.status === 200 || r.status === 402;
+    },
+  });
+
+  if (res.status === 200) {
+    try {
+      const body = JSON.parse(res.body);
+      auditFindingsTotal.add(body.errorCount ?? 0);
+    } catch {
+      // ignore parse failure — already flagged by the check above
+    }
+  }
+
+  recordResult(res, ok);
+  sleep(0.2);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: `
+=== CareGuard Bill Audit Load Test Summary ===
+Iterations:          ${data.metrics.iterations?.values?.count ?? "?"}
+Success rate:        ${((data.metrics.success_rate?.values?.rate ?? 0) * 100).toFixed(1)}%
+5xx errors:           ${data.metrics.errors_5xx?.values?.count ?? 0}
+p95 audit duration:   ${data.metrics.bill_audit_duration_ms?.values?.["p(95)"]?.toFixed(0) ?? "?"}ms
+Total audit findings: ${data.metrics.audit_findings_total?.values?.count ?? 0}
+
+Note: 402 responses indicate the x402 payment gate is active and blocking audit
+computation from actually running — see the script header comment for how to point
+this at a server configured to accept test payments.
+`,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:watch": "vitest",
     "e2e": "cd dashboard && npx playwright test --config ../e2e/playwright.config.ts",
     "load": "k6 run load/agent-run.js",
+    "load:bill-audit": "k6 run load/bill-audit.js",
     "check:env-vars": "tsx scripts/check-env-vars.ts"
   },
   "keywords": [],

--- a/services/drug-interaction-api/__tests__/server.integration.test.ts
+++ b/services/drug-interaction-api/__tests__/server.integration.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+import type { Server } from "http";
+
+/**
+ * HTTP integration tests (Issue #789) for GET /drug/interactions and GET /ready.
+ *
+ * The x402 payment middleware itself (facilitator sync, verify/settle) has its own
+ * dedicated contract tests (shared/__tests__/x402-*-contract.test.ts); here we mock
+ * it as a no-op so we can drive the actual route handler — query parsing,
+ * normalization, caps, and error shape — over real HTTP via supertest.
+ */
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("../../../shared/x402-middleware.ts", () => ({
+  applyX402Middleware: vi.fn(),
+  NETWORK: "stellar:testnet",
+  OZ_FACILITATOR_URL: "https://example.invalid/facilitator",
+}));
+
+let app: Express;
+let server: Server;
+
+beforeAll(async () => {
+  process.env.PHARMACY_2_PUBLIC_KEY = "GPUB123TEST";
+  process.env.DRUG_INTERACTION_API_PORT = "0"; // OS-assigned ephemeral port, avoids conflicts
+  const mod = await import("../server.ts");
+  app = mod.app;
+  server = mod.server;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /drug/interactions (Issue #789)", () => {
+  it("returns interaction pairs with severity for a known pair", async () => {
+    const res = await request(app).get("/drug/interactions?meds=Lisinopril,Potassium");
+    expect(res.status).toBe(200);
+    expect(res.body.interactionCount).toBe(1);
+    expect(res.body.interactions[0]).toMatchObject({
+      drug1: "Lisinopril",
+      drug2: "Potassium",
+      severity: "severe",
+    });
+    expect(res.body.overallRisk).toBe("high");
+  });
+
+  it("resolves case-mismatched and whitespace-padded names to the same interaction", async () => {
+    const res = await request(app).get(
+      "/drug/interactions?meds=" + encodeURIComponent("  LISINOPRIL , potassium  "),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.interactionCount).toBe(1);
+    expect(res.body.interactions[0].severity).toBe("severe");
+    // Output uses canonical (title-case) naming regardless of input casing
+    expect(res.body.interactions[0].drug1).toBe("Lisinopril");
+    expect(res.body.interactions[0].drug2).toBe("Potassium");
+  });
+
+  it("a single-drug query returns an empty interactions array, not an error", async () => {
+    const res = await request(app).get("/drug/interactions?meds=Lisinopril");
+    expect(res.status).toBe(200);
+    expect(res.body.interactionCount).toBe(0);
+    expect(res.body.interactions).toEqual([]);
+    expect(res.body.overallRisk).toBe("none");
+  });
+
+  it("rejects a missing meds param with a structured 4xx", async () => {
+    const res = await request(app).get("/drug/interactions");
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+    expect(typeof res.body.error).toBe("string");
+  });
+
+  it("rejects an oversized drug list (>20 items) with a structured 4xx", async () => {
+    const meds = Array.from({ length: 25 }, (_, i) => `drug${i}`).join(",");
+    const res = await request(app).get(`/drug/interactions?meds=${meds}`);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+    expect(res.body.error).toMatch(/at most 20/);
+  });
+
+  it("does not leak stack traces or internal error text in the error response", async () => {
+    const res = await request(app).get("/drug/interactions?meds=" + "x".repeat(5000));
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+    expect(JSON.stringify(res.body)).not.toMatch(/at .*\(.*:\d+:\d+\)/); // no stack-trace-shaped text
+    expect(JSON.stringify(res.body).toLowerCase()).not.toContain("node_modules");
+  });
+});
+
+describe("GET /ready (Issue #789)", () => {
+  it("returns 200 when not draining", async () => {
+    const res = await request(app).get("/ready");
+    expect(res.status).toBe(200);
+  });
+});

--- a/services/drug-interaction-api/logic.ts
+++ b/services/drug-interaction-api/logic.ts
@@ -88,10 +88,10 @@ export const DrugInteractionsQuerySchema = z
     meds: delimitedFreeTextListSchema("meds"),
   })
   .strict()
-  .refine(
-    ({ meds }) => meds.length >= 2,
-    "Need at least 2 medications",
-  )
+  // A single medication can't have a pairwise interaction, but that's not
+  // malformed input — checkInteractions() already returns an empty
+  // interactions array for a length-1 list, so let it through rather than
+  // erroring.
   .transform(({ meds }) => ({ medications: meds }));
 
 export type DrugInteractionsQuery = z.infer<typeof DrugInteractionsQuerySchema>;

--- a/services/drug-interaction-api/server.ts
+++ b/services/drug-interaction-api/server.ts
@@ -31,7 +31,7 @@ const PAY_TO = process.env.PHARMACY_2_PUBLIC_KEY;
 
 if (!PAY_TO) throw new Error("PHARMACY_2_PUBLIC_KEY required in .env");
 
-const app = express();
+export const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
 app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
@@ -87,7 +87,7 @@ app.get("/ready", (_req, res) => {
   res.send("OK");
 });
 
-const server = app.listen(PORT, () => {
+export const server = app.listen(PORT, () => {
   logger.info({ port: PORT, network: NETWORK, facilitator: OZ_FACILITATOR_URL, payTo: PAY_TO }, "Drug Interaction API started");
 });
 

--- a/services/pharmacy-payment/__tests__/http-order.integration.test.ts
+++ b/services/pharmacy-payment/__tests__/http-order.integration.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, chmodSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import request from "supertest";
+import type { Express } from "express";
+import type { Server } from "http";
+
+/**
+ * HTTP integration tests (Issue #790) against the REAL server.ts app (exported
+ * for testing) — not a hand-copied route reimplementation. Only the MPP/Stellar
+ * SDKs and file-locking are mocked; real Express middleware and real fs against
+ * a temp data dir are used, so this exercises the actual charge -> order-record
+ * -> read-back path on the wire, including the header-sanitization and
+ * facilitator-unavailable handling added alongside this test.
+ */
+
+let mppChargeImpl: (webReq: Request) => Promise<any> = async () => ({
+  status: 402,
+  challenge: {
+    headers: new Map([["X-Payment-Required", "1"]]),
+    text: async () => JSON.stringify({ requires: "payment" }),
+  },
+});
+let lastWebReqHeaders: Headers | undefined;
+
+vi.mock("mppx/server", () => ({
+  Store: {
+    memory: vi.fn(() => ({ type: "memory" })),
+    fileSystem: vi.fn((p: string) => ({ type: "fileSystem", path: p })),
+  },
+  Mppx: {
+    create: vi.fn(() => ({
+      charge: () => (webReq: Request) => {
+        lastWebReqHeaders = webReq.headers;
+        return mppChargeImpl(webReq);
+      },
+    })),
+  },
+}));
+vi.mock("@stellar/mpp/charge/server", () => ({ stellar: { charge: vi.fn(() => ({})) } }));
+vi.mock("@stellar/mpp", () => ({ USDC_SAC_TESTNET: "USDC_SAC_TESTNET" }));
+vi.mock("dotenv/config", () => ({}));
+vi.mock("proper-lockfile", () => ({
+  default: { lock: vi.fn(() => Promise.resolve(() => Promise.resolve())) },
+}));
+
+const successCharge = async (_webReq: Request) => ({
+  status: 200,
+  withReceipt: (resp: Response) => resp,
+});
+
+let app: Express;
+let server: Server;
+let dataDir: string;
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(path.join(tmpdir(), "careguard-mpp-http-"));
+  process.env.DATA_DIR = dataDir;
+  process.env.PHARMACY_1_PUBLIC_KEY = "GPUB123TEST";
+  process.env.MPP_SECRET_KEY = "test-mpp-secret";
+  process.env.PHARMACY_PAYMENT_PORT = "0";
+
+  const mod = await import("../server.ts");
+  app = mod.app;
+  server = mod.server;
+});
+
+beforeEach(() => {
+  // The global test setup (tests/setup.ts) wipes process.env.DATA_DIR after every
+  // test regardless of file — recreate our fixed temp dir so the already-imported
+  // server module (which captured DATA_DIR once at import time) keeps working.
+  if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
+});
+
+afterEach(() => {
+  mppChargeImpl = async () => ({
+    status: 402,
+    challenge: {
+      headers: new Map([["X-Payment-Required", "1"]]),
+      text: async () => JSON.stringify({ requires: "payment" }),
+    },
+  });
+  lastWebReqHeaders = undefined;
+});
+
+afterAll(() => {
+  server?.close();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("POST /pharmacy/order (Issue #790)", () => {
+  it("with a settled payment, returns 200 and the order is readable via GET /pharmacy/orders", async () => {
+    mppChargeImpl = successCharge;
+
+    const postRes = await request(app)
+      .post("/pharmacy/order")
+      .send({ drug: "Amoxicillin", pharmacy: "Test Pharmacy", amount: 12.5 });
+
+    expect(postRes.status).toBe(200);
+    expect(postRes.body.order.id).toMatch(/^order-/);
+
+    const listRes = await request(app).get("/pharmacy/orders");
+    expect(listRes.status).toBe(200);
+    const found = listRes.body.orders.find((o: any) => o.id === postRes.body.order.id);
+    expect(found).toBeDefined();
+    expect(found.drug).toBe("Amoxicillin");
+  });
+
+  it("rejects a negative amount with 4xx before any charge is attempted", async () => {
+    const chargeSpy = vi.fn(successCharge);
+    mppChargeImpl = chargeSpy;
+
+    const res = await request(app)
+      .post("/pharmacy/order")
+      .send({ drug: "Amoxicillin", pharmacy: "Test Pharmacy", amount: -5 });
+
+    expect(res.status).toBe(400);
+    expect(chargeSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an Infinity amount with 4xx before any charge is attempted", async () => {
+    const chargeSpy = vi.fn(successCharge);
+    mppChargeImpl = chargeSpy;
+
+    const res = await request(app)
+      .post("/pharmacy/order")
+      .send({ drug: "Amoxicillin", pharmacy: "Test Pharmacy", amount: "Infinity" });
+
+    expect(res.status).toBe(400);
+    expect(chargeSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unbounded (>$10,000) amount with 4xx before any charge is attempted", async () => {
+    const chargeSpy = vi.fn(successCharge);
+    mppChargeImpl = chargeSpy;
+
+    const res = await request(app)
+      .post("/pharmacy/order")
+      .send({ drug: "Amoxicillin", pharmacy: "Test Pharmacy", amount: 999999 });
+
+    expect(res.status).toBe(400);
+    expect(chargeSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 and persists no order when the MPP facilitator throws", async () => {
+    mppChargeImpl = async () => {
+      throw new Error("facilitator unreachable");
+    };
+
+    const before = await request(app).get("/pharmacy/orders");
+    const beforeCount = before.body.orders.length;
+
+    const res = await request(app)
+      .post("/pharmacy/order")
+      .send({ drug: "Ibuprofen", pharmacy: "Test Pharmacy", amount: 5 });
+
+    expect(res.status).toBe(503);
+
+    const after = await request(app).get("/pharmacy/orders");
+    expect(after.body.orders.length).toBe(beforeCount);
+  });
+
+  it("does not forward the caller's Authorization/Cookie headers to the upstream MPP call", async () => {
+    mppChargeImpl = successCharge;
+
+    await request(app)
+      .post("/pharmacy/order")
+      .set("Authorization", "Bearer super-secret-caller-token")
+      .set("Cookie", "session=super-secret-session")
+      .send({ drug: "Amoxicillin", pharmacy: "Test Pharmacy", amount: 8 });
+
+    expect(lastWebReqHeaders).toBeDefined();
+    expect(lastWebReqHeaders!.get("authorization")).toBeNull();
+    expect(lastWebReqHeaders!.get("cookie")).toBeNull();
+  });
+});
+
+describe("GET /ready (Issue #790)", () => {
+  it("returns 200 when the order store directory is writable", async () => {
+    const res = await request(app).get("/ready");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 503 when the order store directory is not writable", async () => {
+    chmodSync(dataDir, 0o444);
+    try {
+      const res = await request(app).get("/ready");
+      expect(res.status).toBe(503);
+    } finally {
+      chmodSync(dataDir, 0o755); // restore so afterAll cleanup can remove it
+    }
+  });
+});

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -37,7 +37,7 @@ if (!RECIPIENT) throw new Error("PHARMACY_1_PUBLIC_KEY required in .env");
 if (!MPP_SECRET_KEY) throw new Error("MPP_SECRET_KEY required in .env");
 
 // Order storage (persisted to file)
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, accessSync, constants as fsConstants } from "fs";
 import lock from "proper-lockfile";
 
 const DATA_DIR = process.env.DATA_DIR || new URL("../../data", import.meta.url).pathname;
@@ -105,7 +105,7 @@ async function saveOrder(order: any) {
   }
 }
 
-const app = express();
+export const app = express();
 applySecurityMiddleware(app);
 app.use(createCorsMiddleware());
 app.use(express.json({ limit: process.env.JSON_BODY_LIMIT ?? "20kb" }));
@@ -155,10 +155,14 @@ app.post("/pharmacy/order", async (req, res) => {
   const safeDrug = sanitizeUserString(order.drug);
   const safePharmacy = sanitizeUserString(order.pharmacy);
 
-  // Convert Express request to Web Request for mppx
+  // Convert Express request to Web Request for mppx. Never forward the
+  // caller's own auth/session headers into the upstream MPP charge call —
+  // mppx only needs the payment-protocol headers (e.g. X-Payment).
+  const FORWARD_HEADER_BLOCKLIST = new Set(["authorization", "cookie"]);
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
     if (value == null) continue;
+    if (FORWARD_HEADER_BLOCKLIST.has(key.toLowerCase())) continue;
     if (Array.isArray(value)) {
       for (const entry of value) headers.append(key, entry);
     } else {
@@ -172,10 +176,17 @@ app.post("/pharmacy/order", async (req, res) => {
   });
 
   // Run MPP charge flow
-  const result = await mppx.charge({
-    amount: Number(order.amount).toFixed(2),
-    description: `Medication: ${safeDrug} from ${safePharmacy}`,
-  })(webReq);
+  let result;
+  try {
+    result = await mppx.charge({
+      amount: Number(order.amount).toFixed(2),
+      description: `Medication: ${safeDrug} from ${safePharmacy}`,
+    })(webReq);
+  } catch (err: any) {
+    logger.error({ err: err?.message }, "MPP charge flow failed — facilitator unavailable");
+    res.status(503).json({ error: "Payment facilitator unavailable, try again shortly" });
+    return;
+  }
 
   // 402 = client needs to sign and pay
   if (result.status === 402) {
@@ -226,10 +237,16 @@ app.get("/ready", (_req, res) => {
     res.status(503).send("Service Unavailable");
     return;
   }
+  try {
+    accessSync(DATA_DIR, fsConstants.W_OK);
+  } catch {
+    res.status(503).json({ error: "Order store is not writable" });
+    return;
+  }
   res.send("OK");
 });
 
-const server = app.listen(PORT, () => {
+export const server = app.listen(PORT, () => {
   logger.info({ port: PORT, network: NETWORK, recipient: RECIPIENT, currency: USDC_SAC_TESTNET }, "Pharmacy Payment Service (MPP Charge) started");
 });
 

--- a/shared/__tests__/stellar-fee.test.ts
+++ b/shared/__tests__/stellar-fee.test.ts
@@ -145,6 +145,84 @@ describe("getTargetFee", () => {
     const fee = await getTargetFee(horizon);
     expect(fee).toBe("100");
   });
+
+  it("falls back to 100 when fee_stats is missing the fee_charged key entirely", async () => {
+    const horizon = createMockHorizon({
+      ledger_capacity_usage: "0.50",
+      // fee_charged intentionally absent — partial/malformed Horizon response
+    });
+
+    const fee = await getTargetFee(horizon);
+    expect(fee).toBe("100");
+  });
+
+  it("falls back to 100 when fee_stats resolves to an empty object", async () => {
+    const horizon = createMockHorizon({});
+    const fee = await getTargetFee(horizon);
+    expect(fee).toBe("100");
+  });
+
+  it("falls back to 100 when fee_charged.p90 itself is missing", async () => {
+    const horizon = createMockHorizon({
+      fee_charged: { max: "2000", min: "100" }, // no p90 field
+      ledger_capacity_usage: "0.50",
+    });
+
+    const fee = await getTargetFee(horizon);
+    expect(fee).toBe("100");
+  });
+
+  it("reflects a congestion spike with a higher fee, capped to a sane maximum", async () => {
+    const horizon = createMockHorizon({
+      fee_charged: {
+        max: "50000000",
+        min: "100",
+        mode: "5000",
+        p10: "100",
+        p20: "200",
+        p30: "500",
+        p40: "1000",
+        p50: "2000",
+        p60: "5000",
+        p70: "10000",
+        p80: "50000",
+        p90: "5000000", // severe congestion spike
+        p95: "10000000",
+        p99: "50000000",
+      },
+      max_fee: { max: "50000000", min: "100", p90: "5000000" },
+      ledger_capacity_usage: "1.0",
+    });
+
+    const fee = await getTargetFee(horizon);
+    // Higher than the normal-congestion case (450) but clamped, not the raw 5,000,000
+    expect(Number(fee)).toBeGreaterThan(450);
+    expect(Number(fee)).toBeLessThanOrEqual(100_000);
+    expect(fee).toBe("100000");
+  });
+
+  it("handles a network/Horizon error from the fee_stats call with the fallback value", async () => {
+    const horizon = createMockHorizon(new Error("ECONNRESET"));
+    const fee = await getTargetFee(horizon);
+    expect(fee).toBe("100");
+  });
+
+  it("always returns a valid stringified positive integer in stroops", async () => {
+    const cases = [
+      { fee_charged: { p90: "450" } },
+      { fee_charged: { p90: "50" } },
+      { fee_charged: { p90: "abc" } },
+      {},
+      new Error("boom"),
+    ];
+    for (const c of cases) {
+      const horizon = createMockHorizon(c as any);
+      const fee = await getTargetFee(horizon);
+      expect(fee).toMatch(/^\d+$/);
+      expect(Number(fee)).toBeGreaterThan(0);
+      expect(Number.isInteger(Number(fee))).toBe(true);
+    }
+  });
 });
 
 describe("fee bump retry logic", () => {

--- a/shared/stellar-fee.ts
+++ b/shared/stellar-fee.ts
@@ -8,19 +8,24 @@
 import { Horizon } from "@stellar/stellar-sdk";
 
 const MIN_FEE_STROOPS = 100;
+// Matches the fee-bump ceiling in agent/tools.ts — a congestion spike in
+// fee_charged.p90 should never push the *initial* target fee past what the
+// retry logic treats as its own maximum.
+const MAX_FEE_STROOPS = 100_000;
 
 /**
  * Fetch the target fee from Horizon's /fee_stats endpoint.
  *
  * @param horizon - A connected Horizon.Server instance.
- * @returns The p90 fee as a string, or "100" on error.
+ * @returns The p90 fee as a string, clamped to [100, 100000] stroops, or "100"
+ *          on any error or missing/malformed fee_stats data.
  */
 export async function getTargetFee(horizon: Horizon.Server): Promise<string> {
   try {
     const feeStats = await horizon.feeStats();
     const p90Fee = parseInt(feeStats.fee_charged.p90, 10);
     if (Number.isFinite(p90Fee) && p90Fee > 0) {
-      return String(Math.max(MIN_FEE_STROOPS, p90Fee));
+      return String(Math.min(MAX_FEE_STROOPS, Math.max(MIN_FEE_STROOPS, p90Fee)));
     }
     return String(MIN_FEE_STROOPS);
   } catch {


### PR DESCRIPTION
## Summary

- **#789** — Added `services/drug-interaction-api/__tests__/server.integration.test.ts`, supertest-based tests against the real `server.ts` app (now exported for testing) covering query parsing, case/whitespace normalization, the 20-item cap, missing-param 4xx, no-stack-leak on error responses, and `GET /ready`. The x402 payment middleware is mocked out (it has its own dedicated contract tests elsewhere). **Found and fixed:** a single-drug query returned a 400 ("Need at least 2 medications") instead of an empty interactions array as the issue expects — `checkInteractions()` already handles a length-1 list correctly, so removed the overly strict zod `.refine()` rather than special-casing it in the route.
- **#790** — Added `services/pharmacy-payment/__tests__/http-order.integration.test.ts` against the real `server.ts` app + `http.Server` (both now exported), with a mocked MPP/Stellar SDK and a real temp-dir order store: settled payment → 200 + readable via `GET /pharmacy/orders`; negative/Infinity/unbounded amounts rejected before any charge is attempted; `GET /ready` reflecting store writability. **Found and fixed three real gaps in `server.ts`:** (1) the caller's `Authorization`/`Cookie` headers were forwarded verbatim into the outbound MPP charge request — added a blocklist; (2) an MPP charge failure had no `try/catch`, falling through to a bare 500 — added a catch returning 503 with a test proving no order gets persisted; (3) `GET /ready` never checked the order store at all — it now does a write-access check on `DATA_DIR`.
- **#798** — Added edge-case tests to `shared/__tests__/stellar-fee.test.ts`: missing `fee_charged`, missing `fee_charged.p90`, an empty `fee_stats` response, a Horizon/network error, and an "always a valid positive stringified integer" sweep. **Found and fixed a real gap:** `getTargetFee` had no ceiling, so a congestion spike in `fee_charged.p90` would be returned uncapped — added a 100,000-stroop cap matching the existing `MAX_FEE_STROOPS` used by `payBill`'s own fee-bump retry logic, with a test covering the capped case.
- **#800** — Added `load/bill-audit.js`, a k6 script mirroring `load/agent-run.js`'s pattern: a ramping-VU scenario (1→10→30→0 over 2 min) posting a realistic 10-line-item bill, plus a constant-VU scenario alternating between a 480-item and a 600-item bill to check the `BILL_AUDIT_MAX_ITEMS=500` boundary. Thresholds gate p95 latency (<2s) and require zero 5xx; a custom `audit_findings_total` counter confirms real audit work happened under load. Documented in `docs/load-testing.md` and wired up as `pnpm load:bill-audit`.

  **Note on scope:** `POST /bill/audit` is x402-payment-protected and this script doesn't perform a real Stellar payment, so against a server with a live facilitator key it'll see 402s instead of exercising the audit computation — same category of prerequisite as `agent-run.js`'s documented "run with a mocked LLM" requirement, except there's no in-repo mock facilitator today to point at instead. Documented as an environment setup step in both the script header and the docs; the script treats 402 as an expected response, not a failure, so its thresholds are still meaningful either way.
Closes #789 
Closes #790 
Closes #798 
Closes #800 
## Test plan

- [x] `npx vitest run services/drug-interaction-api/ services/pharmacy-payment/ shared/__tests__/stellar-fee.test.ts` — 69 tests pass across 10 files, no regressions in existing tests
- [x] `npx tsc --noEmit -p tsconfig.json` — no new errors in any touched file
- [x] `node --check load/bill-audit.js` — valid syntax (k6 itself isn't installed in this environment to run it end-to-end)
- [x] Manually traced the 503/header-sanitization/writability fixes against the mocked failure paths in the new pharmacy-payment test to confirm they fail without the fix and pass with it