### PR TITLE
Feat/api docs and stellar retry tests

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -1,0 +1,38 @@
+name: OpenAPI
+
+on:
+  pull_request:
+    paths:
+      - "docs/openapi.yml"
+      - "scripts/gen-openapi.ts"
+      - "scripts/validate-openapi.ts"
+      - "shared/api-docs.ts"
+      - ".github/workflows/openapi.yml"
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate OpenAPI spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      # Structure, YAML shape, and drift against scripts/gen-openapi.ts.
+      # Fails when docs/openapi.yml is malformed or was not regenerated.
+      - name: Validate spec structure and freshness
+        run: npm run validate:openapi
+
+      # Full OpenAPI 3.1 conformance lint. Runs from the registry so no
+      # dependency is added to package.json.
+      - name: Lint spec against OpenAPI 3.1
+        run: npx --yes @redocly/cli@1 lint docs/openapi.yml --format=stylish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,20 @@ For information on versioning, deprecations, hotfixes, and rollbacks, see:
 - ESLint + Prettier (run `npm run lint` before pushing)
 - Keep services self-contained; shared code goes in `shared/`
 
+## API Changes
+
+HTTP endpoints are described by [`docs/openapi.yml`](docs/openapi.yml), rendered
+at `/docs` on the running server (<http://localhost:3000/docs> locally). The spec
+is **generated** — never edit the YAML by hand:
+
+1. Change the endpoint definition in [`scripts/gen-openapi.ts`](scripts/gen-openapi.ts)
+2. Run `npm run gen-openapi` and commit the regenerated `docs/openapi.yml`
+3. Run `npm run validate:openapi` — CI runs the same check plus a full OpenAPI
+   3.1 lint, and fails on a malformed or out-of-date spec
+
+See [`docs/api/README.md`](docs/api/README.md) for how the docs are hosted, how
+CI validates the spec, and how the x402 `X-PAYMENT` auth scheme behaves.
+
 ## Observability
 
 When adding or modifying metrics, follow the conventions in

--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ See [docs/observability/health-checks.md](docs/observability/health-checks.md) f
 
 ---
 
+## API Documentation
+
+The OpenAPI 3.1 spec is rendered as an interactive reference by the unified server:
+
+| What | Local | Production |
+|------|-------|------------|
+| Interactive reference | <http://localhost:3000/docs> | <https://api.careguard.xyz/docs> |
+| Raw spec | <http://localhost:3000/openapi.yml> | <https://api.careguard.xyz/openapi.yml> |
+
+The spec is generated (`npm run gen-openapi`), never hand-edited, and validated in
+CI (`npm run validate:openapi`). See [docs/api/README.md](docs/api/README.md) for the
+hosting setup, CI validation, and how the x402 `X-PAYMENT` auth scheme works.
+
+---
+
 ## Running Tests
 
 ```bash

--- a/agent/__tests__/fee-bump-doubling.test.ts
+++ b/agent/__tests__/fee-bump-doubling.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Fee-bump envelope doubling tests (Issue #795).
+ *
+ * submitTransactionWithFeeBump answers a tx_insufficient_fee by doubling the fee
+ * and resubmitting the transaction inside a fee-bump envelope. These tests pin
+ * the doubling sequence, the attempt cap, the MAX_FEE_STROOPS clamp, who signs
+ * the envelope, and that a non-fee error is never wrapped.
+ *
+ * Horizon is mocked, and an injected RetryClock keeps the suite free of real sleeps.
+ */
+
+const { mockLoadAccount, mockSubmitTransaction, mockBuildFeeBump, builtTransactions, MOCK_HINT } =
+  vi.hoisted(() => {
+    process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+    process.env.BILL_PROVIDER_PUBLIC_KEY = "GBQTESTBILLPROVIDER";
+    const MOCK_HINT = Buffer.from([0xca, 0xfe, 0xba, 0xbe]);
+    return {
+      mockLoadAccount: vi.fn(),
+      mockSubmitTransaction: vi.fn(),
+      mockBuildFeeBump: vi.fn(),
+      // Every inner transaction the builder produces, in build order.
+      builtTransactions: [] as any[],
+      MOCK_HINT,
+    };
+  });
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("fs", () => ({
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("@stellar/stellar-sdk", () => {
+  const TransactionBuilderMock: any = vi.fn().mockImplementation((_source: any, opts: any) => ({
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockImplementation(() => {
+      const tx = {
+        kind: "inner",
+        fee: opts?.fee,
+        sign: vi.fn(),
+        signatures: [{ hint: vi.fn().mockReturnValue(MOCK_HINT) }],
+      };
+      builtTransactions.push(tx);
+      return tx;
+    }),
+  }));
+  TransactionBuilderMock.buildFeeBumpTransaction = mockBuildFeeBump;
+
+  return {
+    Keypair: {
+      fromSecret: vi.fn().mockReturnValue({
+        publicKey: () => "GPUB123",
+        sign: vi.fn(),
+        signatureHint: vi.fn().mockReturnValue(MOCK_HINT),
+      }),
+    },
+    Networks: { TESTNET: "Test SDF Network ; September 2015" },
+    TransactionBuilder: TransactionBuilderMock,
+    Operation: { payment: vi.fn() },
+    Asset: vi.fn(),
+    Horizon: {
+      Server: vi.fn().mockReturnValue({
+        loadAccount: mockLoadAccount,
+        submitTransaction: mockSubmitTransaction,
+      }),
+    },
+  };
+});
+vi.mock("@x402/stellar", () => ({
+  createEd25519Signer: vi.fn().mockReturnValue({}),
+  ExactStellarScheme: vi.fn(),
+}));
+vi.mock("@x402/fetch", () => ({
+  wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
+  x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }),
+  decodePaymentResponseHeader: vi.fn(),
+}));
+vi.mock("@stellar/mpp/charge/client", () => ({ stellar: vi.fn().mockReturnValue({}) }));
+vi.mock("mppx/client", () => ({ Mppx: { create: vi.fn().mockReturnValue({ fetch: vi.fn() }) } }));
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  submitTransactionWithFeeBump,
+  FEE_BUMP_MAX_ATTEMPTS,
+  type RetryClock,
+} from "../tools.ts";
+
+const MAX_FEE_STROOPS = 100_000; // matches the MAX_FEE_STROOPS default in tools.ts
+const mockAccount = { id: "GPUB123", sequence: "1" };
+const mockServer = { loadAccount: mockLoadAccount, submitTransaction: mockSubmitTransaction } as any;
+const signer = { publicKey: () => "GPUB123", sign: () => {} } as any;
+
+function horizonError(code: string) {
+  const err: any = new Error("Request failed with status code 400");
+  err.response = {
+    status: 400,
+    data: { extras: { result_codes: { transaction: code } } },
+  };
+  return err;
+}
+
+function makeFakeClock(startAt = 0) {
+  let now = startAt;
+  const clock: RetryClock = {
+    now: () => now,
+    sleep: async (ms: number) => {
+      now += ms;
+    },
+  };
+  return { clock };
+}
+
+/** Fees passed to buildFeeBumpTransaction, in call order. */
+function feeBumpFees(): string[] {
+  return mockBuildFeeBump.mock.calls.map((call: any[]) => call[1]);
+}
+
+beforeEach(() => {
+  mockLoadAccount.mockReset();
+  mockSubmitTransaction.mockReset();
+  mockBuildFeeBump.mockReset();
+  builtTransactions.length = 0;
+  mockLoadAccount.mockResolvedValue(mockAccount);
+  mockBuildFeeBump.mockImplementation(() => ({ kind: "feeBump", sign: vi.fn() }));
+});
+
+describe("submitTransactionWithFeeBump — doubling schedule (Issue #795)", () => {
+  it("wraps the inner tx in a fee-bump envelope at exactly double the prior fee", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockResolvedValueOnce({ hash: "hash-bumped" });
+
+    const result = await submitTransactionWithFeeBump(
+      mockServer, mockAccount, [{}], signer, "100", clock,
+    );
+
+    expect(result).toEqual({ hash: "hash-bumped", fee: "200" });
+    expect(feeBumpFees()).toEqual(["200"]);
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("doubles again when the first fee bump is still too cheap", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockResolvedValueOnce({ hash: "hash-second-bump" });
+
+    const result = await submitTransactionWithFeeBump(
+      mockServer, mockAccount, [{}], signer, "100", clock,
+    );
+
+    expect(result.fee).toBe("400");
+    expect(feeBumpFees()).toEqual(["200", "400"]);
+  });
+
+  it("submits exactly once per step of the doubling schedule", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockRejectedValue(horizonError("tx_insufficient_fee"));
+
+    await expect(
+      submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock),
+    ).rejects.toMatchObject({
+      response: { data: { extras: { result_codes: { transaction: "tx_insufficient_fee" } } } },
+    });
+
+    // Base attempt + one submission per fee bump.
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(FEE_BUMP_MAX_ATTEMPTS);
+    expect(feeBumpFees()).toEqual(["200", "400"]);
+
+    const innerFees = builtTransactions.map((tx) => tx.fee);
+    expect(innerFees).toEqual(["100", "200", "400"]);
+  });
+
+  it("stops at the attempt cap and surfaces the final failure instead of retrying forever", async () => {
+    const { clock } = makeFakeClock();
+    const finalError = horizonError("tx_insufficient_fee");
+    mockSubmitTransaction.mockRejectedValue(finalError);
+
+    await expect(
+      submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock),
+    ).rejects.toBe(finalError);
+
+    expect(mockSubmitTransaction.mock.calls.length).toBe(FEE_BUMP_MAX_ATTEMPTS);
+    expect(mockBuildFeeBump.mock.calls.length).toBe(FEE_BUMP_MAX_ATTEMPTS - 1);
+  });
+
+  it("clamps the doubled fee at MAX_FEE_STROOPS", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockResolvedValueOnce({ hash: "hash-clamped" });
+
+    // 80_000 doubled is 160_000, above the 100_000 cap.
+    const result = await submitTransactionWithFeeBump(
+      mockServer, mockAccount, [{}], signer, "80000", clock,
+    );
+
+    expect(result.fee).toBe(String(MAX_FEE_STROOPS));
+    expect(feeBumpFees()).toEqual([String(MAX_FEE_STROOPS)]);
+  });
+});
+
+describe("submitTransactionWithFeeBump — envelope signing", () => {
+  it("signs the envelope with the agent keypair as fee source", async () => {
+    const { clock } = makeFakeClock();
+    const envelope = { kind: "feeBump", sign: vi.fn() };
+    mockBuildFeeBump.mockReturnValue(envelope);
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockResolvedValueOnce({ hash: "hash-signed" });
+
+    await submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock);
+
+    const [feeSource, fee, inner, passphrase] = mockBuildFeeBump.mock.calls[0];
+    expect(feeSource).toBe(signer);
+    expect(fee).toBe("200");
+    expect(inner.kind).toBe("inner");
+    expect(passphrase).toBeDefined();
+    expect(envelope.sign).toHaveBeenCalledWith(signer);
+  });
+
+  it("preserves the inner transaction's own signature", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockResolvedValueOnce({ hash: "hash-inner-signed" });
+
+    await submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock);
+
+    const inner = mockBuildFeeBump.mock.calls[0][2];
+    expect(inner.sign).toHaveBeenCalledWith(signer);
+    expect(inner.signatures).toHaveLength(1);
+  });
+
+  it("submits the envelope, not the bare inner transaction", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_insufficient_fee"))
+      .mockResolvedValueOnce({ hash: "hash-envelope" });
+
+    await submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock);
+
+    expect(mockSubmitTransaction.mock.calls[0][0].kind).toBe("inner");
+    expect(mockSubmitTransaction.mock.calls[1][0].kind).toBe("feeBump");
+  });
+});
+
+describe("submitTransactionWithFeeBump — non-fee errors", () => {
+  it("propagates tx_bad_auth immediately without wrapping it", async () => {
+    const { clock } = makeFakeClock();
+    const authError = horizonError("tx_bad_auth");
+    mockSubmitTransaction.mockRejectedValue(authError);
+
+    await expect(
+      submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock),
+    ).rejects.toBe(authError);
+
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+    expect(mockBuildFeeBump).not.toHaveBeenCalled();
+  });
+
+  it("propagates tx_insufficient_balance without a fee bump", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockRejectedValue(horizonError("tx_insufficient_balance"));
+
+    await expect(
+      submitTransactionWithFeeBump(mockServer, mockAccount, [{}], signer, "100", clock),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    expect(mockBuildFeeBump).not.toHaveBeenCalled();
+  });
+
+  it("returns the first success without ever building an envelope", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockResolvedValueOnce({ hash: "hash-first-try" });
+
+    const result = await submitTransactionWithFeeBump(
+      mockServer, mockAccount, [{}], signer, "100", clock,
+    );
+
+    expect(result).toEqual({ hash: "hash-first-try", fee: "100" });
+    expect(mockBuildFeeBump).not.toHaveBeenCalled();
+  });
+});

--- a/agent/__tests__/tx-bad-seq-retry.test.ts
+++ b/agent/__tests__/tx-bad-seq-retry.test.ts
@@ -1,0 +1,331 @@
+/**
+ * tx_bad_seq account-reload retry tests (Issue #796).
+ *
+ * A Stellar sequence-number collision is the normal outcome of two payments
+ * racing from the same wallet. The only recovery is to reload the account,
+ * rebuild the envelope with the fresh sequence, and resubmit — so these tests
+ * pin that the reload happens, that it happens *only* for sequence errors, and
+ * that the loop stays inside the 35s budget instead of spinning.
+ *
+ * An injected RetryClock replaces the 1s backoff sleeps, so the suite runs fast.
+ */
+
+const { mockLoadAccount, mockSubmitTransaction, MOCK_HINT } = vi.hoisted(() => {
+  process.env.AGENT_SECRET_KEY = "SBWWZYCAFDDJXNRRMKSFNRB6OTVZHTCMPUCVZ4FBZLSPHFKHYLPRTJCD";
+  process.env.BILL_PROVIDER_PUBLIC_KEY = "GBQTESTBILLPROVIDER";
+  const MOCK_HINT = Buffer.from([0xca, 0xfe, 0xba, 0xbe]);
+  return {
+    mockLoadAccount: vi.fn(),
+    mockSubmitTransaction: vi.fn(),
+    MOCK_HINT,
+  };
+});
+
+vi.mock("dotenv/config", () => ({}));
+vi.mock("fs", () => ({
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+}));
+vi.mock("@stellar/stellar-sdk", () => ({
+  Keypair: {
+    fromSecret: vi.fn().mockReturnValue({
+      publicKey: () => "GPUB123",
+      sign: vi.fn(),
+      signatureHint: vi.fn().mockReturnValue(MOCK_HINT),
+    }),
+  },
+  Networks: { TESTNET: "Test SDF Network ; September 2015" },
+  TransactionBuilder: Object.assign(
+    vi.fn().mockReturnValue({
+      addOperation: vi.fn().mockReturnThis(),
+      setTimeout: vi.fn().mockReturnThis(),
+      build: vi.fn().mockReturnValue({
+        sign: vi.fn(),
+        signatures: [{ hint: vi.fn().mockReturnValue(MOCK_HINT) }],
+      }),
+    }),
+    { buildFeeBumpTransaction: vi.fn().mockReturnValue({ sign: vi.fn() }) },
+  ),
+  Operation: { payment: vi.fn() },
+  Asset: vi.fn(),
+  Horizon: {
+    Server: vi.fn().mockReturnValue({
+      loadAccount: mockLoadAccount,
+      submitTransaction: mockSubmitTransaction,
+    }),
+  },
+}));
+vi.mock("@x402/stellar", () => ({
+  createEd25519Signer: vi.fn().mockReturnValue({}),
+  ExactStellarScheme: vi.fn(),
+}));
+vi.mock("@x402/fetch", () => ({
+  wrapFetchWithPayment: vi.fn().mockReturnValue(vi.fn()),
+  x402Client: vi.fn().mockReturnValue({ register: vi.fn().mockReturnThis() }),
+  decodePaymentResponseHeader: vi.fn(),
+}));
+vi.mock("@stellar/mpp/charge/client", () => ({ stellar: vi.fn().mockReturnValue({}) }));
+vi.mock("mppx/client", () => ({ Mppx: { create: vi.fn().mockReturnValue({ fetch: vi.fn() }) } }));
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  submitTransactionWithRetry,
+  RetryBudgetExceededError,
+  type RetryClock,
+} from "../tools.ts";
+
+const BUDGET_MS = 35_000;
+const mockServer = { loadAccount: mockLoadAccount, submitTransaction: mockSubmitTransaction } as any;
+
+/** A Horizon-shaped failure: HTTP 400 with the result code in extras. */
+function horizonError(code: string) {
+  const err: any = new Error(`Request failed with status code 400`);
+  err.response = {
+    status: 400,
+    data: { extras: { result_codes: { transaction: code } } },
+  };
+  return err;
+}
+
+/** A fake clock whose sleep() advances simulated time instead of really waiting. */
+function makeFakeClock(startAt = 0) {
+  let now = startAt;
+  const clock: RetryClock = {
+    now: () => now,
+    sleep: async (ms: number) => {
+      now += ms;
+    },
+  };
+  return { clock, current: () => now };
+}
+
+/**
+ * A rebuild closure shaped like the real one in submitTransactionWithFeeBump:
+ * it reloads the account and returns an envelope carrying that sequence.
+ */
+function makeRebuild() {
+  return async () => {
+    const account = await mockServer.loadAccount("GPUB123");
+    return { sequence: account.sequence, kind: "rebuilt" };
+  };
+}
+
+beforeEach(() => {
+  mockLoadAccount.mockReset();
+  mockSubmitTransaction.mockReset();
+  let sequence = 100;
+  // Each reload observes the ledger having moved on.
+  mockLoadAccount.mockImplementation(async () => ({
+    id: "GPUB123",
+    sequence: String(++sequence),
+  }));
+});
+
+describe("submitTransactionWithRetry — tx_bad_seq (Issue #796)", () => {
+  it("reloads the account and resubmits with the refreshed sequence", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_bad_seq"))
+      .mockResolvedValueOnce({ hash: "hash-after-reload" });
+
+    const result = await submitTransactionWithRetry(
+      mockServer,
+      { sequence: "100", kind: "original" },
+      2,
+      35_000,
+      makeRebuild(),
+      undefined,
+      clock,
+    );
+
+    expect(result.hash).toBe("hash-after-reload");
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(2);
+
+    // The resubmit must carry the rebuilt envelope, not the stale one.
+    const resubmitted = mockSubmitTransaction.mock.calls[1][0];
+    expect(resubmitted.kind).toBe("rebuilt");
+    expect(resubmitted.sequence).toBe("101");
+  });
+
+  it("keeps reloading across repeated collisions until one lands", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_bad_seq"))
+      .mockRejectedValueOnce(horizonError("tx_bad_seq"))
+      .mockResolvedValueOnce({ hash: "hash-third-try" });
+
+    const result = await submitTransactionWithRetry(
+      mockServer,
+      { sequence: "100" },
+      2,
+      35_000,
+      makeRebuild(),
+      undefined,
+      clock,
+    );
+
+    expect(result.hash).toBe("hash-third-try");
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+    expect(mockSubmitTransaction.mock.calls[2][0].sequence).toBe("102");
+  });
+
+  it("surfaces the failure after the sequence retries are exhausted, without looping unbounded", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockRejectedValue(horizonError("tx_bad_seq"));
+
+    await expect(
+      submitTransactionWithRetry(
+        mockServer,
+        { sequence: "100" },
+        2,
+        35_000,
+        makeRebuild(),
+        undefined,
+        clock,
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    // 1 initial + at most 3 sequence retries.
+    expect(mockSubmitTransaction.mock.calls.length).toBeLessThanOrEqual(4);
+    expect(mockLoadAccount.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it("two concurrent payments from the same wallet both settle", async () => {
+    // Horizon accepts one sequence number once; the loser of the race gets
+    // tx_bad_seq and must recover rather than failing permanently.
+    const consumed = new Set<string>();
+    mockSubmitTransaction.mockImplementation(async (tx: any) => {
+      if (consumed.has(tx.sequence)) throw horizonError("tx_bad_seq");
+      consumed.add(tx.sequence);
+      return { hash: `hash-seq-${tx.sequence}` };
+    });
+
+    const clockA = makeFakeClock().clock;
+    const clockB = makeFakeClock().clock;
+
+    const [first, second] = await Promise.all([
+      submitTransactionWithRetry(
+        mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), undefined, clockA,
+      ),
+      submitTransactionWithRetry(
+        mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), undefined, clockB,
+      ),
+    ]);
+
+    expect(first.hash).toBeDefined();
+    expect(second.hash).toBeDefined();
+    expect(first.hash).not.toBe(second.hash);
+  });
+
+  it("stops at the retry budget instead of resubmitting past it", async () => {
+    const { clock, current } = makeFakeClock();
+    // Every submit burns 15s, so the third one cannot fit in the 35s budget.
+    mockSubmitTransaction.mockImplementation(async () => {
+      await clock.sleep(15_000);
+      throw horizonError("tx_bad_seq");
+    });
+
+    const deadlineAt = clock.now() + BUDGET_MS;
+
+    await expect(
+      submitTransactionWithRetry(
+        mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), deadlineAt, clock,
+      ),
+    ).rejects.toThrow(RetryBudgetExceededError);
+
+    expect(current()).toBeLessThanOrEqual(BUDGET_MS + 15_000);
+  });
+
+  it("does not reload the account when no rebuild function is available", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockRejectedValue(horizonError("tx_bad_seq"));
+
+    await expect(
+      submitTransactionWithRetry(
+        mockServer, { sequence: "100" }, 2, 35_000, undefined, undefined, clock,
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    expect(mockLoadAccount).not.toHaveBeenCalled();
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("submitTransactionWithRetry — timebound codes are handled distinctly", () => {
+  it("tx_too_late rebuilds with fresh timebounds and resubmits", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(horizonError("tx_too_late"))
+      .mockResolvedValueOnce({ hash: "hash-fresh-timebounds" });
+
+    const result = await submitTransactionWithRetry(
+      mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), undefined, clock,
+    );
+
+    expect(result.hash).toBe("hash-fresh-timebounds");
+    expect(mockSubmitTransaction.mock.calls[1][0].kind).toBe("rebuilt");
+  });
+
+  it("tx_too_early propagates immediately — no reload, no retry", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockRejectedValue(horizonError("tx_too_early"));
+
+    await expect(
+      submitTransactionWithRetry(
+        mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), undefined, clock,
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    expect(mockLoadAccount).not.toHaveBeenCalled();
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("submitTransactionWithRetry — non-sequence failures never reload", () => {
+  it("tx_bad_auth propagates immediately without a reload", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction.mockRejectedValue(horizonError("tx_bad_auth"));
+
+    await expect(
+      submitTransactionWithRetry(
+        mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), undefined, clock,
+      ),
+    ).rejects.toMatchObject({ response: { status: 400 } });
+
+    expect(mockLoadAccount).not.toHaveBeenCalled();
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("a network timeout backs off and retries the same envelope, without reloading", async () => {
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(new Error("ETIMEDOUT"))
+      .mockResolvedValueOnce({ hash: "hash-after-backoff" });
+
+    const result = await submitTransactionWithRetry(
+      mockServer, { sequence: "100", kind: "original" }, 2, 35_000, makeRebuild(), undefined, clock,
+    );
+
+    expect(result.hash).toBe("hash-after-backoff");
+    expect(mockLoadAccount).not.toHaveBeenCalled();
+    expect(mockSubmitTransaction.mock.calls[1][0].kind).toBe("original");
+  });
+
+  it("recognises tx_bad_seq reported only in the error message", async () => {
+    // Some SDK paths surface the code in the message with no Horizon envelope.
+    const { clock } = makeFakeClock();
+    mockSubmitTransaction
+      .mockRejectedValueOnce(new Error("tx_bad_seq"))
+      .mockResolvedValueOnce({ hash: "hash-message-path" });
+
+    const result = await submitTransactionWithRetry(
+      mockServer, { sequence: "100" }, 2, 35_000, makeRebuild(), undefined, clock,
+    );
+
+    expect(result.hash).toBe("hash-message-path");
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -223,6 +223,22 @@ export function extractX402TxHash(
   return TX_HASH_EXTRACTION_FAILED;
 }
 
+/**
+ * Read a Stellar transaction result code from a Horizon error.
+ *
+ * Horizon reports failures as `extras.result_codes.transaction` on a 400
+ * response; only some SDK/network paths surface the code in `err.message`.
+ * Matching on the message alone missed every real Horizon rejection (issue #796),
+ * so both are checked.
+ */
+function getTxResultCode(err: any): string {
+  return err?.response?.data?.extras?.result_codes?.transaction ?? "";
+}
+
+function isTxResultCode(err: any, code: string): boolean {
+  return getTxResultCode(err) === code || String(err?.message ?? "").includes(code);
+}
+
 // Helper: submitTransaction with timeout and retry
 export async function submitTransactionWithRetry(
   server: Horizon.Server,
@@ -243,11 +259,22 @@ export async function submitTransactionWithRetry(
       return result;
     } catch (err: any) {
       lastError = err;
-      if (err?.response?.status) throw err;
-      const msg = err?.message ?? "";
+
+      const isBadSeq = isTxResultCode(err, "tx_bad_seq");
+      const isTooLate = isTxResultCode(err, "tx_too_late");
+      const isTooEarly = isTxResultCode(err, "tx_too_early");
+
+      // Horizon errors carry an HTTP status; only the sequence/timebound codes
+      // below are recoverable, everything else propagates untouched.
+      if (err?.response?.status && !isBadSeq && !isTooLate && !isTooEarly) throw err;
+
+      // tx_too_early: the transaction is not yet valid. Rebuilding cannot help —
+      // a fresh envelope has the same lower timebound — so surface it distinctly
+      // rather than burning retries or reloading the account.
+      if (isTooEarly) throw err;
 
       // tx_bad_seq: sequence number mismatch — reload account and rebuild with 1 s backoff
-      if (msg.includes("tx_bad_seq") && rebuildTx) {
+      if (isBadSeq && rebuildTx) {
         for (let seqRetry = 0; seqRetry < 3; seqRetry++) {
           if (deadlineAt !== undefined && clock.now() >= deadlineAt) {
             throw new RetryBudgetExceededError(FEE_BUMP_BUDGET_MS);
@@ -271,19 +298,22 @@ export async function submitTransactionWithRetry(
             return result;
           } catch (retryErr: any) {
             lastError = retryErr;
-            if (!retryErr?.message?.includes("tx_bad_seq")) throw retryErr;
+            if (!isTxResultCode(retryErr, "tx_bad_seq")) throw retryErr;
           }
         }
         throw lastError;
       }
 
       // tx_too_late: timebounds expired — retry once with fresh timebounds if rebuild fn provided
-      if (msg.includes("tx_too_late") && rebuildTx && attempt < maxRetries) {
+      if (isTooLate && rebuildTx && attempt < maxRetries) {
         logger.warn({ attempt: attempt + 1 }, "[Stellar] tx_too_late, rebuilding with fresh timebounds");
         tx = await rebuildTx();
         continue;
       }
-      if (msg.includes("tx_bad_seq") || msg.includes("tx_too_early") || msg.includes("tx_too_late")) throw err;
+      // A sequence/timebound failure with no way to recover (no rebuild fn, or
+      // retries exhausted) is terminal — never fall through to the generic
+      // backoff, which would resubmit the same doomed envelope.
+      if (isBadSeq || isTooEarly || isTooLate) throw err;
       if (attempt < maxRetries) {
         const delay = Math.pow(2, attempt) * 500;
         if (deadlineAt !== undefined && clock.now() + delay >= deadlineAt) {
@@ -301,7 +331,15 @@ export async function submitTransactionWithRetry(
 }
 
 // Helper: submit transaction with automatic fee bump on insufficient_fee error.
-// Wraps retries in fee-bump envelopes, doubling the fee each time (up to 3x max).
+//
+// Attempt 1 submits a plain transaction at the recommended fee. Each
+// tx_insufficient_fee doubles the fee (capped at MAX_FEE_STROOPS) and resubmits
+// the transaction wrapped in a fee-bump envelope, for at most FEE_BUMP_MAX_ATTEMPTS
+// submissions in total. When the last allowed attempt still fails, that failure
+// is surfaced — the loop never retries indefinitely. Non-fee errors are never
+// wrapped and propagate on the spot.
+export const FEE_BUMP_MAX_ATTEMPTS = 3;
+
 export async function submitTransactionWithFeeBump(
   server: Horizon.Server,
   account: any,
@@ -312,87 +350,75 @@ export async function submitTransactionWithFeeBump(
 ): Promise<{ hash: string; fee: string }> {
   let currentFee = initialFee || await getRecommendedFee();
   let attempt = 0;
-  const maxAttempts = 3; // up to 3 fee bumps
   const deadlineAt = clock.now() + FEE_BUMP_BUDGET_MS;
 
-  while (attempt < maxAttempts) {
+  const buildInner = (source: any) => {
+    const builder = new TransactionBuilder(source, {
+      fee: currentFee,
+      networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+    });
+    for (const op of operations) {
+      builder.addOperation(op);
+    }
+    const built = builder.setTimeout(30).build();
+    built.sign(signer);
+    return built;
+  };
+
+  while (attempt < FEE_BUMP_MAX_ATTEMPTS) {
     if (clock.now() >= deadlineAt) {
       throw new RetryBudgetExceededError(FEE_BUMP_BUDGET_MS);
     }
+
+    const isFeeBumpAttempt = attempt > 0;
+
     try {
-      const tx = new TransactionBuilder(account, {
-        fee: currentFee,
-        networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
-      });
+      const innerTx = buildInner(account);
 
-      for (const op of operations) {
-        tx.addOperation(op);
-      }
-
-      const builtTx = tx.setTimeout(30).build();
-      builtTx.sign(signer);
-
-      const result = await submitTransactionWithRetry(server, builtTx, 2, 35000, async () => {
-        const freshAccount = await server.loadAccount(signer.publicKey());
-        const newTx = new TransactionBuilder(freshAccount, {
-          fee: currentFee,
-          networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
-        });
-        for (const op of operations) {
-          newTx.addOperation(op);
-        }
-        const rebuilt = newTx.setTimeout(30).build();
-        rebuilt.sign(signer);
-        return rebuilt;
-      }, deadlineAt, clock);
-      return { hash: result.hash, fee: currentFee };
-    } catch (err: any) {
-      if (err instanceof RetryBudgetExceededError) throw err;
-      const resultCodes = err?.response?.data?.extras?.result_codes;
-      const isFeeError = resultCodes?.transaction === 'tx_insufficient_fee';
-
-      if (isFeeError && clock.now() >= deadlineAt) {
-        throw new RetryBudgetExceededError(FEE_BUMP_BUDGET_MS);
-      }
-
-      if (isFeeError && attempt < maxAttempts - 1) {
-        // Double the fee and wrap in a fee-bump envelope
-        const newFee = Math.min(parseInt(currentFee) * 2, MAX_FEE_STROOPS);
-        logger.warn(
-          { oldFee: currentFee, newFee, attempt: attempt + 1 },
-          '[Stellar] Insufficient fee, wrapping in fee-bump envelope',
-        );
-        currentFee = newFee.toString();
-        stellarFeeBumpsTotal.inc();
-        attempt++;
-
-        // Build the inner transaction with the new fee
-        const innerTx = new TransactionBuilder(account, {
-          fee: currentFee,
-          networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
-        });
-        for (const op of operations) {
-          innerTx.addOperation(op);
-        }
-        const builtInner = innerTx.setTimeout(30).build();
-        builtInner.sign(signer);
-
-        // Wrap in fee-bump envelope: feeSource is the agent wallet itself
-        const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
-          signer,
-          currentFee,
-          builtInner,
-          STELLAR_NETWORK_PASSPHRASE,
-        );
-        feeBumpTx.sign(signer);
-
-        const result = await submitTransactionWithRetry(
-          server, feeBumpTx as any, 2, 35000, undefined, deadlineAt, clock,
-        );
+      if (!isFeeBumpAttempt) {
+        // First attempt: a plain envelope, rebuildable on a sequence collision.
+        const result = await submitTransactionWithRetry(server, innerTx, 2, 35000, async () => {
+          const freshAccount = await server.loadAccount(signer.publicKey());
+          return buildInner(freshAccount);
+        }, deadlineAt, clock);
         return { hash: result.hash, fee: currentFee };
       }
 
-      throw err;
+      // Fee-bump attempt: the inner transaction keeps its own signature and the
+      // agent keypair signs the envelope as fee source. A fee-bump envelope
+      // cannot be rebuilt mid-flight, so no rebuild fn is passed.
+      const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+        signer,
+        currentFee,
+        innerTx,
+        STELLAR_NETWORK_PASSPHRASE,
+      );
+      feeBumpTx.sign(signer);
+
+      const result = await submitTransactionWithRetry(
+        server, feeBumpTx as any, 2, 35000, undefined, deadlineAt, clock,
+      );
+      return { hash: result.hash, fee: currentFee };
+    } catch (err: any) {
+      if (err instanceof RetryBudgetExceededError) throw err;
+
+      // Only an insufficient fee is worth bumping; anything else (tx_bad_auth,
+      // tx_bad_seq that already exhausted its own retries, …) propagates.
+      if (!isTxResultCode(err, "tx_insufficient_fee")) throw err;
+
+      attempt++;
+      if (attempt >= FEE_BUMP_MAX_ATTEMPTS) throw err;
+      if (clock.now() >= deadlineAt) {
+        throw new RetryBudgetExceededError(FEE_BUMP_BUDGET_MS);
+      }
+
+      const newFee = Math.min(parseInt(currentFee, 10) * 2, MAX_FEE_STROOPS);
+      logger.warn(
+        { oldFee: currentFee, newFee, attempt },
+        '[Stellar] Insufficient fee, wrapping in fee-bump envelope',
+      );
+      currentFee = newFee.toString();
+      stellarFeeBumpsTotal.inc();
     }
   }
 

--- a/docs/adr/unified-vs-split-server.md
+++ b/docs/adr/unified-vs-split-server.md
@@ -36,7 +36,15 @@ Each route now has its own rate-limit bucket (configured in `shared/rate-limit.t
 | `RATE_LIMIT_DRUG_INTERACTIONS` | 30 req/min | `GET /drug/interactions` |
 | `RATE_LIMIT_PHARMACY_ORDER` | 10 req/min | `POST /pharmacy/order` |
 
-A `route_concurrent_requests{route}` Prometheus gauge is also emitted so operators can observe in-flight concurrency per route and alert on sustained saturation.
+An env value that is not a positive integer (empty, `abc`, `0`, `-5`, `2.5`) is
+ignored and the default in the table above applies — a typo must not silently
+disable limiting for a route.
+
+Rejected requests get `429` with a `Retry-After` header (window length in
+seconds) and are counted on `ratelimit_hits_total{policy}`, labelled per policy
+so one route's rejections are never attributed to another.
+
+A `route_concurrent_requests{route}` Prometheus gauge is also emitted so operators can observe in-flight concurrency per route and alert on sustained saturation. Express fires both `finish` and `close` for most responses, so the decrement is latched — the gauge counts each request exactly once and cannot drift negative.
 
 ### Long-term: split into per-service containers behind a gateway
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,140 @@
+# API Documentation Hosting
+
+How the CareGuard OpenAPI spec is generated, served, viewed, and validated.
+
+## Where the docs live
+
+| What | URL | Source |
+| --- | --- | --- |
+| Interactive reference | `GET /docs` | [shared/api-docs.ts](../../shared/api-docs.ts) |
+| Raw OpenAPI 3.1 spec | `GET /openapi.yml` | [docs/openapi.yml](../openapi.yml) |
+
+Both routes are mounted on the unified server ([server.ts](../../server.ts)), so they
+follow whatever host that process is deployed to:
+
+- Local: <http://localhost:3000/docs> (spec at <http://localhost:3000/openapi.yml>)
+- Docker dev: <http://localhost:3004/docs>
+- Production: <https://api.careguard.xyz/docs>
+
+Neither route requires authentication or payment — the reference has to be
+readable before anyone can pay for an endpoint.
+
+## Hosting approach
+
+The reference is rendered by [Scalar API Reference](https://github.com/scalar/scalar),
+loaded from a pinned jsDelivr build and pointed at `/openapi.yml` on the same
+origin. This was chosen over Swagger UI or Redoc for concrete reasons:
+
+- **No new runtime dependency.** Nothing is added to `package.json`, so the
+  install footprint and the dependency-review surface are unchanged.
+- **Spec is served, not embedded.** The page fetches `/openapi.yml` at load
+  time, so a regenerated spec is live on the next request — the rendered docs
+  cannot drift from the file in the repo.
+- **The spec already documented this.** `/docs` is described in the spec itself
+  as "Scalar UI serving this OpenAPI spec".
+
+The app-wide CSP in [shared/security-middleware.ts](../../shared/security-middleware.ts)
+only allows `'self'` scripts, so the docs route sets its own CSP header, scoped
+to that one page, allowing scripts and styles from `cdn.jsdelivr.net` and
+keeping `connect-src` at `'self'`.
+
+### Running it locally
+
+```bash
+npm run gen-openapi     # regenerate docs/openapi.yml from scripts/gen-openapi.ts
+npm start               # unified server on PORT (default 3000)
+open http://localhost:3000/docs
+```
+
+### Switching to a vendored (offline) renderer
+
+The CDN dependency is the one trade-off: an air-gapped deployment renders a
+blank page (the spec at `/openapi.yml` still serves fine). To vendor it:
+
+1. `npm install @scalar/api-reference` (or `swagger-ui-dist`).
+2. Serve the package's `dist/` via `express.static` from
+   [shared/api-docs.ts](../../shared/api-docs.ts).
+3. Point `SCALAR_CDN_URL` at the local asset path and drop `cdn.jsdelivr.net`
+   from `DOCS_CSP`.
+
+The route contract (`/docs`, `/openapi.yml`) stays the same either way.
+
+## Keeping the spec valid and in sync
+
+`docs/openapi.yml` is **generated**, not hand-edited. Edit
+[scripts/gen-openapi.ts](../../scripts/gen-openapi.ts) and regenerate:
+
+```bash
+npm run gen-openapi
+npm run validate:openapi
+```
+
+### CI validation
+
+[.github/workflows/openapi.yml](../../.github/workflows/openapi.yml) runs on every
+PR touching the spec, the generator, the validator, or the docs router, and on
+pushes to `main`. A broken spec fails the build. Two steps:
+
+1. **`npm run validate:openapi`** ([scripts/validate-openapi.ts](../../scripts/validate-openapi.ts))
+   - *Structure*: 3.1.x version, `info`, at least one server, non-empty `paths`,
+     every operation has a summary and at least one described response with a
+     valid status code, every `security` requirement names a declared scheme,
+     and every `$ref` resolves.
+   - *Serialization*: no tabs, no trailing whitespace, and no container
+     punctuation in column 0. This last one is not hypothetical — the generator
+     used to emit `security:\n[]`, which made the whole document unparseable and
+     was why nothing could render it.
+   - *Drift*: the checked-in file must byte-match what the generator produces
+     today. Forgetting to commit a regenerated spec fails CI.
+2. **`npx @redocly/cli lint`** — full OpenAPI 3.1 conformance lint, run from the
+   registry so no dependency is added. Errors fail the job; style warnings
+   (missing `operationId`, missing `license`) do not.
+
+To reproduce the CI run locally:
+
+```bash
+npm run validate:openapi
+npx --yes @redocly/cli@1 lint docs/openapi.yml
+```
+
+## Authentication: the X402Auth scheme
+
+Most endpoints are behind the [x402](https://www.x402.org/) payment protocol
+rather than a conventional API key, which the spec models as the `X402Auth`
+security scheme. What consumers need to know:
+
+- **You do not send a bearer token.** `X402Auth` is declared as `http`/`bearer`
+  because OpenAPI 3.1 has no native x402 type. The real credential is the
+  **`X-PAYMENT`** request header carrying a signed Stellar payment payload.
+- **The flow is challenge-first.** Call a protected route with no `X-PAYMENT`
+  header and the server answers **`402 Payment Required`** with the accepted
+  scheme, network (`stellar:testnet`), `payTo` address, and price. Sign that
+  payment, resend the request with `X-PAYMENT`, and the call proceeds.
+- **The receipt comes back in a header.** Successful paid responses carry
+  `PAYMENT-RESPONSE`, from which the Stellar transaction hash is extracted for
+  on-chain verification (see `extractX402TxHash` in
+  [agent/tools.ts](../../agent/tools.ts)).
+- **Payment is never skipped.** The facilitator connection is fail-closed: if it
+  is unreachable, protected routes return `503` instead of serving unpaid
+  traffic. See [shared/x402-middleware.ts](../../shared/x402-middleware.ts).
+- **Prices are per route**, declared where each route is mounted in
+  [server.ts](../../server.ts):
+
+  | Route | Price |
+  | --- | --- |
+  | `GET /pharmacy/compare` | $0.002 USDC |
+  | `GET /drug/interactions` | $0.001 USDC |
+  | `POST /bill/audit` | $0.01 USDC |
+  | `POST /pharmacy/order` | quoted per order |
+
+- **Unprotected routes**: `/health`, `/ready`, `/metrics`, `/docs`, and
+  `/openapi.yml` carry `security: []` in the spec and never require payment.
+
+Client-side handling of the 402 challenge is automatic when using
+`@x402/fetch`; see the x402 client setup in [agent/tools.ts](../../agent/tools.ts).
+
+## Related
+
+- [docs/openapi.yml](../openapi.yml) — the spec
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md) — service topology
+- [docs/observability/health-checks.md](../observability/health-checks.md) — `/health` and `/ready` semantics

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -9,8 +9,7 @@ servers:
   - url: 'https://api.careguard.xyz'
     description: 'Production server'
 security:
-  - X402Auth:
-[]
+  - X402Auth: []
 components:
   securitySchemes:
     X402Auth:
@@ -55,8 +54,7 @@ paths:
       summary: 'Liveness probe — always fast, no dependency checks'
       tags:
         - 'Observability'
-      security:
-[]
+      security: []
       responses:
         200:
           description: 'Process is up'
@@ -74,8 +72,7 @@ paths:
       summary: 'Readiness probe — checks required env, Horizon, and OZ facilitator status'
       tags:
         - 'Observability'
-      security:
-[]
+      security: []
       responses:
         200:
           description: 'All dependency checks passed'
@@ -112,8 +109,7 @@ paths:
       tags:
         - 'Pharmacy'
       security:
-        - X402Auth:
-[]
+        - X402Auth: []
       parameters:
         - in: 'query'
           name: 'drug'
@@ -182,8 +178,7 @@ paths:
       tags:
         - 'Bill Audit'
       security:
-        - X402Auth:
-[]
+        - X402Auth: []
       requestBody:
         required: true
         content:
@@ -235,8 +230,7 @@ paths:
       tags:
         - 'Drug Interactions'
       security:
-        - X402Auth:
-[]
+        - X402Auth: []
       parameters:
         - in: 'query'
           name: 'meds'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "tsc -p tsconfig.build.json",
     "lint": "tsc --noEmit",
     "gen-openapi": "node --import tsx scripts/gen-openapi.ts",
+    "validate:openapi": "node --import tsx scripts/validate-openapi.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "e2e": "cd dashboard && npx playwright test --config ../e2e/playwright.config.ts",

--- a/scripts/__tests__/validate-openapi.test.ts
+++ b/scripts/__tests__/validate-openapi.test.ts
@@ -1,0 +1,134 @@
+/**
+ * OpenAPI validation tests (Issue #752).
+ *
+ * The point of the validator is that a broken docs/openapi.yml fails the build,
+ * so these tests feed it broken inputs and assert it complains — including the
+ * exact serializer bug that made the committed spec unparseable (a bare "[]" in
+ * column 0 under `security:`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateSpec, specToYaml } from "../gen-openapi.ts";
+import {
+  validate,
+  validateSpecStructure,
+  validateYamlShape,
+} from "../validate-openapi.ts";
+
+describe("validate() against the checked-in spec", () => {
+  it("passes for the current docs/openapi.yml", () => {
+    const { errors } = validate();
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("validateSpecStructure", () => {
+  const base = () => JSON.parse(JSON.stringify(generateSpec()));
+
+  it("accepts the generated spec", () => {
+    expect(validateSpecStructure(base())).toEqual([]);
+  });
+
+  it("rejects a non-3.1 version", () => {
+    const spec = base();
+    spec.openapi = "3.0.0";
+    expect(validateSpecStructure(spec).join(" ")).toContain("3.1");
+  });
+
+  it("rejects a missing info block", () => {
+    const spec = base();
+    delete spec.info.title;
+    expect(validateSpecStructure(spec).join(" ")).toContain("info.title");
+  });
+
+  it("rejects an empty paths object", () => {
+    const spec = base();
+    spec.paths = {};
+    expect(validateSpecStructure(spec).join(" ")).toContain("paths must not be empty");
+  });
+
+  it("rejects an operation with no responses", () => {
+    const spec = base();
+    spec.paths["/health"].get.responses = {};
+    expect(validateSpecStructure(spec).join(" ")).toContain("at least one response");
+  });
+
+  it("rejects a response without a description", () => {
+    const spec = base();
+    spec.paths["/health"].get.responses["200"] = {};
+    expect(validateSpecStructure(spec).join(" ")).toContain("description is required");
+  });
+
+  it("rejects an invalid status code", () => {
+    const spec = base();
+    spec.paths["/health"].get.responses["abc"] = { description: "nope" };
+    expect(validateSpecStructure(spec).join(" ")).toContain("not a valid status code");
+  });
+
+  it("rejects security requirements naming an undeclared scheme", () => {
+    const spec = base();
+    spec.paths["/health"].get.security = [{ ApiKeyAuth: [] }];
+    expect(validateSpecStructure(spec).join(" ")).toContain("unknown scheme 'ApiKeyAuth'");
+  });
+
+  it("rejects a dangling $ref", () => {
+    const spec = base();
+    spec.paths["/ready"].get.responses["200"].content["application/json"].schema = {
+      $ref: "#/components/schemas/DoesNotExist",
+    };
+    expect(validateSpecStructure(spec).join(" ")).toContain("does not resolve");
+  });
+
+  it("rejects a missing security scheme definition", () => {
+    const spec = base();
+    spec.components.securitySchemes = {};
+    expect(validateSpecStructure(spec).join(" ")).toContain("at least one scheme");
+  });
+});
+
+describe("validateYamlShape", () => {
+  it("accepts the generated YAML", () => {
+    expect(validateYamlShape(specToYaml(generateSpec()))).toEqual([]);
+  });
+
+  it("catches container punctuation in column 0 — the bug that broke the spec", () => {
+    const broken = ["openapi: '3.1.0'", "security:", "  - X402Auth:", "[]"].join("\n");
+    expect(validateYamlShape(broken).join(" ")).toContain("column 0");
+  });
+
+  it("catches tab indentation", () => {
+    const broken = ["openapi: '3.1.0'", "info:", "\ttitle: 'x'"].join("\n");
+    expect(validateYamlShape(broken).join(" ")).toContain("tab character");
+  });
+
+  it("catches trailing whitespace", () => {
+    const broken = ["openapi: '3.1.0'", "info:   "].join("\n");
+    expect(validateYamlShape(broken).join(" ")).toContain("trailing whitespace");
+  });
+
+  it("requires the document to start with the openapi key", () => {
+    const broken = ["info:", "  title: 'x'"].join("\n");
+    expect(validateYamlShape(broken).join(" ")).toContain("line 1");
+  });
+});
+
+describe("specToYaml empty containers", () => {
+  it("keeps empty arrays inline after their key", () => {
+    expect(specToYaml({ security: [] })).toBe("security: []");
+  });
+
+  it("keeps empty objects inline after their key", () => {
+    expect(specToYaml({ details: {} })).toBe("details: {}");
+  });
+
+  it("still nests non-empty containers", () => {
+    expect(specToYaml({ tags: ["Agent"] })).toBe("tags:\n  - 'Agent'");
+  });
+
+  it("emits a valid security requirement for the X402Auth scheme", () => {
+    // The real-world shape that used to serialize as `- X402Auth:\n[]`.
+    expect(specToYaml({ security: [{ X402Auth: [] }] })).toBe(
+      "security:\n  - X402Auth: []",
+    );
+  });
+});

--- a/scripts/gen-openapi.ts
+++ b/scripts/gen-openapi.ts
@@ -9,7 +9,7 @@
 import { z } from "zod";
 import { writeFileSync, mkdirSync } from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import {
   MAX_FREE_TEXT_LENGTH,
   MAX_FREE_TEXT_LIST_LENGTH,
@@ -82,7 +82,7 @@ function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
   };
 }
 
-function generateSpec(): OpenAPISpec {
+export function generateSpec(): OpenAPISpec {
   return {
     openapi: "3.1.0",
     info: {
@@ -457,7 +457,7 @@ function generateSpec(): OpenAPISpec {
   };
 }
 
-function saveSpec() {
+export function saveSpec() {
   mkdirSync(docsDir, { recursive: true });
 
   const spec = generateSpec();
@@ -469,7 +469,16 @@ function saveSpec() {
   console.log(`✓ OpenAPI spec generated: ${filePath}`);
 }
 
-function specToYaml(obj: unknown, indent = 0): string {
+/** True for `[]` and `{}` — containers YAML must keep inline after a key. */
+function isEmptyContainer(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object" && value !== null) {
+    return Object.keys(value as Record<string, unknown>).length === 0;
+  }
+  return false;
+}
+
+export function specToYaml(obj: unknown, indent = 0): string {
   const spaces = " ".repeat(indent);
 
   if (obj === null || obj === undefined) {
@@ -491,12 +500,22 @@ function specToYaml(obj: unknown, indent = 0): string {
       .join("\n");
   }
 
+  if (typeof obj === "object" && isEmptyContainer(obj)) {
+    return "{}";
+  }
+
   if (typeof obj === "object") {
     const entries = Object.entries(obj as Record<string, unknown>);
     if (entries.length === 0) return "{}";
     return entries
       .map(([key, value]) => {
         const valueStr = specToYaml(value, indent + 2);
+        // Empty arrays/objects serialize to "[]"/"{}" with no indentation, so
+        // they must stay on the key's line — emitting them on the next line
+        // puts a bare "[]" in column 0 and makes the document unparseable.
+        if (isEmptyContainer(value)) {
+          return `${spaces}${key}: ${valueStr}`;
+        }
         if (
           valueStr.includes("\n") ||
           (typeof value === "object" && value !== null)
@@ -511,4 +530,8 @@ function specToYaml(obj: unknown, indent = 0): string {
   return String(obj);
 }
 
-saveSpec();
+// Only write the file when run directly (`npm run gen-openapi`); importing this
+// module — e.g. from the CI validator — must have no side effects.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  saveSpec();
+}

--- a/scripts/validate-openapi.ts
+++ b/scripts/validate-openapi.ts
@@ -1,0 +1,196 @@
+/**
+ * Validate docs/openapi.yml so a broken spec fails the build.
+ *
+ * Three checks, in order of what they catch:
+ *   1. Structure  — the generated spec object has the fields OpenAPI 3.1 and
+ *                   our consumers require (info, servers, paths, responses,
+ *                   resolvable security schemes and $refs).
+ *   2. Serialization — the emitted YAML has no malformed lines. A bare "[]" or
+ *                   "{}" in column 0 previously made the whole document
+ *                   unparseable; that class of bug is caught here.
+ *   3. Drift      — the checked-in docs/openapi.yml matches what the generator
+ *                   produces today, so the spec cannot go stale silently.
+ *
+ * Run: npm run validate:openapi
+ * CI:  .github/workflows/openapi.yml (also runs a full 3.1 lint via Redocly)
+ */
+
+import { readFileSync, existsSync } from "fs";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { generateSpec, specToYaml } from "./gen-openapi.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SPEC_PATH = path.resolve(__dirname, "../docs/openapi.yml");
+
+export interface ValidationResult {
+  errors: string[];
+  warnings: string[];
+}
+
+/** Structural checks against the spec object the generator builds. */
+export function validateSpecStructure(spec: Record<string, any>): string[] {
+  const errors: string[] = [];
+
+  if (typeof spec.openapi !== "string" || !spec.openapi.startsWith("3.1")) {
+    errors.push(`openapi must be a 3.1.x version string (got ${JSON.stringify(spec.openapi)})`);
+  }
+  if (!spec.info?.title) errors.push("info.title is required");
+  if (!spec.info?.version) errors.push("info.version is required");
+  if (!Array.isArray(spec.servers) || spec.servers.length === 0) {
+    errors.push("at least one server entry is required");
+  }
+
+  const schemes = spec.components?.securitySchemes ?? {};
+  if (Object.keys(schemes).length === 0) {
+    errors.push("components.securitySchemes must define at least one scheme");
+  }
+
+  const knownSchemes = new Set(Object.keys(schemes));
+  const schemaNames = new Set(Object.keys(spec.components?.schemas ?? {}));
+
+  const checkSecurity = (requirements: unknown, where: string) => {
+    if (requirements === undefined) return;
+    if (!Array.isArray(requirements)) {
+      errors.push(`${where}: security must be an array`);
+      return;
+    }
+    for (const requirement of requirements) {
+      for (const name of Object.keys(requirement ?? {})) {
+        if (!knownSchemes.has(name)) {
+          errors.push(`${where}: security references unknown scheme '${name}'`);
+        }
+      }
+    }
+  };
+
+  checkSecurity(spec.security, "root");
+
+  const paths = spec.paths ?? {};
+  if (Object.keys(paths).length === 0) errors.push("paths must not be empty");
+
+  for (const [route, methods] of Object.entries<Record<string, any>>(paths)) {
+    if (!route.startsWith("/")) errors.push(`path '${route}' must start with '/'`);
+
+    for (const [method, operation] of Object.entries(methods ?? {})) {
+      const where = `${method.toUpperCase()} ${route}`;
+      if (!operation?.summary) errors.push(`${where}: summary is required`);
+
+      const responses = operation?.responses ?? {};
+      if (Object.keys(responses).length === 0) {
+        errors.push(`${where}: at least one response is required`);
+      }
+      for (const [status, response] of Object.entries<Record<string, any>>(responses)) {
+        if (!/^[1-5]\d{2}$/.test(String(status))) {
+          errors.push(`${where}: '${status}' is not a valid status code`);
+        }
+        if (!response?.description) {
+          errors.push(`${where} ${status}: description is required`);
+        }
+      }
+
+      checkSecurity(operation?.security, where);
+    }
+  }
+
+  // Every local $ref must resolve to a declared component schema.
+  const refs: string[] = [];
+  const collectRefs = (node: unknown) => {
+    if (Array.isArray(node)) {
+      node.forEach(collectRefs);
+      return;
+    }
+    if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        if (key === "$ref" && typeof value === "string") refs.push(value);
+        else collectRefs(value);
+      }
+    }
+  };
+  collectRefs(spec);
+
+  for (const ref of refs) {
+    const match = /^#\/components\/schemas\/(.+)$/.exec(ref);
+    if (!match) {
+      errors.push(`unsupported $ref '${ref}' (only #/components/schemas/* is used)`);
+      continue;
+    }
+    if (!schemaNames.has(match[1])) errors.push(`$ref '${ref}' does not resolve`);
+  }
+
+  return errors;
+}
+
+/**
+ * Line-level checks on the emitted YAML. These catch serializer bugs that a
+ * structural check cannot see, because the object is fine and only its
+ * rendering is broken.
+ */
+export function validateYamlShape(yaml: string): string[] {
+  const errors: string[] = [];
+  const lines = yaml.split("\n");
+
+  lines.forEach((line, index) => {
+    const lineNo = index + 1;
+    if (line.includes("\t")) {
+      errors.push(`line ${lineNo}: tab character (YAML forbids tabs for indentation)`);
+    }
+    if (/^[[{\]}]/.test(line)) {
+      errors.push(`line ${lineNo}: container punctuation in column 0 — '${line.trim()}'`);
+    }
+    if (/\s+$/.test(line)) {
+      errors.push(`line ${lineNo}: trailing whitespace`);
+    }
+  });
+
+  if (!lines[0]?.startsWith("openapi:")) {
+    errors.push("line 1: document must start with the openapi version key");
+  }
+
+  return errors;
+}
+
+export function validate(): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const spec = generateSpec();
+  errors.push(...validateSpecStructure(spec as unknown as Record<string, any>));
+
+  const generated = specToYaml(spec);
+  errors.push(...validateYamlShape(generated));
+
+  if (!existsSync(SPEC_PATH)) {
+    errors.push("docs/openapi.yml is missing — run `npm run gen-openapi`");
+    return { errors, warnings };
+  }
+
+  const onDisk = readFileSync(SPEC_PATH, "utf-8");
+  errors.push(...validateYamlShape(onDisk));
+
+  if (onDisk.trim() !== generated.trim()) {
+    errors.push(
+      "docs/openapi.yml is out of date with scripts/gen-openapi.ts — run `npm run gen-openapi` and commit the result",
+    );
+  }
+
+  return { errors, warnings };
+}
+
+function main() {
+  const { errors, warnings } = validate();
+
+  for (const warning of warnings) console.warn(`warning: ${warning}`);
+
+  if (errors.length > 0) {
+    console.error(`✗ OpenAPI validation failed (${errors.length} error(s)):`);
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+
+  console.log("✓ docs/openapi.yml is valid and in sync with scripts/gen-openapi.ts");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/server.ts
+++ b/server.ts
@@ -24,6 +24,7 @@ import { z } from "zod";
 import { applyX402Middleware } from "./shared/x402-middleware.ts";
 import { createCorsMiddleware } from "./shared/cors.ts";
 import { applySecurityMiddleware } from "./shared/security-middleware.ts";
+import { createApiDocsRouter } from "./shared/api-docs.ts";
 import { logger } from "./shared/logger.ts";
 import { requireApiKey } from "./shared/auth.ts";
 import { validateTask, getSuspiciousTaskCount } from "./shared/task-validation.ts";
@@ -233,6 +234,9 @@ app.use("/agent/audit", auditRouter);
 
 // --- Prometheus metrics ---
 app.get("/metrics", metricsHandler());
+
+// --- API docs: GET /docs (Scalar UI) and GET /openapi.yml (raw spec) ---
+app.use(createApiDocsRouter());
 
 // --- Root info ---
 app.get("/", (_req, res) => {

--- a/shared/__tests__/api-docs.test.ts
+++ b/shared/__tests__/api-docs.test.ts
@@ -1,0 +1,143 @@
+/**
+ * API docs hosting tests (Issue #752).
+ *
+ * Pins the two routes consumers depend on — the rendered reference at /docs and
+ * the raw spec at /openapi.yml — plus the CSP relaxation the renderer needs,
+ * which the app-wide policy in security-middleware.ts would otherwise block.
+ */
+
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { applySecurityMiddleware } from "../security-middleware.ts";
+import { createApiDocsRouter, DOCS_ROUTE, SPEC_ROUTE, SCALAR_CDN_URL } from "../api-docs.ts";
+
+const SPEC_FIXTURE = `openapi: '3.1.0'
+info:
+  title: 'CareGuard API'
+  version: '1.0.0'
+paths:
+  /health:
+    get:
+      summary: 'Liveness probe'
+      security: []
+      responses:
+        200:
+          description: 'Process is up'
+`;
+
+function buildApp(specPath?: string) {
+  const app = express();
+  // Mirror production ordering: the strict app-wide CSP is applied first.
+  applySecurityMiddleware(app);
+  app.use(createApiDocsRouter(specPath ? { specPath } : {}));
+  return app;
+}
+
+function withTempSpec(contents: string | null) {
+  const dir = mkdtempSync(path.join(tmpdir(), "careguard-openapi-"));
+  const specPath = path.join(dir, "openapi.yml");
+  if (contents !== null) writeFileSync(specPath, contents, "utf-8");
+  return { specPath, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("GET /openapi.yml", () => {
+  it("serves the spec as YAML", async () => {
+    const { specPath, cleanup } = withTempSpec(SPEC_FIXTURE);
+    try {
+      const res = await request(buildApp(specPath)).get(SPEC_ROUTE);
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("yaml");
+      expect(res.text).toBe(SPEC_FIXTURE);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("serves the checked-in spec by default", async () => {
+    const res = await request(buildApp()).get(SPEC_ROUTE);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("openapi: '3.1.0'");
+    expect(res.text).toContain("X402Auth");
+  });
+
+  it("is not cached, so a regenerated spec is served immediately", async () => {
+    const { specPath, cleanup } = withTempSpec(SPEC_FIXTURE);
+    try {
+      const app = buildApp(specPath);
+      const before = await request(app).get(SPEC_ROUTE);
+      expect(before.headers["cache-control"]).toBe("no-cache");
+
+      writeFileSync(specPath, SPEC_FIXTURE.replace("1.0.0", "2.0.0"), "utf-8");
+      const after = await request(app).get(SPEC_ROUTE);
+
+      expect(after.text).toContain("2.0.0");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("returns a diagnosable error when the spec file is missing", async () => {
+    const { specPath, cleanup } = withTempSpec(null);
+    try {
+      const res = await request(buildApp(specPath)).get(SPEC_ROUTE);
+
+      expect(res.status).toBe(500);
+      expect(res.body.code).toBe("SPEC_MISSING");
+      expect(res.body.details.hint).toContain("gen-openapi");
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("GET /docs", () => {
+  it("renders an HTML page pointed at the spec route", async () => {
+    const res = await request(buildApp()).get(DOCS_ROUTE);
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/html");
+    expect(res.text).toContain(`data-url="${SPEC_ROUTE}"`);
+    expect(res.text).toContain(SCALAR_CDN_URL);
+  });
+
+  it("pins the renderer to an exact version rather than a floating tag", () => {
+    expect(SCALAR_CDN_URL).toMatch(/@\d+\.\d+\.\d+\//);
+  });
+
+  it("relaxes CSP for the renderer CDN without widening connect-src", async () => {
+    const res = await request(buildApp()).get(DOCS_ROUTE);
+    const csp = res.headers["content-security-policy"];
+
+    expect(csp).toContain("script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net");
+    // The page only ever fetches the spec from its own origin.
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("leaves the strict app-wide CSP in place for other routes", async () => {
+    const app = buildApp();
+    app.get("/other", (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get("/other");
+
+    expect(res.headers["content-security-policy"]).toContain("default-src 'self'");
+    expect(res.headers["content-security-policy"]).not.toContain("cdn.jsdelivr.net");
+  });
+
+  it("does not require authentication or payment", async () => {
+    const docs = await request(buildApp()).get(DOCS_ROUTE);
+    const spec = await request(buildApp()).get(SPEC_ROUTE);
+
+    expect(docs.status).toBe(200);
+    expect(spec.status).toBe(200);
+    expect(docs.headers["www-authenticate"]).toBeUndefined();
+  });
+});

--- a/shared/__tests__/rate-limit-burst.test.ts
+++ b/shared/__tests__/rate-limit-burst.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Rate-limit burst-behaviour integration tests (Issue #799).
+ *
+ * The middleware is mounted on a real Express app and driven with bursts, so
+ * these pin end-to-end behaviour rather than internals: rejected requests get a
+ * 429 with Retry-After (and never hang), the concurrency gauge returns to zero
+ * without going negative when both `finish` and `close` fire, malformed env
+ * limits fall back to safe defaults, and metric labels keep routes and policies
+ * distinguishable.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { EventEmitter } from "events";
+import {
+  concurrentRequestsMiddleware,
+  createRateLimiter,
+  parseLimitEnv,
+  rateLimitHitsTotal,
+  routeConcurrentRequests,
+  RATE_LIMIT_DEFAULTS,
+} from "../rate-limit.ts";
+
+/** Current value of a labelled metric, or 0 when it has never been touched. */
+async function metricValue(
+  metric: { get(): Promise<any> | any },
+  labelKey: string,
+  labelValue: string,
+): Promise<number> {
+  const data = await metric.get();
+  const match = data.values.find((v: any) => v.labels[labelKey] === labelValue);
+  return match?.value ?? 0;
+}
+
+function buildApp(limiterRoute: string, max: number, windowMs = 60_000) {
+  const app = express();
+  app.get(
+    `/${limiterRoute}`,
+    createRateLimiter(limiterRoute, max, windowMs),
+    concurrentRequestsMiddleware(limiterRoute),
+    (_req, res) => {
+      res.json({ ok: true });
+    },
+  );
+  return app;
+}
+
+beforeEach(() => {
+  routeConcurrentRequests.reset();
+});
+
+describe("burst over the limit", () => {
+  it("serves up to the limit, then answers 429 without hanging", async () => {
+    const app = buildApp("burst_basic", 3);
+
+    const responses = [];
+    for (let i = 0; i < 5; i++) {
+      responses.push(await request(app).get("/burst_basic"));
+    }
+
+    expect(responses.map((r) => r.status)).toEqual([200, 200, 200, 429, 429]);
+    // Every request resolved — a handler that forgot to respond would surface
+    // here as a supertest timeout instead.
+    expect(responses.every((r) => r.text !== undefined)).toBe(true);
+  });
+
+  it("includes Retry-After on the 429", async () => {
+    const app = buildApp("burst_retry_after", 1, 60_000);
+
+    await request(app).get("/burst_retry_after");
+    const rejected = await request(app).get("/burst_retry_after");
+
+    expect(rejected.status).toBe(429);
+    expect(rejected.headers["retry-after"]).toBe("60");
+  });
+
+  it("advertises the limit through standard RateLimit headers", async () => {
+    const app = buildApp("burst_headers", 2);
+
+    const first = await request(app).get("/burst_headers");
+
+    expect(first.headers["ratelimit-limit"]).toBe("2");
+    expect(first.headers["x-ratelimit-limit"]).toBeUndefined();
+  });
+
+  it("keeps serving concurrent in-flight requests that are under the limit", async () => {
+    const app = buildApp("burst_parallel", 10);
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () => request(app).get("/burst_parallel")),
+    );
+
+    expect(responses.every((r) => r.status === 200)).toBe(true);
+  });
+});
+
+describe("concurrent-requests gauge", () => {
+  it("returns to zero after a burst", async () => {
+    const app = buildApp("gauge_burst", 50);
+
+    await Promise.all(Array.from({ length: 10 }, () => request(app).get("/gauge_burst")));
+
+    expect(await metricValue(routeConcurrentRequests, "route", "gauge_burst")).toBe(0);
+  });
+
+  it("never goes negative when both finish and close fire", async () => {
+    const route = "gauge_double_release";
+    const res = new EventEmitter() as any;
+    const next = () => {};
+
+    concurrentRequestsMiddleware(route)({} as any, res, next);
+    expect(await metricValue(routeConcurrentRequests, "route", route)).toBe(1);
+
+    // Express emits both for a normally completed response.
+    res.emit("finish");
+    res.emit("close");
+
+    expect(await metricValue(routeConcurrentRequests, "route", route)).toBe(0);
+  });
+
+  it("stays at zero even if the same response emits release events repeatedly", async () => {
+    const route = "gauge_repeat_release";
+    const res = new EventEmitter() as any;
+
+    concurrentRequestsMiddleware(route)({} as any, res, () => {});
+    res.emit("close");
+    res.emit("close");
+    res.emit("finish");
+
+    expect(await metricValue(routeConcurrentRequests, "route", route)).toBe(0);
+  });
+
+  it("tracks overlapping requests independently", async () => {
+    const route = "gauge_overlap";
+    const first = new EventEmitter() as any;
+    const second = new EventEmitter() as any;
+    const middleware = concurrentRequestsMiddleware(route);
+
+    middleware({} as any, first, () => {});
+    middleware({} as any, second, () => {});
+    expect(await metricValue(routeConcurrentRequests, "route", route)).toBe(2);
+
+    first.emit("finish");
+    first.emit("close");
+    expect(await metricValue(routeConcurrentRequests, "route", route)).toBe(1);
+
+    second.emit("close");
+    expect(await metricValue(routeConcurrentRequests, "route", route)).toBe(0);
+  });
+
+  it("labels each route separately", async () => {
+    const app = buildApp("gauge_route_a", 20);
+    const other = new EventEmitter() as any;
+
+    await request(app).get("/gauge_route_a");
+    concurrentRequestsMiddleware("gauge_route_b")({} as any, other, () => {});
+
+    expect(await metricValue(routeConcurrentRequests, "route", "gauge_route_a")).toBe(0);
+    expect(await metricValue(routeConcurrentRequests, "route", "gauge_route_b")).toBe(1);
+
+    other.emit("finish");
+  });
+});
+
+describe("env-configured limits", () => {
+  it("uses a valid positive integer", () => {
+    expect(parseLimitEnv("42", RATE_LIMIT_DEFAULTS.billAudit)).toBe(42);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["non-numeric", "abc"],
+    ["partially numeric", "20abc"],
+    ["zero", "0"],
+    ["negative", "-5"],
+    ["fractional", "2.5"],
+    ["NaN literal", "NaN"],
+    ["Infinity", "Infinity"],
+  ])("falls back to the default for a %s value", (_label, raw) => {
+    expect(parseLimitEnv(raw as string | undefined, RATE_LIMIT_DEFAULTS.agentRun)).toBe(
+      RATE_LIMIT_DEFAULTS.agentRun,
+    );
+  });
+
+  it("keeps limiting when the env value is garbage, rather than disabling it", async () => {
+    const limit = parseLimitEnv("not-a-number", 2);
+    const app = buildApp("burst_bad_env", limit);
+
+    const responses = [];
+    for (let i = 0; i < 4; i++) {
+      responses.push(await request(app).get("/burst_bad_env"));
+    }
+
+    expect(responses.map((r) => r.status)).toEqual([200, 200, 429, 429]);
+  });
+});
+
+describe("metric labelling", () => {
+  it("counts rejections per policy", async () => {
+    const before = await metricValue(rateLimitHitsTotal, "policy", "policy_labelled");
+    const app = buildApp("policy_labelled", 1);
+
+    await request(app).get("/policy_labelled");
+    await request(app).get("/policy_labelled");
+    await request(app).get("/policy_labelled");
+
+    const after = await metricValue(rateLimitHitsTotal, "policy", "policy_labelled");
+    expect(after - before).toBe(2);
+  });
+
+  it("does not attribute one policy's rejections to another", async () => {
+    const strict = buildApp("policy_strict", 1);
+    const loose = buildApp("policy_loose", 50);
+
+    const strictBefore = await metricValue(rateLimitHitsTotal, "policy", "policy_strict");
+    const looseBefore = await metricValue(rateLimitHitsTotal, "policy", "policy_loose");
+
+    await request(strict).get("/policy_strict");
+    await request(strict).get("/policy_strict"); // rejected
+    await request(loose).get("/policy_loose");
+    await request(loose).get("/policy_loose"); // allowed
+
+    expect(
+      (await metricValue(rateLimitHitsTotal, "policy", "policy_strict")) - strictBefore,
+    ).toBe(1);
+    expect(
+      (await metricValue(rateLimitHitsTotal, "policy", "policy_loose")) - looseBefore,
+    ).toBe(0);
+  });
+
+  it("keeps per-route buckets independent, so one route cannot starve another", async () => {
+    const busy = buildApp("bucket_busy", 1);
+    const quiet = buildApp("bucket_quiet", 1);
+
+    await request(busy).get("/bucket_busy");
+    const busyRejected = await request(busy).get("/bucket_busy");
+    const quietFirst = await request(quiet).get("/bucket_quiet");
+
+    expect(busyRejected.status).toBe(429);
+    expect(quietFirst.status).toBe(200);
+  });
+});

--- a/shared/api-docs.ts
+++ b/shared/api-docs.ts
@@ -1,0 +1,101 @@
+/**
+ * Interactive API documentation for docs/openapi.yml.
+ *
+ * Mounts two routes on the unified server:
+ *   GET /openapi.yml — the raw OpenAPI 3.1 spec (text/yaml)
+ *   GET /docs        — Scalar API Reference rendering that spec
+ *
+ * The renderer is loaded from a pinned CDN build rather than a vendored copy,
+ * so no runtime dependency is added. The app-wide CSP (shared/security-middleware.ts)
+ * only allows 'self' scripts, so this router sets its own CSP header scoped to
+ * the docs page. See docs/api/README.md for the hosting contract and for the
+ * offline/vendored alternative.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { readFileSync, existsSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Pinned so the docs page cannot change under us when the CDN publishes a new major. */
+export const SCALAR_CDN_URL =
+  "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.128/dist/browser/standalone.min.js";
+
+export const SPEC_ROUTE = "/openapi.yml";
+export const DOCS_ROUTE = "/docs";
+
+const DEFAULT_SPEC_PATH = path.resolve(__dirname, "../docs/openapi.yml");
+
+/**
+ * CSP for the docs page only. The renderer is a CDN script that injects its own
+ * styles, and it fetches the spec from this same origin.
+ */
+const DOCS_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+  "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com",
+  "font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net",
+  "img-src 'self' data: https://cdn.jsdelivr.net",
+  "connect-src 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+function renderDocsPage(specUrl: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CareGuard API Reference</title>
+  </head>
+  <body>
+    <script id="api-reference" type="application/json" data-url="${specUrl}"></script>
+    <script src="${SCALAR_CDN_URL}" crossorigin="anonymous"></script>
+  </body>
+</html>`;
+}
+
+export interface ApiDocsOptions {
+  /** Absolute path to the spec. Defaults to docs/openapi.yml. */
+  specPath?: string;
+}
+
+/**
+ * Router serving the spec and its rendered reference.
+ *
+ * The spec is read from disk on each request so `npm run gen-openapi` is picked
+ * up without a restart in development; the file is small and this is not a hot
+ * path.
+ */
+export function createApiDocsRouter(options: ApiDocsOptions = {}): Router {
+  const specPath = options.specPath ?? DEFAULT_SPEC_PATH;
+  const router = Router();
+
+  router.get(SPEC_ROUTE, (_req: Request, res: Response) => {
+    if (!existsSync(specPath)) {
+      res.status(500).json({
+        error: "OpenAPI spec not found",
+        code: "SPEC_MISSING",
+        details: { hint: "Run `npm run gen-openapi` to regenerate docs/openapi.yml" },
+      });
+      return;
+    }
+
+    res
+      .type("text/yaml; charset=utf-8")
+      .set("Cache-Control", "no-cache")
+      .send(readFileSync(specPath, "utf-8"));
+  });
+
+  router.get(DOCS_ROUTE, (_req: Request, res: Response) => {
+    res
+      .type("text/html; charset=utf-8")
+      .set("Content-Security-Policy", DOCS_CSP)
+      .set("Cache-Control", "no-cache")
+      .send(renderDocsPage(SPEC_ROUTE));
+  });
+
+  return router;
+}

--- a/shared/rate-limit.ts
+++ b/shared/rate-limit.ts
@@ -15,21 +15,70 @@ export const routeConcurrentRequests = new Gauge({
   labelNames: ["route"],
 });
 
-const createLimiter = (policyName: string, maxRequests: number, windowMs: number = 60 * 1000) => {
-  if (process.env.NODE_ENV === "test") {
-    return (req: any, res: any, next: any) => next();
-  }
+export const DEFAULT_WINDOW_MS = 60 * 1000;
+
+/**
+ * Parse an env-configured request limit.
+ *
+ * A malformed value must never disable limiting: `parseInt` alone turns "abc"
+ * into NaN and "-5" into a negative, either of which express-rate-limit reads as
+ * "no limit". Anything that is not a positive integer falls back to the
+ * documented default instead (issue #799).
+ */
+export function parseLimitEnv(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+/**
+ * Build a rate limiter for one policy.
+ *
+ * Exported so tests can mount a real limiter — the module-level policies below
+ * deliberately no-op under NODE_ENV=test so unrelated suites are not throttled.
+ */
+export function createRateLimiter(
+  policyName: string,
+  maxRequests: number,
+  windowMs: number = DEFAULT_WINDOW_MS,
+): RateLimitRequestHandler {
   return rateLimit({
     windowMs,
     max: maxRequests,
     standardHeaders: true,
     legacyHeaders: false,
-    handler: (req, res, next, options) => {
+    handler: (_req, res, _next, options) => {
       rateLimitHitsTotal.inc({ policy: policyName });
-      res.status(options.statusCode).set("Retry-After", String(Math.ceil(options.windowMs / 1000))).send(options.message);
+      // Always terminate the chain with a response — never fall through without
+      // one, which would leave the request hanging until the client gives up.
+      res
+        .status(options.statusCode)
+        .set("Retry-After", String(Math.ceil(options.windowMs / 1000)))
+        .send(options.message);
     },
   });
+}
+
+const createLimiter = (
+  policyName: string,
+  maxRequests: number,
+  windowMs: number = DEFAULT_WINDOW_MS,
+) => {
+  if (process.env.NODE_ENV === "test") {
+    return (_req: Request, _res: Response, next: NextFunction) => next();
+  }
+  return createRateLimiter(policyName, maxRequests, windowMs);
 };
+
+// Documented defaults, used whenever the matching env var is unset or invalid.
+export const RATE_LIMIT_DEFAULTS = {
+  agentRun: 5,
+  billAudit: 20,
+  pharmacyCompare: 30,
+  drugInteractions: 30,
+  pharmacyOrder: 10,
+} as const;
 
 // Per-route rate limiters with independent token buckets so a spike on one
 // route (e.g. bill audits) cannot starve another (e.g. agent runs).
@@ -37,24 +86,48 @@ const createLimiter = (policyName: string, maxRequests: number, windowMs: number
 // traffic is measured. See docs/adr/unified-vs-split-server.md for context.
 export const perRouteLimiters = {
   // Agent run is CPU+LLM bound; strict limit prevents queue starvation
-  agentRun: createLimiter("agent_run", parseInt(process.env.RATE_LIMIT_AGENT_RUN || "5")),
+  agentRun: createLimiter(
+    "agent_run",
+    parseLimitEnv(process.env.RATE_LIMIT_AGENT_RUN, RATE_LIMIT_DEFAULTS.agentRun),
+  ),
   // Bill audit is I/O light but payload-heavy; separate bucket
-  billAudit: createLimiter("bill_audit", parseInt(process.env.RATE_LIMIT_BILL_AUDIT || "20")),
+  billAudit: createLimiter(
+    "bill_audit",
+    parseLimitEnv(process.env.RATE_LIMIT_BILL_AUDIT, RATE_LIMIT_DEFAULTS.billAudit),
+  ),
   // Pharmacy compare is cheap — allow more headroom
-  pharmacyCompare: createLimiter("pharmacy_compare", parseInt(process.env.RATE_LIMIT_PHARMACY_COMPARE || "30")),
+  pharmacyCompare: createLimiter(
+    "pharmacy_compare",
+    parseLimitEnv(
+      process.env.RATE_LIMIT_PHARMACY_COMPARE,
+      RATE_LIMIT_DEFAULTS.pharmacyCompare,
+    ),
+  ),
   // Drug interactions is lightweight
-  drugInteractions: createLimiter("drug_interactions", parseInt(process.env.RATE_LIMIT_DRUG_INTERACTIONS || "30")),
+  drugInteractions: createLimiter(
+    "drug_interactions",
+    parseLimitEnv(
+      process.env.RATE_LIMIT_DRUG_INTERACTIONS,
+      RATE_LIMIT_DEFAULTS.drugInteractions,
+    ),
+  ),
   // Pharmacy orders involve on-chain payment; keep tight
-  pharmacyOrder: createLimiter("pharmacy_order", parseInt(process.env.RATE_LIMIT_PHARMACY_ORDER || "10")),
+  pharmacyOrder: createLimiter(
+    "pharmacy_order",
+    parseLimitEnv(
+      process.env.RATE_LIMIT_PHARMACY_ORDER,
+      RATE_LIMIT_DEFAULTS.pharmacyOrder,
+    ),
+  ),
 };
 
 export const rateLimiters = {
   agent: createLimiter("agent", 5),
   x402: createLimiter("x402", 30),
   health: rateLimit({
-    windowMs: 60 * 1000,
+    windowMs: DEFAULT_WINDOW_MS,
     max: 0,
-    handler: (req, res, next) => next(),
+    handler: (_req, _res, next) => next(),
   }) as RateLimitRequestHandler,
   default: createLimiter("default", 60),
 };
@@ -65,12 +138,24 @@ rateLimiters.health = ((req: Request, res: Response, next: NextFunction) => next
 /**
  * Middleware that increments/decrements the route_concurrent_requests gauge
  * so operators can detect noisy-neighbor patterns in Prometheus/Grafana.
+ *
+ * Express fires both `finish` and `close` for most requests, so the decrement is
+ * latched: without it the gauge drifts negative and the "in-flight" reading
+ * becomes meaningless (issue #799).
  */
 export function concurrentRequestsMiddleware(route: string) {
   return (_req: Request, res: Response, next: NextFunction) => {
     routeConcurrentRequests.inc({ route });
-    res.on("finish", () => routeConcurrentRequests.dec({ route }));
-    res.on("close", () => routeConcurrentRequests.dec({ route }));
+
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      routeConcurrentRequests.dec({ route });
+    };
+
+    res.on("finish", release);
+    res.on("close", release);
     next();
   };
 }


### PR DESCRIPTION
## Summary

Closes #752 closes #796  closes #795 closes #799

## Changes

**#752 — Host the OpenAPI spec**

`docs/openapi.yml` was **invalid YAML** on `main`: the generator emitted `security:` followed by a bare `[]` in column 0, so the document did not parse and nothing could render it. Fixed the serializer in `scripts/gen-openapi.ts` (empty containers stay inline after their key) and regenerated the spec.

New `shared/api-docs.ts` serves two routes from the unified server:

| Route | Purpose |
|---|---|
| `GET /docs` | Scalar API Reference rendering the spec |
| `GET /openapi.yml` | Raw OpenAPI 3.1 spec |

The renderer is a pinned CDN build, so no dependency is added, and the page fetches the spec from its own origin — the rendered docs cannot drift from the file in the repo. The app-wide CSP is `script-src 'self'`, so the docs route sets its own CSP scoped to that page while keeping `connect-src 'self'`.

CI validation is `scripts/validate-openapi.ts` (`npm run validate:openapi`) plus a full Redocly 3.1 lint, wired up in `.github/workflows/openapi.yml`. The validator covers structure (version, info, servers, responses, resolvable security schemes and `$ref`s), YAML shape (catches exactly the column-0 bug), and drift against the generator, so a stale or malformed spec fails the build.

`docs/api/README.md` documents the hosting approach and URLs, the CI checks, the offline/vendored alternative, and the `X402Auth` / `X-PAYMENT` challenge-first flow with per-route prices. Cross-linked from `README.md` and `CONTRIBUTING.md`.

**#796 — tx_bad_seq reload and resubmit**

The reload path existed but was unreachable. `if (err?.response?.status) throw err` ran first, and every real Horizon rejection carries a 400, so a genuine `tx_bad_seq` was rethrown before the account could ever be reloaded — only synthetic message-only errors reached it. Result codes are now read from `extras.result_codes.transaction` as well as the message, so `tx_bad_seq` reaches the reload → rebuild → resubmit loop, `tx_too_late` rebuilds with fresh timebounds, and `tx_too_early` propagates distinctly instead of burning retries.

**#795 — fee-bump doubling**

The retry returned or threw from inside the `catch`, so despite a 3-attempt cap only **one** doubling ever happened. Restructured so each `tx_insufficient_fee` doubles the fee (clamped at `MAX_FEE_STROOPS`), rewraps in a fee-bump envelope and resubmits, up to `FEE_BUMP_MAX_ATTEMPTS` submissions, then surfaces the final failure. Non-fee errors are never wrapped.

**#799 — rate-limit burst behaviour**

Three findings fixed in `shared/rate-limit.ts`:

- `parseLimitEnv` rejects NaN, zero, negative and fractional env values and falls back to the documented default — a typo no longer silently disables limiting for a route
- the concurrency gauge decrement is latched, so Express firing both `finish` and `close` can no longer drive `route_concurrent_requests` negative
- `createRateLimiter` is exported so tests can mount a real limiter; the module-level policies still no-op under `NODE_ENV=test`

429s already carried `Retry-After`; that is now pinned by tests. Behaviour documented in `docs/adr/unified-vs-split-server.md`.

## Testing

75 new tests across five suites, all passing:

| Suite | Tests |
|---|---|
| `shared/__tests__/api-docs.test.ts` | 9 |
| `scripts/__tests__/validate-openapi.test.ts` | 20 |
| `agent/__tests__/tx-bad-seq-retry.test.ts` | 11 |
| `agent/__tests__/fee-bump-doubling.test.ts` | 11 |
| `shared/__tests__/rate-limit-burst.test.ts` | 24 |

The Stellar suites mock Horizon and inject a fake `RetryClock`, so they simulate the full 35s budget without any real sleeping. The pre-existing `fee-bump-retry-budget` suite still passes after the restructure, and `npx tsc --noEmit` matches the clean-tree baseline.

`npx @redocly/cli lint docs/openapi.yml` passes locally (exit 0, style warnings only).


