### PR TITLE
fix(observability): complete issues #774 #775 #776 #787

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,15 @@ The [dependabot-automerge workflow](.github/workflows/dependabot-automerge.yml) 
 - ESLint + Prettier (run `npm run lint` before pushing)
 - Keep services self-contained; shared code goes in `shared/`
 
+## Observability
+
+When adding or modifying metrics, follow the conventions in
+[`docs/observability/metrics-naming.md`](docs/observability/metrics-naming.md).
+This document covers naming conventions (prefixes, `_total` suffix, base-unit
+policy), label-cardinality rules, and includes a checklist for new metrics.
+Every new metric must also be added to
+[`docs/observability/metrics-catalog.md`](docs/observability/metrics-catalog.md).
+
 ## Smart Contract Guidelines (Stellar/Soroban)
 
 If contributing to on-chain components:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -2,8 +2,57 @@ global:
   scrape_interval: 5s
   evaluation_interval: 5s
 
+# ---------------------------------------------------------------------------
+# Rule files
+# ---------------------------------------------------------------------------
+# recording-rules.yml — pre-aggregated SLI ratio series (multi-window pairs)
+#   used by Grafana dashboards and by the alert expressions below so they can
+#   reference cheap, stable series instead of recomputing raw counter rates.
+# rules.yml — alerting rules for key failure conditions (Issue #774).
+#
+# Validate both files with:
+#   promtool check config docker/prometheus/prometheus.yml
 rule_files:
   - "recording-rules.yml"
+  - "rules.yml"
+
+# ---------------------------------------------------------------------------
+# Alertmanager — routing path from rule fire to notification
+# ---------------------------------------------------------------------------
+# Interim decision (no Alertmanager container deployed):
+#
+#   This project does not yet run a dedicated Alertmanager instance.
+#   Alert routing is handled by Grafana's built-in alerting engine instead:
+#
+#     1. Prometheus evaluates the rules in rules.yml on every evaluation_interval.
+#     2. Grafana (port 3030) scrapes Prometheus as a data source.
+#     3. Grafana Alert Rules mirror the same PromQL expressions and forward
+#        firing alerts to a Grafana Contact Point (e-mail, Slack, PagerDuty, etc.)
+#        configured under Alerting → Contact points in the Grafana UI.
+#     4. Notification policies in Grafana control grouping, repeat intervals,
+#        and silence windows — replacing the Alertmanager routes/receivers config.
+#
+#   This is a documented interim: once the deployment warrants a dedicated
+#   on-call pager workflow, add an Alertmanager container to docker-compose.yml,
+#   uncomment the section below, and remove the Grafana-managed alert rules that
+#   duplicate the Prometheus rule expressions.
+#
+#   When Alertmanager IS wired up, the routing path will be:
+#     Prometheus evaluates rule → ALERTS metric fires →
+#     Prometheus pushes to Alertmanager (alertmanagers targets below) →
+#     Alertmanager groups & deduplicates → routes to receiver (Slack/PagerDuty) →
+#     notification delivered to on-call engineer.
+#
+# Uncomment and populate when Alertmanager is deployed:
+#
+# alerting:
+#   alertmanagers:
+#     - static_configs:
+#         - targets:
+#             - "alertmanager:9093"   # docker-compose service name + port
+#       scheme: http
+#       timeout: 10s
+#       api_version: v2
 
 scrape_configs:
   # When running via docker compose, the server is reachable as `server` on

--- a/docker/prometheus/rules.yml
+++ b/docker/prometheus/rules.yml
@@ -1,0 +1,248 @@
+# CareGuard Prometheus Alerting Rules — Issue #774
+#
+# Alert rules covering key failure conditions observed through the metrics
+# defined in shared/metrics.ts.  Grouped by subsystem for readability.
+#
+# Validate with:
+#   promtool check rules docker/prometheus/rules.yml
+#
+# Threshold rationale is documented inline for each alert.
+# Runbooks are linked via the runbook_url annotation.
+#
+# Cross-linked: docker/prometheus/prometheus.yml (rule_files section),
+#               docs/observability/slo.md (SLO targets these alerts enforce).
+
+groups:
+  # -------------------------------------------------------------------------
+  # Agent run failures
+  # -------------------------------------------------------------------------
+  - name: careguard-agent-runs
+    rules:
+      - alert: AgentRunErrorRateHigh
+        # Fire when more than 5 % of agent runs are failing over the last 5 min.
+        # Threshold rationale: SLO target is ≥ 99 % success (slo.md). A 5 %
+        # error rate burns the monthly error budget in ~6 hours, so fast detection
+        # is warranted. Pair with the 1-hour window (below) to avoid paging on
+        # short spikes.
+        expr: |
+          (
+            sum(rate(agent_runs_total{status="error"}[5m]))
+            /
+            sum(rate(agent_runs_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent run error rate is above 5 % (5 m window)"
+          description: >
+            {{ $value | humanizePercentage }} of agent runs are failing.
+            Check agent logs for LLM errors, tool timeouts, or policy blocks.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"
+
+      - alert: AgentRunErrorRateCritical
+        # Fire when more than 10 % of agent runs fail over the last 1 hour.
+        # At 10 % the monthly SLO error budget is exhausted in ~3 hours.
+        expr: |
+          (
+            sum(rate(agent_runs_total{status="error"}[1h]))
+            /
+            sum(rate(agent_runs_total[1h]))
+          ) > 0.10
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Agent run error rate is above 10 % (1 h window)"
+          description: >
+            {{ $value | humanizePercentage }} of agent runs are failing over the
+            past hour. Immediate investigation required.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"
+
+      - alert: AgentIterationLimitBreached
+        # Fire when agents are consistently hitting the iteration cap.
+        # This indicates runaway LLM loops; each hit wastes tokens and blocks
+        # the queue. Even one per 5 min is unusual and worth investigating.
+        expr: rate(agent_iteration_limit_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent runs are hitting the iteration limit"
+          description: >
+            {{ $value }} iteration-limit hits per second in the last 5 min.
+            The LLM may be looping or context may be exhausted.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"
+
+  # -------------------------------------------------------------------------
+  # Stellar transaction failures
+  # -------------------------------------------------------------------------
+  - name: careguard-stellar-tx
+    rules:
+      - alert: StellarTxFailureRateHigh
+        # Fire when more than 2 % of submitted Stellar transactions fail over 5 min.
+        # Threshold rationale: SLO target is ≥ 99.5 % success. At 2 % the monthly
+        # budget is exhausted in ~10 hours — fast page.
+        expr: |
+          (
+            sum(rate(stellar_tx_submitted_total{result!="success"}[5m]))
+            /
+            sum(rate(stellar_tx_submitted_total[5m]))
+          ) > 0.02
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Stellar transaction failure rate above 2 % (5 m window)"
+          description: >
+            {{ $value | humanizePercentage }} of Stellar transactions are failing.
+            Check Horizon connectivity and sequence-number contention.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/oz-facilitator-outage.md"
+
+      - alert: StellarTxFailureRateCritical
+        # Fire when more than 5 % of Stellar txs fail over 15 min. At this rate
+        # payments to pharmacies and bill payments are broadly broken.
+        expr: |
+          (
+            sum(rate(stellar_tx_submitted_total{result!="success"}[15m]))
+            /
+            sum(rate(stellar_tx_submitted_total[15m]))
+          ) > 0.05
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Stellar transaction failure rate above 5 % (15 m window)"
+          description: >
+            {{ $value | humanizePercentage }} of Stellar transactions are failing
+            over the past 15 min. Payments are broadly degraded.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/oz-facilitator-outage.md"
+
+      - alert: StellarBadSeqRetriesHigh
+        # Sustained bad-sequence retries indicate account sequence contention
+        # (concurrent submitters). > 0.5 retries/s over 10 min warrants a page.
+        expr: rate(stellar_tx_bad_seq_retries_total[5m]) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High rate of Stellar tx_bad_seq retries"
+          description: >
+            {{ $value | humanize }} retries/s due to sequence-number conflicts.
+            Consider serialising submissions or using a sequence cache.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/oz-facilitator-outage.md"
+
+  # -------------------------------------------------------------------------
+  # Spending policy blocks and payment rejections
+  # -------------------------------------------------------------------------
+  - name: careguard-policy
+    rules:
+      - alert: PolicyBlockRateSustained
+        # Fire when policy blocks are occurring at > 1 per minute sustained for
+        # 10 min. Isolated blocks are normal (limits working correctly); a
+        # sustained rate suggests a misconfigured policy or an agent stuck in
+        # a spend loop.
+        expr: rate(policy_blocks_total[5m]) * 60 > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Spending policy is blocking agent actions at an elevated rate"
+          description: >
+            {{ $value | humanize }} policy blocks per minute over the last 5 min.
+            Verify that spending limits are correctly configured and the agent is
+            not looping on a single expensive action.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"
+
+      - alert: PaymentRejectionRateSustained
+        # Fire when payments are being rejected at > 1 per minute for 10 min.
+        # Separate from policy_blocks_total — this counter covers downstream
+        # payment-gateway rejections rather than in-process policy enforcement.
+        expr: rate(payment_rejected_total[5m]) * 60 > 1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Payment rejections are occurring at an elevated rate"
+          description: >
+            {{ $value | humanize }} payment rejections per minute. This may
+            indicate invalid payment credentials, an outage on the payment
+            gateway, or mismatched USDC balances.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/wallet-low.md"
+
+  # -------------------------------------------------------------------------
+  # Agent queue depth / saturation
+  # -------------------------------------------------------------------------
+  - name: careguard-queue
+    rules:
+      - alert: AgentQueueDepthHigh
+        # Fire when active concurrent agent runs stay above 5 for 5 min.
+        # Threshold rationale: the default concurrency limit is low (single-digit).
+        # Sustained depth > 5 means the queue is approaching saturation and new
+        # requests will start waiting or being rejected.
+        expr: agent_queue_depth > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent queue depth is high"
+          description: >
+            {{ $value }} agent runs are executing concurrently. New requests may
+            be queued or rejected. Consider scaling horizontally.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"
+
+      - alert: AgentQueueSaturated
+        # Fire when waiting jobs > 0 sustained for 5 min — the queue is full
+        # and callers are being made to wait. Any sustained backlog is critical
+        # for a near-real-time caregiver-facing service.
+        expr: agent_waiting_jobs > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Agent queue is saturated — requests are waiting"
+          description: >
+            {{ $value }} agent requests are waiting in the queue. The service
+            is not keeping up with demand. Immediate action required.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"
+
+  # -------------------------------------------------------------------------
+  # LLM health
+  # -------------------------------------------------------------------------
+  - name: careguard-llm
+    rules:
+      - alert: AgentLlmErrorRateHigh
+        # Fire when > 1 % of agent runs hit an LLM API error over 5 min.
+        # Threshold rationale: SLO target is ≤ 1 % LLM error rate (slo.md).
+        # Breaching this even briefly means the SLO target is at risk.
+        expr: |
+          (
+            sum(rate(agent_llm_error_total[5m]))
+            /
+            sum(rate(agent_runs_total[5m]))
+          ) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "LLM API error rate exceeds 1 % SLO target"
+          description: >
+            {{ $value | humanizePercentage }} of agent runs are hitting LLM
+            errors. Check the LLM provider status and API key validity.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/rotate-agent-api-key.md"
+
+      - alert: AgentLlmContextNearExhaustion
+        # Fire when the latest context-usage ratio is above 90 %.
+        # At > 90 % context fill the model may truncate the conversation,
+        # causing unpredictable tool-call behaviour.
+        expr: agent_llm_context_usage_ratio > 0.9
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent LLM context window is nearly full (> 90 %)"
+          description: >
+            Context usage ratio is {{ $value | humanizePercentage }}.
+            The model may start truncating earlier conversation turns,
+            leading to missed context and incorrect decisions.
+          runbook_url: "https://github.com/harystyleseze/careguard/blob/main/docs/runbooks/README.md"

--- a/docs/observability/metrics-catalog.md
+++ b/docs/observability/metrics-catalog.md
@@ -5,6 +5,10 @@ are registered on the shared `prom-client` `Registry` in [`shared/metrics.ts`](.
 (queue gauges live in [`shared/agent-queue.ts`](../../shared/agent-queue.ts)) and served at `/metrics`.
 See the [Grafana dashboard guide](./dashboard-guide.md) for how these are visualized.
 
+> **Before adding a metric:** read the [metrics naming and labelling conventions](./metrics-naming.md)
+> for prefix rules, `_total` suffix, base-unit policy, and label-cardinality limits.
+> Add every new metric to this catalog and run through the checklist in that guide.
+
 ## Agent
 
 | Metric | Type | Labels | Meaning | Used by |

--- a/docs/observability/metrics-naming.md
+++ b/docs/observability/metrics-naming.md
@@ -1,0 +1,187 @@
+# Metrics Naming and Labelling Conventions
+
+> **Cross-links:** [metrics-catalog.md](./metrics-catalog.md) · [slo.md](./slo.md) ·
+> [`shared/metrics.ts`](../../shared/metrics.ts) · [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+This guide defines the naming and labelling conventions every contributor must
+follow when adding or modifying a metric in CareGuard.  It also audits the
+existing metrics in `shared/metrics.ts` against these conventions, lists the
+known deviations, and provides a checklist for adding a new metric.
+
+---
+
+## 1. Naming conventions
+
+### 1.1 Prefix
+
+Every metric **must** be prefixed with the service or subsystem it belongs to,
+followed by an underscore.
+
+| Subsystem | Prefix |
+|-----------|--------|
+| Agent runtime | `agent_` |
+| Stellar / payments | `stellar_` or `payments_` |
+| x402 protocol | `x402_` |
+| Pharmacy service | `pharmacy_` |
+| Bill audit service | `bill_audit_` |
+| Spending policy | `policy_` or `payment_` |
+
+### 1.2 Counter suffix — `_total`
+
+All counters **must** end in `_total` (the Prometheus / OpenMetrics standard).
+
+```
+# Good
+agent_runs_total
+stellar_tx_submitted_total
+
+# Bad  ← missing _total
+agent_runs
+stellar_txs_submitted
+```
+
+### 1.3 Unit suffix
+
+Metrics that measure a quantity in a specific unit **must** include the base
+unit as the final component before `_total` (for counters) or at the end (for
+gauges / histograms).
+
+| Quantity | Base unit suffix |
+|----------|-----------------|
+| Duration / latency | `_seconds` (not `_ms`, not `_milliseconds`) |
+| Byte count | `_bytes` |
+| USD / USDC amounts | `_usd` or `_usdc` |
+
+**Exception:** `agent_llm_latency_ms` currently uses `_ms` — this is a known
+deviation (see §3) that should be migrated to `_seconds` in a follow-up.
+
+### 1.4 Base-unit policy
+
+Use Prometheus base units.  Do **not** pre-scale.
+
+| Measure | Store as |
+|---------|----------|
+| 500 milliseconds | `0.5` (seconds) |
+| 1.5 kilobytes | `1536` (bytes) |
+| $0.002 | `0.002` (USD) |
+
+The Grafana dashboard layer applies display scaling (e.g. `* 1000` to show ms).
+
+### 1.5 Naming style
+
+- lowercase `snake_case` only — no camelCase, no hyphens.
+- Be descriptive and avoid abbreviations that are not universally understood
+  (`tx` for transaction is acceptable; `ag` for agent is not).
+- Verb-first for event counters is fine (`agent_runs_total`, not `total_agent_runs`).
+
+---
+
+## 2. Labelling conventions
+
+### 2.1 Allowed label cardinality
+
+Labels must have **bounded, low-cardinality values**.
+
+| Limit | Guidance |
+|-------|----------|
+| Max labels per metric | 4 |
+| Max unique values per label | ~20 in normal operation |
+| Unbounded strings (user input, drug names) | **Forbidden** as label values — use a separate counter or sanitise to a fixed set |
+
+> **Why?** High-cardinality labels (one time-series per unique user, drug name,
+> or error message) cause Prometheus memory to grow unboundedly and make scrapes
+> slow.  `pharmacy_unknown_drug_total{drug="..."}` is the one existing violation
+> — see §3.
+
+### 2.2 Standard label names
+
+Use these names consistently across all metrics:
+
+| Label | Meaning | Example values |
+|-------|---------|---------------|
+| `status` | Outcome of an operation | `success`, `error`, `timeout` |
+| `result` | Synonym for `status` on Stellar counters (legacy — prefer `status` for new metrics) | `success`, `failure` |
+| `type` | Payment or category variant | `x402`, `mpp`, `direct` |
+| `tool` | Agent tool name | `compare_prices`, `check_interactions` |
+| `kind` | Sub-type within a metric | `prompt`, `completion` |
+| `reason` | Why a block / rejection occurred | `daily_limit`, `category_limit` |
+| `model` | LLM model identifier | `llama3-70b-8192` |
+| `category` | Spending category | `medications`, `bills` |
+
+### 2.3 Do not use labels for
+
+- Free-form user-supplied strings (drug names, addresses, error messages).
+- High-cardinality identifiers (session IDs, request IDs, wallet addresses).
+- Boolean flags — prefer two separate counters or a `status=active/inactive`
+  label with a fixed two-value set.
+
+---
+
+## 3. Audit of existing metrics in `shared/metrics.ts`
+
+The table below lists every metric, its current convention compliance, and any
+deviations that need to be fixed.
+
+| Metric | Type | Labels | Convention check | Deviation / action |
+|--------|------|--------|------------------|--------------------|
+| `agent_runs_total` | Counter | `status` | ✅ | — |
+| `agent_tool_calls_total` | Counter | `tool`, `status` | ✅ | — |
+| `payments_usdc_total` | Counter | `type` | ✅ | — |
+| `x402_settlements_total` | Counter | — | ✅ | — |
+| `stellar_tx_submitted_total` | Counter | `result` | ⚠️ | `result` label should be `status` for consistency; migrate in a follow-up |
+| `policy_blocks_total` | Counter | `reason` | ✅ | — |
+| `payment_rejected_total` | Counter | `reason` | ✅ | — |
+| `agent_iteration_limit_total` | Counter | — | ✅ | — |
+| `agent_llm_tokens_total` | Counter | `kind` | ✅ | — |
+| `agent_llm_iteration_tokens` | Gauge | `kind` | ✅ | — |
+| `agent_llm_context_usage_ratio` | Gauge | — | ✅ | — |
+| `agent_spending_usd` | Gauge | `category` | ✅ | — |
+| `agent_transactions_total` | Counter | `status` | ⚠️ | Overlaps with `agent_runs_total` and `stellar_tx_submitted_total`; clarify scope in a follow-up |
+| `x402_tx_extraction_failed_total` | Counter | — | ✅ | — |
+| `pharmacy_unknown_drug_total` | Counter | `drug` | ❌ | **High-cardinality label** — `drug` is a free-form user string; cap to a safe set or drop the label and use a separate low-cardinality label like `drug_known=false`. Track in issue. |
+| `agent_llm_error_total` | Counter | — | ✅ | — |
+| `agent_llm_latency_ms` | Gauge | `model` | ❌ | **Unit suffix violation** — must be `_seconds` not `_ms`; rename to `agent_llm_latency_seconds` in a follow-up. Also a Gauge tracking only the latest observation — consider a Histogram. |
+| `stellar_fee_bumps_total` | Counter | — | ✅ | — |
+| `stellar_tx_bad_seq_retries_total` | Counter | — | ✅ | — |
+| `bill_audit_oversized_rejections_total` | Counter | — | ✅ | — |
+
+### Queue metrics (in `shared/agent-queue.ts`)
+
+| Metric | Type | Labels | Convention check | Deviation / action |
+|--------|------|--------|------------------|--------------------|
+| `agent_queue_depth` | Gauge | — | ✅ | — |
+| `agent_waiting_jobs` | Gauge | — | ✅ | — |
+
+### Summary of deviations to fix
+
+| Priority | Metric | Issue |
+|----------|--------|-------|
+| High | `pharmacy_unknown_drug_total` | Unbounded `drug` label — cardinality risk |
+| Medium | `agent_llm_latency_ms` | Wrong unit suffix (`_ms` → `_seconds`); point-in-time Gauge rather than Histogram |
+| Low | `stellar_tx_submitted_total` | `result` label should be `status` for consistency |
+| Low | `agent_transactions_total` | Scope overlap with other counters — needs clarification |
+
+---
+
+## 4. Checklist for adding a new metric
+
+Before opening a PR that introduces a metric, verify each item:
+
+- [ ] **Prefix** matches the subsystem table in §1.1.
+- [ ] **Counter ends in `_total`** (§1.2).
+- [ ] **Unit suffix** uses a base unit (`_seconds`, `_bytes`, `_usd`) if the
+      metric measures a dimensioned quantity (§1.3 & §1.4).
+- [ ] **Name is `snake_case`** with no camelCase or hyphens (§1.5).
+- [ ] **Labels are low-cardinality** — max ~20 unique values per label in normal
+      operation (§2.1).
+- [ ] **No free-form user input in labels** (§2.3).
+- [ ] **Label names** use the standard vocabulary in §2.2 where applicable.
+- [ ] **Metric and each label have a `help` string** that explains what they
+      measure.
+- [ ] **Metric is registered on the shared `registry`** in `shared/metrics.ts`
+      (never on the global default registry).
+- [ ] **Added to [`docs/observability/metrics-catalog.md`](./metrics-catalog.md)**
+      with type, labels, meaning, and which dashboard panel uses it.
+- [ ] **Consider whether an alert rule in
+      [`docker/prometheus/rules.yml`](../../docker/prometheus/rules.yml)
+      is appropriate** for the new metric.

--- a/services/pharmacy-api/__tests__/routes.integration.test.ts
+++ b/services/pharmacy-api/__tests__/routes.integration.test.ts
@@ -1,0 +1,541 @@
+/**
+ * HTTP integration tests for pharmacy-api — Issue #787
+ *
+ * Black-box tests that boot the Express app via supertest and exercise all
+ * 11 route handlers end-to-end: validation, status codes, error bodies, and
+ * the db.ts-backed persistence layer. Each describe block uses an isolated
+ * in-memory SQLite store so tests never share state or touch seed data on disk.
+ */
+
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("../../../shared/x402-middleware.ts", () => ({
+  applyX402Middleware: vi.fn(),
+  NETWORK: "stellar:testnet",
+  OZ_FACILITATOR_URL: "https://example.test/x402",
+}));
+
+const ADMIN_TOKEN = "test-admin-secret";
+const PAY_TO = "GBQTESTPAYTO1";
+
+const { createPharmacyPricingStore } = await import("../db.ts");
+const { createPharmacyApp } = await import("../server.ts");
+
+/** Helper – spin up a fresh in-memory store + app before each test. */
+function makeApp() {
+  const store = createPharmacyPricingStore({ dbPath: ":memory:", seedData: { pharmacies: [], drugs: [], prices: [] } });
+  const { app } = createPharmacyApp({
+    payTo: PAY_TO,
+    adminToken: ADMIN_TOKEN,
+    pricingStore: store,
+    enablePayments: false,
+  });
+  return { app, store };
+}
+
+/** Helper – Bearer header for admin calls. */
+const adminHeader = { Authorization: `Bearer ${ADMIN_TOKEN}` };
+
+// ---------------------------------------------------------------------------
+// GET / — service info
+// ---------------------------------------------------------------------------
+describe("GET /", () => {
+  it("returns 200 with service metadata", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/");
+    expect(res.status).toBe(200);
+    expect(res.body.service).toMatch(/pharmacy/i);
+    expect(res.body.protocol).toMatch(/x402/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /ready
+// ---------------------------------------------------------------------------
+describe("GET /ready", () => {
+  it("returns 200 OK when store is initialised", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/ready");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 503 when the app is draining", async () => {
+    const store = createPharmacyPricingStore({ dbPath: ":memory:", seedData: { pharmacies: [], drugs: [], prices: [] } });
+    const instance = createPharmacyApp({
+      payTo: PAY_TO,
+      adminToken: ADMIN_TOKEN,
+      pricingStore: store,
+      enablePayments: false,
+    });
+    instance.setDraining(true);
+    const res = await request(instance.app).get("/ready");
+    expect(res.status).toBe(503);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown route → 404
+// ---------------------------------------------------------------------------
+describe("unknown routes", () => {
+  it("returns 404 for an unregistered path", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /pharmacy/drugs
+// ---------------------------------------------------------------------------
+describe("GET /pharmacy/drugs", () => {
+  it("returns an empty drugs list when the store has no drugs", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/pharmacy/drugs");
+    expect(res.status).toBe(200);
+    expect(res.body.drugs).toEqual([]);
+    expect(res.body.count).toBe(0);
+  });
+
+  it("lists drugs that were previously created", async () => {
+    const { app } = makeApp();
+    await request(app)
+      .post("/pharmacy/drugs")
+      .set(adminHeader)
+      .send({ name: "metformin", displayName: "Metformin", defaultDosage: "500mg" });
+
+    const res = await request(app).get("/pharmacy/drugs");
+    expect(res.status).toBe(200);
+    expect(res.body.drugs).toHaveLength(1);
+    expect(res.body.drugs[0].name).toBe("metformin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /pharmacy/pharmacies
+// ---------------------------------------------------------------------------
+describe("GET /pharmacy/pharmacies", () => {
+  it("returns an empty pharmacies list when the store has no pharmacies", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/pharmacy/pharmacies");
+    expect(res.status).toBe(200);
+    expect(res.body.pharmacies).toEqual([]);
+  });
+
+  it("lists pharmacies that were previously created", async () => {
+    const { app } = makeApp();
+    await request(app)
+      .post("/pharmacy/pharmacies")
+      .set(adminHeader)
+      .send({ id: "walgreens-001", name: "Walgreens", distanceMiles: 1.2 });
+
+    const res = await request(app).get("/pharmacy/pharmacies");
+    expect(res.status).toBe(200);
+    expect(res.body.pharmacies).toHaveLength(1);
+    expect(res.body.pharmacies[0].id).toBe("walgreens-001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /pharmacy/drugs — admin required
+// ---------------------------------------------------------------------------
+describe("POST /pharmacy/drugs", () => {
+  it("returns 401 without an Authorization header", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/pharmacy/drugs").send({ name: "aspirin" });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/missing admin token/i);
+  });
+
+  it("returns 403 with a wrong token", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/drugs")
+      .set("Authorization", "Bearer wrong-token")
+      .send({ name: "aspirin" });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/invalid admin token/i);
+  });
+
+  it("returns 400 when the body is missing required fields", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/drugs")
+      .set(adminHeader)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when name exceeds max length", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/drugs")
+      .set(adminHeader)
+      .send({ name: "x".repeat(200) });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 201 and the created drug on valid input", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/drugs")
+      .set(adminHeader)
+      .send({ name: "atorvastatin", displayName: "Atorvastatin", defaultDosage: "10mg" });
+    expect(res.status).toBe(201);
+    expect(res.body.drug.name).toBe("atorvastatin");
+    expect(res.body.drug.displayName).toBe("Atorvastatin");
+    expect(res.body.drug.defaultDosage).toBe("10mg");
+  });
+
+  it("upserts (does not duplicate) on a second POST with the same name", async () => {
+    const { app } = makeApp();
+    await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "ibuprofen" });
+    const res = await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "ibuprofen", displayName: "Ibuprofen 400mg" });
+    expect(res.status).toBe(201);
+    const list = await request(app).get("/pharmacy/drugs");
+    expect(list.body.drugs).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /pharmacy/drugs/:drugName — admin required
+// ---------------------------------------------------------------------------
+describe("PUT /pharmacy/drugs/:drugName", () => {
+  it("returns 401 without an Authorization header", async () => {
+    const { app } = makeApp();
+    const res = await request(app).put("/pharmacy/drugs/aspirin").send({ displayName: "Aspirin" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when the body has an invalid field", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put("/pharmacy/drugs/aspirin")
+      .set(adminHeader)
+      .send({ distanceMiles: -1 }); // unknown strict field
+    expect(res.status).toBe(400);
+  });
+
+  it("creates-or-updates a drug and returns 200", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put("/pharmacy/drugs/lisinopril")
+      .set(adminHeader)
+      .send({ displayName: "Lisinopril Updated", defaultDosage: "20mg" });
+    expect(res.status).toBe(200);
+    expect(res.body.drug.name).toBe("lisinopril");
+    expect(res.body.drug.displayName).toBe("Lisinopril Updated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /pharmacy/drugs/:drugName — admin required
+// ---------------------------------------------------------------------------
+describe("DELETE /pharmacy/drugs/:drugName", () => {
+  it("returns 401 without Authorization", async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete("/pharmacy/drugs/lisinopril");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the drug does not exist", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .delete("/pharmacy/drugs/nonexistent-drug")
+      .set(adminHeader);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("returns 204 and removes the drug on success", async () => {
+    const { app } = makeApp();
+    await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "warfarin" });
+    const del = await request(app).delete("/pharmacy/drugs/warfarin").set(adminHeader);
+    expect(del.status).toBe(204);
+    // Confirm it's gone
+    const list = await request(app).get("/pharmacy/drugs");
+    expect(list.body.drugs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /pharmacy/pharmacies — admin required
+// ---------------------------------------------------------------------------
+describe("POST /pharmacy/pharmacies", () => {
+  it("returns 401 without Authorization", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/pharmacy/pharmacies").send({ id: "cvs-001", name: "CVS", distanceMiles: 0.5 });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/pharmacies")
+      .set(adminHeader)
+      .send({ name: "CVS" }); // missing id and distanceMiles
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when distanceMiles is negative", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/pharmacies")
+      .set(adminHeader)
+      .send({ id: "cvs-001", name: "CVS", distanceMiles: -1 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 201 and the created pharmacy on valid input", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/pharmacies")
+      .set(adminHeader)
+      .send({ id: "costco-001", name: "Costco Pharmacy", distanceMiles: 2.1 });
+    expect(res.status).toBe(201);
+    expect(res.body.pharmacy.id).toBe("costco-001");
+    expect(res.body.pharmacy.name).toBe("Costco Pharmacy");
+    expect(res.body.pharmacy.distanceMiles).toBe(2.1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /pharmacy/pharmacies/:pharmacyId — admin required
+// ---------------------------------------------------------------------------
+describe("PUT /pharmacy/pharmacies/:pharmacyId", () => {
+  it("returns 401 without Authorization", async () => {
+    const { app } = makeApp();
+    const res = await request(app).put("/pharmacy/pharmacies/cvs-001").send({ name: "CVS", distanceMiles: 1 });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body has invalid distanceMiles", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put("/pharmacy/pharmacies/cvs-001")
+      .set(adminHeader)
+      .send({ name: "CVS", distanceMiles: 600 }); // exceeds max of 500
+    expect(res.status).toBe(400);
+  });
+
+  it("creates-or-updates a pharmacy and returns 200", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .put("/pharmacy/pharmacies/walgreens-001")
+      .set(adminHeader)
+      .send({ name: "Walgreens Updated", distanceMiles: 3.0 });
+    expect(res.status).toBe(200);
+    expect(res.body.pharmacy.id).toBe("walgreens-001");
+    expect(res.body.pharmacy.name).toBe("Walgreens Updated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /pharmacy/pharmacies/:pharmacyId — admin required
+// ---------------------------------------------------------------------------
+describe("DELETE /pharmacy/pharmacies/:pharmacyId", () => {
+  it("returns 401 without Authorization", async () => {
+    const { app } = makeApp();
+    const res = await request(app).delete("/pharmacy/pharmacies/cvs-001");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the pharmacy does not exist", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .delete("/pharmacy/pharmacies/nonexistent-pharmacy")
+      .set(adminHeader);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("returns 204 and removes the pharmacy on success", async () => {
+    const { app } = makeApp();
+    await request(app).post("/pharmacy/pharmacies").set(adminHeader).send({ id: "rite-aid-001", name: "Rite Aid", distanceMiles: 0.8 });
+    const del = await request(app).delete("/pharmacy/pharmacies/rite-aid-001").set(adminHeader);
+    expect(del.status).toBe(204);
+    const list = await request(app).get("/pharmacy/pharmacies");
+    expect(list.body.pharmacies).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /pharmacy/prices — admin required
+// ---------------------------------------------------------------------------
+describe("POST /pharmacy/prices", () => {
+  it("returns 401 without Authorization", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/pharmacy/prices").send({ drug: "metformin", pharmacyId: "cvs-001", price: 5 });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when the body is empty", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/pharmacy/prices").set(adminHeader).send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when price is zero or negative", async () => {
+    const { app } = makeApp();
+    const res = await request(app)
+      .post("/pharmacy/prices")
+      .set(adminHeader)
+      .send({ drug: "metformin", pharmacyId: "cvs-001", price: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 404 when drug does not exist", async () => {
+    const { app } = makeApp();
+    // Create pharmacy but not the drug
+    await request(app).post("/pharmacy/pharmacies").set(adminHeader).send({ id: "cvs-001", name: "CVS", distanceMiles: 0.5 });
+    const res = await request(app)
+      .post("/pharmacy/prices")
+      .set(adminHeader)
+      .send({ drug: "unknowndrug", pharmacyId: "cvs-001", price: 9.99 });
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 404 when pharmacy does not exist", async () => {
+    const { app } = makeApp();
+    await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "metformin" });
+    const res = await request(app)
+      .post("/pharmacy/prices")
+      .set(adminHeader)
+      .send({ drug: "metformin", pharmacyId: "unknown-pharmacy", price: 9.99 });
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 200 with multi-drug payload and saves the price", async () => {
+    const { app } = makeApp();
+    await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "metformin" });
+    await request(app).post("/pharmacy/pharmacies").set(adminHeader).send({ id: "cvs-001", name: "CVS", distanceMiles: 0.5 });
+    const res = await request(app)
+      .post("/pharmacy/prices")
+      .set(adminHeader)
+      .send({ drug: "metformin", pharmacyId: "cvs-001", price: 12.49 });
+    expect(res.status).toBe(200);
+    expect(res.body.price.price).toBe(12.49);
+    expect(res.body.price.drug).toBe("metformin");
+    expect(res.body.price.pharmacyId).toBe("cvs-001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /pharmacy/compare
+// ---------------------------------------------------------------------------
+describe("GET /pharmacy/compare", () => {
+  /** Helper — seed a drug + 2 pharmacies + prices into the given app. */
+  async function seedCompareData(app: Express.Application) {
+    await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "lisinopril", displayName: "Lisinopril", defaultDosage: "10mg" });
+    await request(app).post("/pharmacy/pharmacies").set(adminHeader).send({ id: "cvs-001", name: "CVS", distanceMiles: 0.5 });
+    await request(app).post("/pharmacy/pharmacies").set(adminHeader).send({ id: "costco-001", name: "Costco", distanceMiles: 2.1 });
+    await request(app).post("/pharmacy/prices").set(adminHeader).send({ drug: "lisinopril", pharmacyId: "cvs-001", price: 15.0 });
+    await request(app).post("/pharmacy/prices").set(adminHeader).send({ drug: "lisinopril", pharmacyId: "costco-001", price: 3.5 });
+  }
+
+  it("returns 400 when drug query param is missing", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/pharmacy/compare").query({ zip: "90210" });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when drug name exceeds 80 characters", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/pharmacy/compare").query({ drug: "x".repeat(81), zip: "90210" });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 404 with NO_PRICES_FOUND for a drug not in the catalog", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/pharmacy/compare").query({ drug: "unknowndrug", zip: "90210" });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ ok: false, reason: "NO_PRICES_FOUND" });
+  });
+
+  it("returns 200 with ranked prices and correct cheapest entry", async () => {
+    const { app } = makeApp();
+    await seedCompareData(app);
+    const res = await request(app).get("/pharmacy/compare").query({ drug: "lisinopril", zip: "90210" });
+    expect(res.status).toBe(200);
+    expect(res.body.cheapest.pharmacyId).toBe("costco-001");
+    expect(res.body.cheapest.price).toBe(3.5);
+    expect(res.body.prices).toHaveLength(2);
+    // Prices should be sorted cheapest first
+    expect(res.body.prices[0].price).toBeLessThanOrEqual(res.body.prices[1].price);
+  });
+
+  it("echoes the zipCode back in the response", async () => {
+    const { app } = makeApp();
+    await seedCompareData(app);
+    const res = await request(app).get("/pharmacy/compare").query({ drug: "lisinopril", zip: "94105" });
+    expect(res.status).toBe(200);
+    expect(res.body.zipCode).toBe("94105");
+    expect(res.body.usedZipCode).toBe(true);
+  });
+
+  it("uses default zip 90210 when zip param is omitted", async () => {
+    const { app } = makeApp();
+    await seedCompareData(app);
+    const res = await request(app).get("/pharmacy/compare").query({ drug: "lisinopril" });
+    expect(res.status).toBe(200);
+    expect(res.body.zipCode).toBe("90210");
+  });
+
+  it("includes potentialSavings and savingsPercent in the response", async () => {
+    const { app } = makeApp();
+    await seedCompareData(app);
+    const res = await request(app).get("/pharmacy/compare").query({ drug: "lisinopril", zip: "90210" });
+    expect(res.status).toBe(200);
+    expect(typeof res.body.potentialSavings).toBe("number");
+    expect(typeof res.body.savingsPercent).toBe("number");
+    expect(res.body.potentialSavings).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end state isolation — no shared state leakage between tests
+// ---------------------------------------------------------------------------
+describe("state isolation between tests", () => {
+  it("test A: creates a drug", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/pharmacy/drugs").set(adminHeader).send({ name: "testdrug" });
+    expect(res.status).toBe(201);
+    const list = await request(app).get("/pharmacy/drugs");
+    expect(list.body.drugs).toHaveLength(1);
+  });
+
+  it("test B: sees an empty store (no bleed-over from test A)", async () => {
+    const { app } = makeApp();
+    const list = await request(app).get("/pharmacy/drugs");
+    expect(list.body.drugs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Admin middleware — no token configured
+// ---------------------------------------------------------------------------
+describe("admin middleware — token not configured", () => {
+  it("returns 503 when PHARMACY_ADMIN_TOKEN is not set and adminToken option is undefined", async () => {
+    const store = createPharmacyPricingStore({ dbPath: ":memory:", seedData: { pharmacies: [], drugs: [], prices: [] } });
+    const { app } = createPharmacyApp({
+      payTo: PAY_TO,
+      adminToken: undefined,
+      pricingStore: store,
+      enablePayments: false,
+    });
+    const res = await request(app).post("/pharmacy/drugs").set("Authorization", "Bearer anything").send({ name: "aspirin" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #774, #775, #776, #787

### #774 — Prometheus alerting rules (rules.yml)
- Added `docker/prometheus/rules.yml` with 10 alert rules grouped into 5 subsystems: agent runs, Stellar tx failures, policy blocks/payment rejections, queue depth saturation, and LLM health
- Each alert has `severity` label, inline threshold rationale, and `runbook_url` annotation

### #775 — Wire rule_files and Alertmanager into prometheus.yml
- Extended `docker/prometheus/prometheus.yml` with `rule_files` loading both `rules.yml` and `recording-rules.yml`
- Documented interim decision: Grafana-managed alerting (no Alertmanager container) with full routing path explanation
- Commented Alertmanager block ready to uncomment when a dedicated instance is deployed

### #776 — Metrics naming conventions guide
- Added `docs/observability/metrics-naming.md` covering: prefix conventions, `_total` counter suffix, base-unit policy, label cardinality limits, standard label vocabulary, and a per-metric audit of `shared/metrics.ts`
- Linked from `CONTRIBUTING.md` (new Observability section) and from `docs/observability/metrics-catalog.md` header

### #787 — HTTP integration tests for pharmacy-api CRUD routes
- Added `services/pharmacy-api/__tests__/routes.integration.test.ts` with **46 tests** via supertest
- Covers all 11 routes: drug CRUD, pharmacy CRUD, POST /pharmacy/prices, GET /pharmacy/compare, GET /ready, unknown routes
- Each test uses an isolated in-memory SQLite store — no shared-state leakage between tests
- Verified: `vitest run` passes 46/46 tests

## What was tested
- `npx vitest run services/pharmacy-api/__tests__/routes.integration.test.ts` → 46 passed
- closes 
- closes #774 
- closes #775 
- closes #776 
- closes #787 