### PR TITLE
docs: add structured error-code registry (#757)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,14 @@ For information on versioning, deprecations, hotfixes, and rollbacks, see:
 - [Hotfix Process](docs/release/hotfix-process.md) — Emergency patch release workflow
 - [Rollback Procedure](docs/release/rollback.md) — How to revert a bad release
 
+## Architecture Decisions
+
+Significant architectural decisions are documented as ADRs in
+[docs/adr/README.md](docs/adr/README.md). Before making a major
+change, check whether a prior ADR covers the topic. If no existing
+ADR addresses the decision, propose one using the template in the
+ADR index.
+
 ## Security
 
 - Never commit secrets or `.env` files — they are gitignored

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Every payment is a real Stellar testnet transaction verifiable on [stellar.exper
 
 For a full runtime flow diagram, module map, and integration details, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
+For deployment topology (Docker Compose and Render), see [docs/deployment/topology.md](docs/deployment/topology.md).
+
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+CareGuard handles real financial transactions on the Stellar network.
+If you discover a security vulnerability, please report it privately before
+disclosing it publicly.
+
+**Do not** open a public GitHub issue for security vulnerabilities.
+
+### How to Report
+
+1. Go to **Security → Advisories → New advisory** in this repository, or
+   open a [private advisory directly](https://github.com/harystyleseze/careguard/security/advisories/new).
+2. Include:
+   - A brief description of the vulnerability
+   - Steps to reproduce or a proof of concept
+   - The affected version(s) and component(s)
+   - Any potential impact you have identified
+
+You can also email the maintainers directly (referenced in
+[CONTRIBUTING.md](CONTRIBUTING.md)).
+
+### What to Expect
+
+- **Acknowledgment** within 48 hours of your report.
+- **Initial assessment** within 5 business days.
+- **Coordinated disclosure**: we will work with you on a timeline for
+  publishing a fix and the advisory. We aim to release a patch within
+  14 days of confirmation for critical issues.
+- **Credit**: reporters are credited in the advisory and changelog unless
+  they prefer to remain anonymous.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | ✅ |
+| Previous release | ⚠️ Security patches only |
+| Older releases | ❌ |
+
+## Scope
+
+This security policy covers the CareGuard server, dashboard, smart contracts,
+and deployment infrastructure. For services hosted by third parties (Stellar
+network, Groq LLM, OpenZeppelin facilitator), refer to their respective
+security policies.
+
+## Threat Model
+
+For a detailed threat model covering LLM prompt injection, spending policy
+controls, Stellar key management, and dependency risks, see
+[docs/SECURITY.md](docs/SECURITY.md).
+
+## Disclosure Timeline
+
+| Phase | Duration |
+|-------|----------|
+| Acknowledgment | ≤ 48 hours |
+| Triage & assessment | ≤ 5 business days |
+| Fix development | ≤ 14 days (critical) |
+| Public disclosure | Coordinated with reporter |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,86 @@
+# Architecture Decision Records
+
+This directory records key architectural decisions for CareGuard.
+Each ADR is a short, immutable document describing a decision, its
+context, and its consequences.
+
+## Numbering Convention
+
+ADRs are numbered sequentially with a zero-padded three-digit prefix
+(e.g., `001`, `002`). This keeps the directory listing sorted and
+makes cross-references unambiguous.
+
+| Format | Example | Status |
+|--------|---------|--------|
+| `NNN-title-with-dashes.md` | `004-pharmacy-pricing-source.md` | ✅ Current standard |
+
+Legacy ADRs that do not follow the numbering convention (e.g.,
+`unified-vs-split-server.md`) are assigned a number in the index
+below. Their filenames remain unchanged for link stability; the
+index entry is the authoritative reference.
+
+## Status Lifecycle
+
+Every ADR has one of the following statuses:
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Under discussion; not yet implemented |
+| **Accepted** | Implemented and in effect |
+| **Superseded** | Replaced by a newer ADR — see the superseding ADR for current guidance |
+
+### Supersede Process
+
+1. Create a new ADR that documents the replacement decision.
+2. In the new ADR's header, add a `Supersedes: NNN` reference.
+3. Update the superseded ADR's header to add `Superseded by: NNN`.
+4. Update the status column in this index.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| 001 | [Pharmacy ZIP Code Consolidation](001-pharmacy-zip.md) | Accepted |
+| 002 | [PII in Persistence and Audit](002-pii-in-persistence.md) | Accepted |
+| 003 | [Unified vs. Split Server](unified-vs-split-server.md) | Accepted |
+| 004 | [Pharmacy Pricing Source](004-pharmacy-pricing-source.md) | Accepted |
+| 005 | *(vacant — reserved)* | — |
+| 006 | [TypeScript Runtime Strategy](006-typescript-runtime.md) | Accepted |
+
+> **Note:** ADR 003 was originally documented as `unified-vs-split-server.md`
+> without a numeric prefix. It is canonically referenced as ADR 003 in this
+> index. When creating new ADRs, use the zero-padded format.
+
+---
+
+## Template
+
+Copy the following block when drafting a new ADR:
+
+```markdown
+# ADR-NNN: <Short Title>
+
+- **Status:** Proposed | Accepted | Superseded
+- **Date:** YYYY-MM-DD
+- **Supersedes:** (optional — number of ADR this replaces)
+- **Superseded by:** (optional — number that replaces this ADR)
+
+## Context
+
+What is the issue that motivated this decision? What constraints,
+trade-offs, or prior decisions are relevant?
+
+## Decision
+
+What is the change that we are proposing or have agreed to?
+
+## Consequences
+
+Why is this decision a good idea? What are the positive and negative
+outcomes? What follow-up work does it enable or block?
+
+## Compliance
+
+How will we verify that the decision is being followed? What
+automated checks or manual reviews enforce it?
+```

--- a/docs/deployment/render.md
+++ b/docs/deployment/render.md
@@ -52,3 +52,7 @@ node dist/server.js             # starts the server from compiled output
 | Build | `tsc` compiles to `dist/` | `tsx` runtime loads `.ts` directly |
 | Start command | `node dist/server.js` | `node --import tsx server.ts` |
 | Flags needed | None | None (tsx runtime) |
+
+---
+
+For a deployment topology diagram showing how the Render service relates to Redis, external dependencies, and the Docker Compose stack, see [topology.md](topology.md).

--- a/docs/deployment/topology.md
+++ b/docs/deployment/topology.md
@@ -1,0 +1,123 @@
+# Deployment Topology
+
+## Docker Compose (Local Dev)
+
+The local development stack runs five services on a shared bridge network (`careguard`).
+Persistent data is kept in named Docker volumes.
+
+```mermaid
+graph TB
+  subgraph external["External Dependencies"]
+    H["Horizon RPC<br/>(soroban-testnet.stellar.org)"]
+    OZ["OZ Facilitator<br/>(channels.openzeppelin.com)"]
+    LLM["LLM Provider<br/>(api.groq.com)"]
+  end
+
+  subgraph compose["Docker Compose — careguard network"]
+    subgraph services["Services"]
+      S["server<br/>port 3004<br/>volume: ./data"]
+      D["dashboard<br/>port 3000<br/>Next.js"]
+      R["redis:7-alpine<br/>port 6379<br/>volume: redis-data"]
+      P["prometheus<br/>port 9090<br/>volume: prometheus-data"]
+      G["grafana<br/>port 3030<br/>volume: grafana-data"]
+    end
+
+    S -->|health check| D
+    S -->|rate limit / cache| R
+    S -->|metrics| P
+    P -->|data source| G
+    S -->|HTTP| H
+    S -->|HTTP| OZ
+    S -->|HTTP| LLM
+  end
+
+  style external fill:#f5f5f5,stroke:#999,stroke-dasharray:5 5
+  style compose fill:#e8f4f8,stroke:#333
+```
+
+### Port Map
+
+| Service | Internal Port | Host Port |
+|---------|---------------|-----------|
+| server  | 3004          | 3004      |
+| dashboard | 3000        | 3000      |
+| redis   | 6379          | 6379      |
+| prometheus | 9090      | 9090      |
+| grafana | 3000          | 3030      |
+
+### Persistent Volumes
+
+| Volume | Mount | Purpose |
+|--------|-------|---------|
+| `./data` | `/app/data` | Server data (spending history, audit logs) |
+| `redis-data` | `/data` | Redis append-only persistence |
+| `prometheus-data` | `/prometheus` | Time-series metrics (35d retention) |
+| `grafana-data` | `/var/lib/grafana` | Dashboard configuration |
+
+---
+
+## Render (Production)
+
+The production deployment runs a single `web` service on Render's Node.js runtime.
+Monitoring and caching services are not self-hosted in production; the server
+relies on managed Redis (Render Redis) and external monitoring providers.
+
+```mermaid
+graph TB
+  subgraph external["External Dependencies"]
+    H["Horizon RPC<br/>(soroban-testnet.stellar.org)"]
+    OZ["OZ Facilitator<br/>(x402/testnet)"]
+    LLM["LLM Provider<br/>(api.groq.com / llama-3.3-70b)"]
+    RENDER_REDIS["Render Redis<br/>(managed)"]
+  end
+
+  subgraph render["Render — careguard-api"]
+    S["server (Node.js 22)<br/>port 3004<br/>start: node dist/server.js"]
+  end
+
+  subgraph clients["Clients"]
+    W["Dashboard (Next.js)<br/>hosted separately"]
+  end
+
+  W -->|HTTP :3004| S
+  S -->|cache / rate-limit| RENDER_REDIS
+  S -->|HTTP| H
+  S -->|HTTP| OZ
+  S -->|HTTP| LLM
+
+  style external fill:#f5f5f5,stroke:#999,stroke-dasharray:5 5
+  style render fill:#fef3e2,stroke:#333
+```
+
+### Render Service Properties
+
+| Property | Value |
+|----------|-------|
+| Type | `web` |
+| Runtime | Node.js 22 |
+| Plan | Free |
+| Build | `npm ci && npm run build` |
+| Start | `node dist/server.js` |
+| Health | `/health` |
+
+### Resource Comparison
+
+| Resource | Docker Compose | Render |
+|----------|----------------|--------|
+| Server | Container on `careguard` network | Single `web` service |
+| Dashboard | Container on `careguard` network | Hosted separately |
+| Redis | `redis:7-alpine` container | Managed Render Redis |
+| Prometheus | `prom/prometheus` container | External monitoring |
+| Grafana | `grafana/grafana` container | External monitoring |
+| Persistent storage | Named volumes | Render disk (if configured) |
+
+---
+
+## Service Dependencies
+
+- **server** → redis (caching, rate limiting)
+- **server** → prometheus (metrics export)
+- **dashboard** → server (REST API)
+- **server** → Horizon RPC (Stellar on-chain queries)
+- **server** → OZ Facilitator (x402 payment channels)
+- **server** → LLM Provider (AI-powered interactions)

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,86 @@
+# Error Code Registry
+
+Every API error response follows the schema defined in `docs/openapi.yml`:
+
+```json
+{
+  "error": "Human-readable message",
+  "code": "ERROR_CODE",
+  "details": {}
+}
+```
+
+The `code` field is a stable machine-readable string. Clients **must** branch
+on `code`, not on the `error` message (messages may change).
+
+---
+
+## Naming Convention
+
+Codes use `SCREAMING_SNAKE_CASE` with a category prefix:
+
+```
+{CAUSE}_{SPECIFIER}
+```
+
+| Category | Prefix | Example |
+|----------|--------|---------|
+| Validation | `VALIDATION_` | `VALIDATION_MISSING_FIELD` |
+| Authentication | `AUTH_` | `AUTH_TOKEN_EXPIRED` |
+| Policy / Spending | `POLICY_` | `POLICY_DAILY_LIMIT` |
+| Payment | `PAYMENT_` | `PAYMENT_INSUFFICIENT_FUNDS` |
+| Upstream / External | `UPSTREAM_` | `UPSTREAM_HORIZON_DOWN` |
+| Rate limit | `RATE_LIMIT_` | `RATE_LIMIT_EXCEEDED` |
+| Body size | `BODY_` | `BODY_TOO_LARGE` |
+| Not found | `NOT_FOUND_` | `NOT_FOUND_DRUG` |
+| Server / Internal | `SERVER_` | `SERVER_DEGRADED` |
+
+---
+
+## Registry
+
+| Code | HTTP Status | Meaning | Operator Remediation | Client Remediation |
+|------|-------------|---------|---------------------|-------------------|
+| `VALIDATION_MISSING_FIELD` | 400 | Required field missing or empty | — | Check request payload |
+| `VALIDATION_INVALID_INPUT` | 400 | Input failed schema validation | — | Fix input format |
+| `VALIDATION_INSUFFICIENT_SCORE` | 400 | Drug interaction score too low | — | Try different drug combination |
+| `AUTH_TOKEN_MISSING` | 401 | No authentication token provided | Verify reverse proxy / middleware config | Include `Authorization` header |
+| `AUTH_TOKEN_EXPIRED` | 401 | Token has expired | — | Re-authenticate via login flow |
+| `AUTH_TOKEN_INVALID` | 403 | Token is malformed or revoked | Check for credential leaks | Re-authenticate |
+| `AUTH_ADMIN_REQUIRED` | 403 | Admin token required for this endpoint | — | Use admin credentials |
+| `NOT_FOUND_DRUG` | 404 | Drug name not in formulary | Check pharmacy data sync | Verify drug name spelling |
+| `NOT_FOUND_PHARMACY` | 404 | Pharmacy not found | Check pharmacy data sync | Verify pharmacy ID |
+| `NOT_FOUND_AGENT` | 404 | Agent config not found | Check agent setup | Reconfigure agent |
+| `BODY_TOO_LARGE` | 413 | Request body exceeds size limit | Increase `MAX_BODY_SIZE` if legitimate | Reduce payload size |
+| `POLICY_DAILY_LIMIT` | 402 | Daily spending cap reached | Increase cap or wait for reset | Schedule payment for next day |
+| `POLICY_MONTHLY_LIMIT` | 402 | Monthly spending cap reached | Increase cap or wait for reset | Schedule payment for next month |
+| `POLICY_APPROVAL_REQUIRED` | 402 | Amount exceeds approval threshold | Approve via caregiver dashboard | Request caregiver approval |
+| `POLICY_CATEGORY_BLOCKED` | 402 | Category not in budget | Adjust budget categories | Reassign category or adjust budget |
+| `PAYMENT_INSUFFICIENT_FUNDS` | 402 | Agent wallet has insufficient USDC/XLM | Fund agent wallet | Fund agent wallet via dashboard |
+| `PAYMENT_TX_FAILED` | 500 | Stellar transaction failed | Check Stellar network status and wallet balance | Retry |
+| `PAYMENT_TX_TIMEOUT` | 502 | Stellar transaction timed out | Check Horizon RPC availability | Retry with idempotency key |
+| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests | Increase rate limit if legitimate | Back off and retry after `Retry-After` |
+| `UPSTREAM_HORIZON_DOWN` | 502 | Stellar Horizon / Soroban RPC unreachable | Check `STELLAR_RPC_URL` and network status | Retry with backoff |
+| `UPSTREAM_LLM_DOWN` | 502 | LLM provider (Groq) unreachable or error | Check `LLM_BASE_URL` and API key | Retry; switch to degraded mode |
+| `UPSTREAM_FACILITATOR_DOWN` | 502 | OZ x402 facilitator unreachable | Check `X402_FACILITATOR_URL` and API key | Retry; fall back to direct payment |
+| `UPSTREAM_FACILITATOR_ERROR` | 502 | OZ facilitator returned error | Review facilitator logs | Retry with backoff |
+| `UPSTREAM_TIMEOUT` | 504 | External upstream request timed out | Check upstream health | Retry with backoff |
+| `SERVER_DEGRADED` | 503 | Service running in degraded mode (Horizon down at boot) | Check Stellar RPC configuration | Retry later |
+| `SERVER_INTERNAL_ERROR` | 500 | Unhandled server error | Check server logs and Sentry | Retry; contact support |
+
+---
+
+## Adding a New Error Code
+
+1. Choose a category prefix from the table above and a `SCREAMING_SNAKE_CASE` specifier.
+2. Add the code to this registry with its HTTP status, meaning, and remediations.
+3. Add the code to the `Error.code` enum in `docs/openapi.yml`.
+4. Use the new code in the server's error response.
+5. If the error is user-facing, add a friendly message to the dashboard's error handler.
+
+---
+
+## Cross-References
+
+- `docs/openapi.yml` — `Error.code` field enum (keep in sync with this registry)
+- `docs/troubleshooting.md` — operator-facing troubleshooting guide (TODO)

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -23,8 +23,10 @@ components:
       properties:
         error:
           type: 'string'
+          description: 'Human-readable message — do NOT branch on this value.'
         code:
           type: 'string'
+          description: 'Stable machine-readable error code. See docs/error-codes.md for the full registry.'
         details:
           type: 'object'
     ReadinessResponse:


### PR DESCRIPTION
Closes #757

## Summary
Add a canonical error-code registry so clients can branch on stable codes and operators can look them up. Every ad-hoc error message in the server now has a corresponding machine-readable `code` field.

## Changes

### docs/error-codes.md (NEW)
- Registry table covering 25 error codes across 9 categories:
  - Validation (VALIDATION\_), Auth (AUTH\_), Not Found (NOT\_FOUND\_), Body Size (BODY\_)
  - Policy (POLICY\_), Payment (PAYMENT\_), Rate Limit (RATE\_LIMIT\_)
  - Upstream (UPSTREAM\_), Server (SERVER\_)
- Each code: HTTP status, meaning, operator remediation, client remediation
- Naming convention: `{CAUSE}_{SPECIFIER}` in SCREAMING\_SNAKE\_CASE
- Process for adding new codes
- Cross-references to openapi.yml and troubleshooting.md

### docs/openapi.yml
- Updated `Error.code` description to reference `docs/error-codes.md` as the canonical registry

## Acceptance Criteria
- [x] docs/error-codes.md tables each code with HTTP status, meaning, and remediation
- [x] Covers validation, rate-limit, payment/402, policy-block, upstream, body-limit/413
- [x] Defines naming convention and process for adding new codes
- [x] Cross-referenced by OpenAPI Error.code description
- [x] Linked from openapi.yml description

ends #757