### PR TITLE
docs: add root SECURITY.md for GitHub vulnerability reporting (#760)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Every payment is a real Stellar testnet transaction verifiable on [stellar.exper
 
 For a full runtime flow diagram, module map, and integration details, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
+For deployment topology (Docker Compose and Render), see [docs/deployment/topology.md](docs/deployment/topology.md).
+
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+CareGuard handles real financial transactions on the Stellar network.
+If you discover a security vulnerability, please report it privately before
+disclosing it publicly.
+
+**Do not** open a public GitHub issue for security vulnerabilities.
+
+### How to Report
+
+1. Go to **Security → Advisories → New advisory** in this repository, or
+   open a [private advisory directly](https://github.com/harystyleseze/careguard/security/advisories/new).
+2. Include:
+   - A brief description of the vulnerability
+   - Steps to reproduce or a proof of concept
+   - The affected version(s) and component(s)
+   - Any potential impact you have identified
+
+You can also email the maintainers directly (referenced in
+[CONTRIBUTING.md](CONTRIBUTING.md)).
+
+### What to Expect
+
+- **Acknowledgment** within 48 hours of your report.
+- **Initial assessment** within 5 business days.
+- **Coordinated disclosure**: we will work with you on a timeline for
+  publishing a fix and the advisory. We aim to release a patch within
+  14 days of confirmation for critical issues.
+- **Credit**: reporters are credited in the advisory and changelog unless
+  they prefer to remain anonymous.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | ✅ |
+| Previous release | ⚠️ Security patches only |
+| Older releases | ❌ |
+
+## Scope
+
+This security policy covers the CareGuard server, dashboard, smart contracts,
+and deployment infrastructure. For services hosted by third parties (Stellar
+network, Groq LLM, OpenZeppelin facilitator), refer to their respective
+security policies.
+
+## Threat Model
+
+For a detailed threat model covering LLM prompt injection, spending policy
+controls, Stellar key management, and dependency risks, see
+[docs/SECURITY.md](docs/SECURITY.md).
+
+## Disclosure Timeline
+
+| Phase | Duration |
+|-------|----------|
+| Acknowledgment | ≤ 48 hours |
+| Triage & assessment | ≤ 5 business days |
+| Fix development | ≤ 14 days (critical) |
+| Public disclosure | Coordinated with reporter |

--- a/docs/deployment/render.md
+++ b/docs/deployment/render.md
@@ -52,3 +52,7 @@ node dist/server.js             # starts the server from compiled output
 | Build | `tsc` compiles to `dist/` | `tsx` runtime loads `.ts` directly |
 | Start command | `node dist/server.js` | `node --import tsx server.ts` |
 | Flags needed | None | None (tsx runtime) |
+
+---
+
+For a deployment topology diagram showing how the Render service relates to Redis, external dependencies, and the Docker Compose stack, see [topology.md](topology.md).

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -1,0 +1,123 @@
+# Deployment Topology
+
+## Docker Compose (Local Dev)
+
+The local development stack runs five services on a shared bridge network (`careguard`).
+Persistent data is kept in named Docker volumes.
+
+```mermaid
+graph TB
+  subgraph external["External Dependencies"]
+    H["Horizon RPC<br/>(soroban-testnet.stellar.org)"]
+    OZ["OZ Facilitator<br/>(channels.openzeppelin.com)"]
+    LLM["LLM Provider<br/>(api.groq.com)"]
+  end
+
+  subgraph compose["Docker Compose — careguard network"]
+    subgraph services["Services"]
+      S["server<br/>port 3004<br/>volume: ./data"]
+      D["dashboard<br/>port 3000<br/>Next.js"]
+      R["redis:7-alpine<br/>port 6379<br/>volume: redis-data"]
+      P["prometheus<br/>port 9090<br/>volume: prometheus-data"]
+      G["grafana<br/>port 3030<br/>volume: grafana-data"]
+    end
+
+    S -->|health check| D
+    S -->|rate limit / cache| R
+    S -->|metrics| P
+    P -->|data source| G
+    S -->|HTTP| H
+    S -->|HTTP| OZ
+    S -->|HTTP| LLM
+  end
+
+  style external fill:#f5f5f5,stroke:#999,stroke-dasharray:5 5
+  style compose fill:#e8f4f8,stroke:#333
+```
+
+### Port Map
+
+| Service | Internal Port | Host Port |
+|---------|---------------|-----------|
+| server  | 3004          | 3004      |
+| dashboard | 3000        | 3000      |
+| redis   | 6379          | 6379      |
+| prometheus | 9090      | 9090      |
+| grafana | 3000          | 3030      |
+
+### Persistent Volumes
+
+| Volume | Mount | Purpose |
+|--------|-------|---------|
+| `./data` | `/app/data` | Server data (spending history, audit logs) |
+| `redis-data` | `/data` | Redis append-only persistence |
+| `prometheus-data` | `/prometheus` | Time-series metrics (35d retention) |
+| `grafana-data` | `/var/lib/grafana` | Dashboard configuration |
+
+---
+
+## Render (Production)
+
+The production deployment runs a single `web` service on Render's Node.js runtime.
+Monitoring and caching services are not self-hosted in production; the server
+relies on managed Redis (Render Redis) and external monitoring providers.
+
+```mermaid
+graph TB
+  subgraph external["External Dependencies"]
+    H["Horizon RPC<br/>(soroban-testnet.stellar.org)"]
+    OZ["OZ Facilitator<br/>(x402/testnet)"]
+    LLM["LLM Provider<br/>(api.groq.com / llama-3.3-70b)"]
+    RENDER_REDIS["Render Redis<br/>(managed)"]
+  end
+
+  subgraph render["Render — careguard-api"]
+    S["server (Node.js 22)<br/>port 3004<br/>start: node dist/server.js"]
+  end
+
+  subgraph clients["Clients"]
+    W["Dashboard (Next.js)<br/>hosted separately"]
+  end
+
+  W -->|HTTP :3004| S
+  S -->|cache / rate-limit| RENDER_REDIS
+  S -->|HTTP| H
+  S -->|HTTP| OZ
+  S -->|HTTP| LLM
+
+  style external fill:#f5f5f5,stroke:#999,stroke-dasharray:5 5
+  style render fill:#fef3e2,stroke:#333
+```
+
+### Render Service Properties
+
+| Property | Value |
+|----------|-------|
+| Type | `web` |
+| Runtime | Node.js 22 |
+| Plan | Free |
+| Build | `npm ci && npm run build` |
+| Start | `node dist/server.js` |
+| Health | `/health` |
+
+### Resource Comparison
+
+| Resource | Docker Compose | Render |
+|----------|----------------|--------|
+| Server | Container on `careguard` network | Single `web` service |
+| Dashboard | Container on `careguard` network | Hosted separately |
+| Redis | `redis:7-alpine` container | Managed Render Redis |
+| Prometheus | `prom/prometheus` container | External monitoring |
+| Grafana | `grafana/grafana` container | External monitoring |
+| Persistent storage | Named volumes | Render disk (if configured) |
+
+---
+
+## Service Dependencies
+
+- **server** → redis (caching, rate limiting)
+- **server** → prometheus (metrics export)
+- **dashboard** → server (REST API)
+- **server** → Horizon RPC (Stellar on-chain queries)
+- **server** → OZ Facilitator (x402 payment channels)
+- **server** → LLM Provider (AI-powered interactions)


### PR DESCRIPTION
Closes #760

## Summary
Add a root `SECURITY.md` so GitHub surfaces a Security Policy for the repository, giving external reporters a clear, discoverable disclosure channel.

## Changes

### SECURITY.md (NEW)
- Private reporting via GitHub Security Advisories
- What to include in a report
- Supported versions table (latest, previous, older)
- Coordinated disclosure timeline with SLAs (48h acknowledgment, 5 day triage, 14 day fix for critical)
- Credit policy for reporters
- Links to `docs/SECURITY.md` for the full threat model (does not duplicate it)

## Acceptance Criteria
- [x] SECURITY.md exists at root, detected by GitHub as security policy
- [x] States private reporting channel (GitHub Security Advisories)
- [x] Defines supported versions and coordinated-disclosure expectation
- [x] Links to docs/SECURITY.md for full threat model
- [x] Concise entry point — does not duplicate threat model content

ends #760