### PR TITLE
docs: fix #758 document typed error-response envelope

### DIFF
--- a/docs/api/error-schema.md
+++ b/docs/api/error-schema.md
@@ -1,0 +1,105 @@
+# CareGuard API Error Response Schema
+
+This document defines the stable schema contract for all JSON error responses returned by CareGuard services (agent, pharmacy, bill audit, drug interactions, payments).
+
+## The Error Envelope
+
+Every API error response is formatted as a single JSON object containing standard properties. This contract allows frontends, client SDKs, and external consumers to handle errors consistently.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `error` | `string` | **Yes** | A user-friendly, descriptive message outlining what went wrong and how it can be mitigated. |
+| `code` | `string` | **Yes** | A stable, machine-readable alphanumeric code (uppercase `SNAKE_CASE`) representing the specific error type. |
+| `details` | `object` | No | Additional structured context specific to the error code. For validation failures, this property contains field-level issues. |
+
+---
+
+## Validation Error Structure
+
+For validation errors (HTTP 400 with code `VALIDATION_ERROR`), the `details` field is structured to provide clear, actionable feedback on input parameters.
+
+The `details` object contains a `fields` mapping where:
+- Keys are strings representing the JSON path or parameter name (e.g. `lineItems.0.quantity`).
+- Values are arrays of strings containing the specific constraint violations (e.g., `["quantity must be positive"]`).
+
+---
+
+## HTTP Status Contract
+
+### Envelope Contract (Standard API Errors)
+The following HTTP status codes are guaranteed to carry the standardized `{ error, code, details }` JSON envelope when returned by CareGuard microservices:
+- **`400 Bad Request`**: Validation errors, malformed payloads, or invalid parameters.
+- **`402 Payment Required`**: The request requires a Stellar x402 or MPP payment challenge.
+- **`403 Forbidden`**: CSRF token mismatches, key restrictions, or unauthorized admin requests.
+- **`404 Not Found`**: Non-existent drugs, recipients, orders, or routes.
+- **`409 Conflict`**: Operations violating active state constraints (e.g., trying to run tasks while the agent is paused).
+- **`429 Too Many Requests`**: Rate limits exceeded.
+- **`500 Internal Server Error`**: Unexpected database or service exceptions.
+- **`503 Service Unavailable`**: Degradation of required external dependencies (e.g., Horizon network down, OZ Facilitator unreachable).
+
+### Raw Responses Contract (Exceptions)
+Clients should anticipate raw (non-envelope) responses in the following infrastructure and transport scenarios:
+1. **Infrastructure/Proxy Errors**: A `502 Bad Gateway`, `504 Gateway Timeout`, or `503 Service Unavailable` generated directly by a load balancer, reverse proxy (Nginx, Render routing layer), or Cloudflare. These return raw HTML or text.
+2. **Payload Size Limits**: If a request exceeds server body size limits (HTTP `413 Payload Too Large`), Express's `body-parser` layer returns a raw error structure (e.g., `{ error: "Request body too large", limit: "..." }`) before reaching application routing.
+3. **Health & Readiness Probes**: Endpoint `/health` and `/ready` return simple text status (`"OK"`) or custom JSON objects representing liveness checks (`ReadinessResponse`), not error envelopes.
+
+---
+
+## Example Payloads
+
+### 1. Validation Error (400 Bad Request)
+Returned when payload validation fails against schemas (e.g., Zod).
+
+```json
+{
+  "error": "Request validation failed",
+  "code": "VALIDATION_ERROR",
+  "details": {
+    "fields": {
+      "lineItems.0.quantity": [
+        "quantity must be positive"
+      ],
+      "lineItems.0.chargedAmount": [
+        "chargedAmount must be positive"
+      ]
+    }
+  }
+}
+```
+
+### 2. Payment Required Challenge (402 Payment Required)
+Returned for paid query or transaction routes that implement the x402 payment protocol.
+
+> [!NOTE]
+> Standard x402 middleware implementations (such as `@x402/express` used in this codebase) respond with an empty body (`{}`) and instead transmit the base64-encoded payment requirements via the `Payment-Required` HTTP response header. The JSON structure shown below represents the parsed representation of that header metadata used by client libraries and SDKs.
+
+```json
+{
+  "error": "Payment required via x402 protocol",
+  "code": "PAYMENT_REQUIRED",
+  "details": {
+    "scheme": "exact",
+    "network": "stellar:testnet",
+    "payTo": "GBV5W3XYZABC1234567890FGHIJKLMNOPQRSTUVW123",
+    "price": "0.0100000",
+    "asset": "USDC"
+  }
+}
+```
+
+### 3. Policy Block (403 Forbidden or 409 Conflict)
+Returned when an agent task or manual expenditure violates a budget rule or limit configured in the recipient's spending policy.
+
+```json
+{
+  "error": "Transaction exceeds monthly medication budget limit",
+  "code": "POLICY_BLOCKED",
+  "details": {
+    "rule": "medicationMonthlyBudget",
+    "limit": 300.00,
+    "currentUsage": 290.00,
+    "requestedAmount": 20.00,
+    "recipient": "Rosa Garcia"
+  }
+}
+```

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,67 @@
+# CareGuard API Error Codes Registry
+
+This registry lists the stable, machine-readable `code` strings returned in CareGuard JSON error responses.
+
+| Error Code | HTTP Status | Description | Details Payload |
+|------------|-------------|-------------|-----------------|
+| `VALIDATION_ERROR` | 400 Bad Request | The request payload failed schema validation (e.g., Zod checks). | Mapping of invalid fields to arrays of validation messages under `fields`. |
+| `PAYMENT_REQUIRED` | 402 Payment Required | The requested route is paid and requires payment verification via x402 or MPP protocols. | Contains scheme, network, recipient wallet (`payTo`), asset, and price. |
+| `POLICY_BLOCKED` | 400 Bad Request / 403 Forbidden / 409 Conflict | The action violates a spending policy limit or rule (e.g., exceeding budget). | Contains standard limit, rule name, requested amount, current usage, and recipient info. |
+| `UNAUTHORIZED` | 401 Unauthorized | Missing or invalid auth header (e.g. Bearer Token) or missing/expired caregiver credentials. | None. |
+| `FORBIDDEN` | 403 Forbidden | CSRF token mismatch, invalid admin credentials, or insufficient permissions. | None. |
+| `NOT_FOUND` | 404 Not Found | The requested resource (recipient, transaction, drug, price record, or route) was not found. | None. |
+| `AGENT_PAUSED` | 409 Conflict | The transaction or run cannot proceed because the CareGuard agent is currently paused. | `paused: true` and optionally `pausedReason`. |
+| `RATE_LIMIT_EXCEEDED` | 429 Too Many Requests | The client has exceeded rate limiting quotas. | None. |
+| `INTERNAL_SERVER_ERROR` | 500 Internal Server Error | An unexpected server or database error occurred. | None. |
+| `SERVICE_UNAVAILABLE` | 503 Service Unavailable | A critical dependency (e.g. SQLite, Redis, Horizon, OZ Facilitator) is degraded or unreachable. | List of failing checks (e.g. `{"checks": {"horizon": false}}`). |
+
+---
+
+## Detailed Error Code Specifications
+
+### 1. `VALIDATION_ERROR`
+Indicates input parameter or payload schema mismatch.
+* **Details Structure**:
+  ```json
+  {
+    "fields": {
+      "fieldName.subField": ["Error message 1", "Error message 2"]
+    }
+  }
+  ```
+
+### 2. `PAYMENT_REQUIRED`
+Returned when query fees or transaction execution costs must be paid using USDC on Stellar.
+* **Details Structure**:
+  ```json
+  {
+    "scheme": "exact",
+    "network": "stellar:testnet",
+    "payTo": "G...",
+    "price": "0.0100000",
+    "asset": "USDC"
+  }
+  ```
+
+### 3. `POLICY_BLOCKED`
+Returned when a request is blocked because it exceeds spending limits or budgets.
+* **Details Structure**:
+  ```json
+  {
+    "rule": "medicationMonthlyBudget",
+    "limit": 300,
+    "currentUsage": 295,
+    "requestedAmount": 10,
+    "recipient": "Rosa Garcia"
+  }
+  ```
+
+### 4. `AGENT_PAUSED`
+Returned when trying to post tasks or execute actions while the coordinator agent is paused.
+* **Details Structure**:
+  ```json
+  {
+    "paused": true,
+    "pausedReason": "Caregiver manual pause"
+  }
+  ```

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -20,13 +20,19 @@ components:
   schemas:
     Error:
       type: 'object'
+      required:
+        - error
+        - code
       properties:
         error:
           type: 'string'
+          description: 'A human-readable description of the error.'
         code:
           type: 'string'
+          description: 'A stable, machine-readable uppercase SNAKE_CASE code identifying the specific type of error.'
         details:
           type: 'object'
+          description: 'Structured metadata or field-level details specific to the error code.'
     ReadinessResponse:
       type: 'object'
       description: 'See docs/observability/health-checks.md for the full schema and check semantics.'
@@ -49,6 +55,49 @@ components:
               oneOf:
                 - type: 'boolean'
                 - type: 'string'
+  responses:
+    BadRequestError:
+      description: 'Bad Request / Validation Error'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    UnauthorizedError:
+      description: 'Missing or invalid authentication credentials'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ForbiddenError:
+      description: 'Forbidden access (e.g., CSRF token mismatch, invalid admin credentials)'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFoundError:
+      description: 'Requested resource not found'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    PaymentRequiredError:
+      description: 'Payment required (x402 / MPP Challenge)'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ConflictError:
+      description: 'Conflict / State violation (e.g., Agent is paused)'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: 'Internal server error'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
 paths:
   /health:
     get:
@@ -106,6 +155,12 @@ paths:
                     type: 'number'
                   categories:
                     type: 'object'
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+        403:
+          $ref: '#/components/responses/ForbiddenError'
+        500:
+          $ref: '#/components/responses/InternalServerError'
   /pharmacy/compare:
     get:
       summary: 'Compare pharmacy prices for a drug'
@@ -142,7 +197,9 @@ paths:
         200:
           description: 'Pharmacy query results'
         400:
-          description: 'Invalid request'
+          $ref: '#/components/responses/BadRequestError'
+        402:
+          $ref: '#/components/responses/PaymentRequiredError'
   /pharmacy/prices:
     post:
       summary: 'Admin upsert for a drug price at a pharmacy'
@@ -175,7 +232,11 @@ paths:
         200:
           description: 'Price created or updated'
         400:
-          description: 'Validation error'
+          $ref: '#/components/responses/BadRequestError'
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+        403:
+          $ref: '#/components/responses/ForbiddenError'
   /bill/audit:
     post:
       summary: 'Audit medical bills'
@@ -221,14 +282,9 @@ paths:
         200:
           description: 'Audit results'
         400:
-          description: 'Validation error'
-          content:
-            application/json:
-              schema:
-                type: 'object'
-                properties:
-                  errors:
-                    type: 'array'
+          $ref: '#/components/responses/BadRequestError'
+        402:
+          $ref: '#/components/responses/PaymentRequiredError'
   /drug/interactions:
     get:
       summary: 'Check drug interactions for a medication list'
@@ -250,7 +306,9 @@ paths:
         200:
           description: 'Drug interaction results'
         400:
-          description: 'Validation error'
+          $ref: '#/components/responses/BadRequestError'
+        402:
+          $ref: '#/components/responses/PaymentRequiredError'
   /pharmacy/order:
     post:
       summary: 'Submit a paid pharmacy order'
@@ -285,9 +343,9 @@ paths:
         200:
           description: 'Order confirmed'
         400:
-          description: 'Validation error'
+          $ref: '#/components/responses/BadRequestError'
         402:
-          description: 'Payment required'
+          $ref: '#/components/responses/PaymentRequiredError'
   /docs:
     get:
       summary: 'API documentation UI'

--- a/scripts/gen-openapi.ts
+++ b/scripts/gen-openapi.ts
@@ -65,6 +65,7 @@ interface OpenAPISpec {
       };
     };
     schemas: Record<string, Record<string, unknown>>;
+    responses?: Record<string, Record<string, unknown>>;
   };
   paths: Record<string, OpenAPIPath>;
 }
@@ -118,10 +119,20 @@ function generateSpec(): OpenAPISpec {
       schemas: {
         Error: {
           type: "object",
+          required: ["error", "code"],
           properties: {
-            error: { type: "string" },
-            code: { type: "string" },
-            details: { type: "object" },
+            error: {
+              type: "string",
+              description: "A human-readable description of the error.",
+            },
+            code: {
+              type: "string",
+              description: "A stable, machine-readable uppercase SNAKE_CASE code identifying the specific type of error.",
+            },
+            details: {
+              type: "object",
+              description: "Structured metadata or field-level details specific to the error code.",
+            },
           },
         },
         ReadinessResponse: {
@@ -137,6 +148,64 @@ function generateSpec(): OpenAPISpec {
                 horizon: { type: "boolean" },
                 ozFacilitator: { oneOf: [{ type: "boolean" }, { type: "string" }] },
               },
+            },
+          },
+        },
+      },
+      responses: {
+        BadRequestError: {
+          description: "Bad Request / Validation Error",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
+            },
+          },
+        },
+        UnauthorizedError: {
+          description: "Missing or invalid authentication credentials",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
+            },
+          },
+        },
+        ForbiddenError: {
+          description: "Forbidden access (e.g., CSRF token mismatch, invalid admin credentials)",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
+            },
+          },
+        },
+        NotFoundError: {
+          description: "Requested resource not found",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
+            },
+          },
+        },
+        PaymentRequiredError: {
+          description: "Payment required (x402 / MPP Challenge)",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
+            },
+          },
+        },
+        ConflictError: {
+          description: "Conflict / State violation (e.g., Agent is paused)",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
+            },
+          },
+        },
+        InternalServerError: {
+          description: "Internal server error",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/Error" },
             },
           },
         },
@@ -209,6 +278,9 @@ function generateSpec(): OpenAPISpec {
                 },
               },
             },
+            "401": { $ref: "#/components/responses/UnauthorizedError" },
+            "403": { $ref: "#/components/responses/ForbiddenError" },
+            "500": { $ref: "#/components/responses/InternalServerError" },
           },
         },
       },
@@ -256,7 +328,10 @@ function generateSpec(): OpenAPISpec {
               description: "Pharmacy query results",
             },
             "400": {
-              description: "Invalid request",
+              $ref: "#/components/responses/BadRequestError",
+            },
+            "402": {
+              $ref: "#/components/responses/PaymentRequiredError",
             },
           },
         },
@@ -298,7 +373,13 @@ function generateSpec(): OpenAPISpec {
               description: "Price created or updated",
             },
             "400": {
-              description: "Validation error",
+              $ref: "#/components/responses/BadRequestError",
+            },
+            "401": {
+              $ref: "#/components/responses/UnauthorizedError",
+            },
+            "403": {
+              $ref: "#/components/responses/ForbiddenError",
             },
           },
         },
@@ -352,17 +433,10 @@ function generateSpec(): OpenAPISpec {
               description: "Audit results",
             },
             "400": {
-              description: "Validation error",
-              content: {
-                "application/json": {
-                  schema: {
-                    type: "object",
-                    properties: {
-                      errors: { type: "array" },
-                    },
-                  },
-                },
-              },
+              $ref: "#/components/responses/BadRequestError",
+            },
+            "402": {
+              $ref: "#/components/responses/PaymentRequiredError",
             },
           },
         },
@@ -391,7 +465,10 @@ function generateSpec(): OpenAPISpec {
               description: "Drug interaction results",
             },
             "400": {
-              description: "Validation error",
+              $ref: "#/components/responses/BadRequestError",
+            },
+            "402": {
+              $ref: "#/components/responses/PaymentRequiredError",
             },
           },
         },
@@ -434,10 +511,10 @@ function generateSpec(): OpenAPISpec {
               description: "Order confirmed",
             },
             "400": {
-              description: "Validation error",
+              $ref: "#/components/responses/BadRequestError",
             },
             "402": {
-              description: "Payment required",
+              $ref: "#/components/responses/PaymentRequiredError",
             },
           },
         },


### PR DESCRIPTION
Closes #758 

This Pull Request formalizes and documents the standard JSON error-response envelope returned by all CareGuard microservices. Prior to this change, clients received varying JSON error bodies, and the envelope contract was not documented as a stable interface, resulting in loose and fragile parsing in the caregiver dashboard.

## Changed
- **docs/api/error-schema.md**: Created the stable error envelope documentation, validation error details structure, HTTP status contract, and example error payloads.
- **docs/error-codes.md**: Created the error code registry detailing stable code names, HTTP status codes, descriptions, and detail objects.
- **docs/openapi.yml**: Modified `components.schemas.Error` to define required fields and added componentized responses (`BadRequestError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError`, `PaymentRequiredError`, `ConflictError`, `InternalServerError`) across all path definitions.
- **scripts/gen-openapi.ts**: Modified the dynamic schema compiler to generate components.responses and updated endpoint definitions to match the openapi.yml components.