### PR TITLE
docs: Redis/disk-full runbooks, OpenAPI error schema, troubleshooting guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -196,6 +196,11 @@ for b in d['balances']:
 | Dashboard can't connect | Ensure backend services are running (`npm run dev`) |
 | Port already in use | Kill existing processes on the ports (see below) |
 
+For symptoms beyond setup-time issues — stuck agent spinner, repeated 402s,
+blank wallet balance, dashboard "Disconnected", startup hangs on Horizon —
+see [docs/troubleshooting.md](docs/troubleshooting.md), which routes each to
+the relevant runbook.
+
 ### Port Cleanup by OS
 
 **macOS / Linux:**

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Boot time on a warm Docker is ~30s (cold first build is much longer due to npm i
 
 See [docs/observability/health-checks.md](docs/observability/health-checks.md) for the `/health` and `/ready` response schemas and what each dependency check means.
 
+For a symptom-to-resolution index (stuck agent spinner, repeated 402s, blank wallet balance, dashboard "Disconnected", startup hangs on Horizon, missing env), see [docs/troubleshooting.md](docs/troubleshooting.md).
+
 ---
 
 ## API Documentation

--- a/docs/adr/unified-vs-split-server.md
+++ b/docs/adr/unified-vs-split-server.md
@@ -75,5 +75,5 @@ This long-term split is tracked as a follow-up and is **not** part of this PR. T
 ## Alternatives Considered
 
 - **Single global rate limit with higher ceiling:** Rejected — does not prevent cross-route starvation.
-- **Redis-backed rate limiting:** Preferred for multi-instance deployments. The existing `rate-limit-redis` dependency supports this; enabling it requires setting `REDIS_URL`. Not activated here because the current deployment is single-instance.
+- **Redis-backed rate limiting:** Preferred for multi-instance deployments. The existing `rate-limit-redis` dependency supports this; enabling it requires setting `REDIS_URL`. Not activated here because the current deployment is single-instance. See [redis-down.md](../runbooks/redis-down.md) for what currently degrades (webhook replay protection) when `REDIS_URL` is unset or Redis is unreachable — rate limiting itself is unaffected today since it is not yet Redis-backed.
 - **Worker threads for LLM agent:** Deferred to long-term split.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -83,4 +83,4 @@ Codes use `SCREAMING_SNAKE_CASE` with a category prefix:
 ## Cross-References
 
 - `docs/openapi.yml` — `Error.code` field enum (keep in sync with this registry)
-- `docs/troubleshooting.md` — operator-facing troubleshooting guide (TODO)
+- `docs/troubleshooting.md` — operator-facing troubleshooting guide

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -19,15 +19,60 @@ components:
   schemas:
     Error:
       type: 'object'
+      description: 'Standard error envelope for 4xx/5xx responses. See docs/error-codes.md for the full registry of `code` values, their meaning, and remediation.'
       properties:
         error:
           type: 'string'
           description: 'Human-readable message — do NOT branch on this value.'
         code:
           type: 'string'
+          enum:
+            - 'VALIDATION_MISSING_FIELD'
+            - 'VALIDATION_INVALID_INPUT'
+            - 'VALIDATION_INSUFFICIENT_SCORE'
+            - 'AUTH_TOKEN_MISSING'
+            - 'AUTH_TOKEN_EXPIRED'
+            - 'AUTH_TOKEN_INVALID'
+            - 'AUTH_ADMIN_REQUIRED'
+            - 'NOT_FOUND_DRUG'
+            - 'NOT_FOUND_PHARMACY'
+            - 'NOT_FOUND_AGENT'
+            - 'BODY_TOO_LARGE'
+            - 'POLICY_DAILY_LIMIT'
+            - 'POLICY_MONTHLY_LIMIT'
+            - 'POLICY_APPROVAL_REQUIRED'
+            - 'POLICY_CATEGORY_BLOCKED'
+            - 'PAYMENT_INSUFFICIENT_FUNDS'
+            - 'PAYMENT_TX_FAILED'
+            - 'PAYMENT_TX_TIMEOUT'
+            - 'RATE_LIMIT_EXCEEDED'
+            - 'UPSTREAM_HORIZON_DOWN'
+            - 'UPSTREAM_LLM_DOWN'
+            - 'UPSTREAM_FACILITATOR_DOWN'
+            - 'UPSTREAM_FACILITATOR_ERROR'
+            - 'UPSTREAM_TIMEOUT'
+            - 'SERVER_DEGRADED'
+            - 'SERVER_INTERNAL_ERROR'
           description: 'Stable machine-readable error code. See docs/error-codes.md for the full registry.'
         details:
           type: 'object'
+      required:
+        - 'error'
+        - 'code'
+    X402PaymentChallenge:
+      type: 'object'
+      description: 'x402 payment challenge returned on 402 responses from paid routes. Shape is defined by the x402 protocol (see docs/setup/x402.md), not the shared Error schema — clients must branch on HTTP status 402, not on a `code` field, to detect this response.'
+      properties:
+        x402Version:
+          type: 'integer'
+        accepts:
+          type: 'array'
+          description: 'Accepted payment schemes, assets, and amounts for this route.'
+          items:
+            type: 'object'
+        error:
+          type: 'string'
+          description: 'Human-readable reason payment is required or was rejected.'
     ReadinessResponse:
       type: 'object'
       description: 'See docs/observability/health-checks.md for the full schema and check semantics.'
@@ -105,6 +150,18 @@ paths:
                     type: 'number'
                   categories:
                     type: 'object'
+        429:
+          description: 'Too many requests for this route''s rate-limit policy. `code` is RATE_LIMIT_EXCEEDED; back off and retry after the `Retry-After` header.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: 'Unhandled server error. `code` is SERVER_INTERNAL_ERROR.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /pharmacy/compare:
     get:
       summary: 'Compare pharmacy prices for a drug'
@@ -140,7 +197,35 @@ paths:
         200:
           description: 'Pharmacy query results'
         400:
-          description: 'Invalid request'
+          description: 'Invalid request. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        402:
+          description: 'Payment required. Response is an x402 payment challenge (not the shared Error schema): the body describes accepted payment schemes/amounts and an X-PAYMENT-related header identifies the facilitator. Retry the request with an X-PAYMENT header containing a valid payment proof for one of the accepted schemes.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/X402PaymentChallenge'
+        404:
+          description: 'Drug or pharmacy not found. `code` is NOT_FOUND_DRUG or NOT_FOUND_PHARMACY.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        429:
+          description: 'Too many requests for this route''s rate-limit policy. `code` is RATE_LIMIT_EXCEEDED; back off and retry after the `Retry-After` header.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: 'Unhandled server error. `code` is SERVER_INTERNAL_ERROR.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /pharmacy/prices:
     post:
       summary: 'Admin upsert for a drug price at a pharmacy'
@@ -173,7 +258,29 @@ paths:
         200:
           description: 'Price created or updated'
         400:
-          description: 'Validation error'
+          description: 'Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Missing admin token. `code` is AUTH_TOKEN_MISSING.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Admin token invalid or insufficient. `code` is AUTH_TOKEN_INVALID or AUTH_ADMIN_REQUIRED.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: 'Unhandled server error. `code` is SERVER_INTERNAL_ERROR.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /bill/audit:
     post:
       summary: 'Audit medical bills'
@@ -218,7 +325,7 @@ paths:
         200:
           description: 'Audit results'
         400:
-          description: 'Validation error'
+          description: 'Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.'
           content:
             application/json:
               schema:
@@ -226,6 +333,30 @@ paths:
                 properties:
                   errors:
                     type: 'array'
+        402:
+          description: 'Payment required. Response is an x402 payment challenge (not the shared Error schema): the body describes accepted payment schemes/amounts and an X-PAYMENT-related header identifies the facilitator. Retry the request with an X-PAYMENT header containing a valid payment proof for one of the accepted schemes.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/X402PaymentChallenge'
+        413:
+          description: 'Request body exceeds the configured size limit. `code` is BODY_TOO_LARGE; `details.limit` reports the configured maximum in bytes.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        429:
+          description: 'Too many requests for this route''s rate-limit policy. `code` is RATE_LIMIT_EXCEEDED; back off and retry after the `Retry-After` header.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: 'Unhandled server error. `code` is SERVER_INTERNAL_ERROR.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /drug/interactions:
     get:
       summary: 'Check drug interactions for a medication list'
@@ -246,7 +377,29 @@ paths:
         200:
           description: 'Drug interaction results'
         400:
-          description: 'Validation error'
+          description: 'Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT, VALIDATION_INSUFFICIENT_SCORE.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        402:
+          description: 'Payment required. Response is an x402 payment challenge (not the shared Error schema): the body describes accepted payment schemes/amounts and an X-PAYMENT-related header identifies the facilitator. Retry the request with an X-PAYMENT header containing a valid payment proof for one of the accepted schemes.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/X402PaymentChallenge'
+        429:
+          description: 'Too many requests for this route''s rate-limit policy. `code` is RATE_LIMIT_EXCEEDED; back off and retry after the `Retry-After` header.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: 'Unhandled server error. `code` is SERVER_INTERNAL_ERROR.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /pharmacy/order:
     post:
       summary: 'Submit a paid pharmacy order'
@@ -281,9 +434,35 @@ paths:
         200:
           description: 'Order confirmed'
         400:
-          description: 'Validation error'
+          description: 'Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         402:
-          description: 'Payment required'
+          description: 'Payment required. Response is an x402 payment challenge (not the shared Error schema): the body describes accepted payment schemes/amounts and an X-PAYMENT-related header identifies the facilitator. Retry the request with an X-PAYMENT header containing a valid payment proof for one of the accepted schemes.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/X402PaymentChallenge'
+        429:
+          description: 'Too many requests for this route''s rate-limit policy. `code` is RATE_LIMIT_EXCEEDED; back off and retry after the `Retry-After` header.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: 'Order or payment processing failed. `code` is one of SERVER_INTERNAL_ERROR, PAYMENT_TX_FAILED.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        502:
+          description: 'Stellar transaction timed out or an upstream dependency is unreachable. `code` is one of PAYMENT_TX_TIMEOUT, UPSTREAM_HORIZON_DOWN, UPSTREAM_FACILITATOR_DOWN, UPSTREAM_FACILITATOR_ERROR.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /docs:
     get:
       summary: 'API documentation UI'

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,7 @@ Operational runbooks for on-call engineers. Each runbook follows the template:
 | [llm-rate-limit.md](llm-rate-limit.md) | Groq 429 / LLM provider rate-limit hit — behaviour, provider switching mid-incident |
 | [dashboard-disconnected.md](dashboard-disconnected.md) | Dashboard shows "Disconnected" chip — diagnosing API connectivity issues |
 | [horizon-down.md](horizon-down.md) | Stellar Horizon outage or testnet congestion — detection, in-doubt settlement verification, fee-bump tuning, recovery |
+| [redis-down.md](redis-down.md) | Redis unavailable — in-process cache fallback, what state degrades (webhook replay protection), and recovery |
 
 ---
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,6 +17,7 @@ Operational runbooks for on-call engineers. Each runbook follows the template:
 | [dashboard-disconnected.md](dashboard-disconnected.md) | Dashboard shows "Disconnected" chip — diagnosing API connectivity issues |
 | [horizon-down.md](horizon-down.md) | Stellar Horizon outage or testnet congestion — detection, in-doubt settlement verification, fee-bump tuning, recovery |
 | [redis-down.md](redis-down.md) | Redis unavailable — in-process cache fallback, what state degrades (webhook replay protection), and recovery |
+| [disk-full.md](disk-full.md) | Disk full / data directory exhaustion — diagnosing largest writers, safe recovery without breaking the audit-log hash chain |
 
 ---
 

--- a/docs/runbooks/disk-full.md
+++ b/docs/runbooks/disk-full.md
@@ -1,0 +1,157 @@
+# Runbook: Disk full / data directory exhaustion
+
+**Symptom**
+
+One or more of:
+
+- The pharmacy-payment service's `GET /ready` returns `503` with
+  `{ "error": "Order store is not writable" }` (`services/pharmacy-payment/server.ts`
+  checks `accessSync(DATA_DIR, fs.constants.W_OK)` on every readiness probe).
+- `audit-log: failed to write entry: ENOSPC: no space left on device` on stderr
+  from `appendAuditEntry` (`shared/audit-log.ts`) — the catch block writes this
+  directly to `process.stderr` rather than throwing, so the request that
+  triggered the audit write still completes, but the entry is lost.
+- `audit-log: failed to rotate logs: ...` on stderr — rotation failed, usually
+  because there wasn't room to write the renamed archive.
+- Any write to `data/recipients/{id}/spending.json`, `orders.json`, or
+  `data/mpp-store.json` throws `ENOSPC` and the request fails with a 500.
+- `docker compose` or the host reports the volume/filesystem at 100%.
+
+**Impact**
+
+Files under `data/` are written with plain `readFileSync`/`writeFileSync` (not
+atomic rename-then-swap) in most call sites, and disk space is not
+pre-checked before a write is attempted. On a full disk:
+
+| File | What breaks |
+|---|---|
+| `data/audit.log.jsonl` | Appends fail (`ENOSPC`). Because the hash chain (`shared/audit-log.ts`) is computed from `prevHash + canonicalize(payload)` at write time and only advances on a successful append, a failed append simply drops the event — it does **not** corrupt the existing chain. But the event is unrecoverably lost unless it's re-derivable from another source (e.g. re-run the action). |
+| `data/recipients/{id}/spending.json`, `orders.json`, `policy.json` | A write that fails partway through **can** leave a truncated/invalid JSON file, since these are not written via atomic temp-file-then-rename. The next read (`JSON.parse`) throws, and that recipient's spending/policy state becomes unreadable until fixed. |
+| `data/mpp-store.json` (pharmacy-payment service) | Same non-atomic-write risk; `GET /ready` on that service will report `503` as soon as the directory itself fails a writability check, which is the earliest and most reliable signal. |
+| `data/adherence.jsonl` | Appends fail; individual adherence entries are lost, same as the audit log but without a hash chain to protect. |
+
+The audit log's rotation (`rotateLogs()` in `shared/audit-log.ts`) renames
+`audit.log.jsonl` → `audit.log.jsonl.1` → ... → `.12` once the active file
+reaches **10 MB**, keeping at most 12 archived generations (~120 MB total for
+the audit log alone, unbounded for the other files below). Rotation itself
+needs free space for the rename; on a sufficiently full disk even rotation
+can fail, at which point the active file keeps growing past 10 MB.
+
+**Files that grow unbounded** (no automatic rotation or size cap):
+
+- `data/recipients/*/transactions.jsonl` — append-only, one line per transaction, never rotated
+- `data/recipients/*/orders.json` — full order history held as one JSON array
+- `data/adherence.jsonl` — append-only, never rotated
+- Docker/application logs outside `data/`, if not managed by the host's log rotation
+
+**Diagnosis**
+
+1. **Check overall disk usage:**
+   ```bash
+   df -h
+   ```
+   For the Docker Compose deployment specifically, check the volume backing `data/`:
+   ```bash
+   docker compose exec server df -h /app/data   # path may differ; see docker-compose.yml volume mount
+   ```
+
+2. **Identify the largest writers under `data/`:**
+   ```bash
+   du -sh data/* data/recipients/*/* 2>/dev/null | sort -rh | head -20
+   ```
+
+3. **Check audit log size and rotation state specifically:**
+   ```bash
+   ls -lh data/audit.log.jsonl data/audit.log.jsonl.* 2>/dev/null
+   ```
+   If `audit.log.jsonl` is significantly larger than 10 MB, rotation is not
+   keeping up — check for the `failed to rotate logs` stderr line.
+
+4. **Check service health/readiness for the earliest signal:**
+   ```bash
+   curl -s localhost:3000/ready | jq .          # main server
+   curl -s localhost:<pharmacy-payment-port>/ready  # pharmacy-payment service — checks DATA_DIR writability directly
+   ```
+
+5. **Grep logs for write failures:**
+   ```bash
+   docker compose logs | grep -E "ENOSPC|failed to write entry|failed to rotate logs|Order store is not writable"
+   ```
+
+**Mitigation (fastest way to reduce impact — not a permanent fix)**
+
+1. **Free space immediately** by removing or moving old rotated audit archives
+   first — they're the safest thing to relocate since they're already
+   closed/immutable:
+   ```bash
+   # Move (don't delete) old archives off the full volume to preserve them
+   mkdir -p /var/backups/careguard-audit
+   mv data/audit.log.jsonl.[5-9] data/audit.log.jsonl.1[0-2] /var/backups/careguard-audit/ 2>/dev/null
+   ```
+   Do **not** truncate or delete `data/audit.log.jsonl` itself (the active
+   file) — see Remediation below for why that breaks the hash chain.
+
+2. If still critically low on space and no archives remain to move, compress
+   the archives in place rather than deleting them:
+   ```bash
+   gzip data/audit.log.jsonl.[1-9] data/audit.log.jsonl.1[0-2] 2>/dev/null
+   ```
+
+3. Once the writability check passes again (`GET /ready` on pharmacy-payment
+   returns `200`), traffic recovers automatically — there is no explicit
+   "resume" step; the next write attempt just succeeds.
+
+**Remediation (permanent fix, preserving the audit chain)**
+
+1. **Never truncate or edit the active `audit.log.jsonl` in place.** Every
+   entry's `hash` is `sha256(prevHash + canonicalize(payload))`, chained to the
+   entry before it (see `appendAuditEntry` in `shared/audit-log.ts` and the
+   [audit-log-tamper-detected](audit-log-tamper-detected.md) runbook). Deleting
+   or rewriting lines breaks the chain the same way tampering would, and the
+   verifier (`npx tsx scripts/verify-audit-log.ts`) will flag it identically —
+   there's no way to distinguish "operator truncated for space" from
+   "attacker tampered" after the fact. If space must be reclaimed from the
+   active file, force a rotation instead (stop the service, rename
+   `audit.log.jsonl` to `audit.log.jsonl.1` — shifting existing numbered
+   archives up first — then restart so a fresh file with a genesis `prevHash`
+   is created).
+2. **Relocate `data/` to a volume with headroom.** Set `DATA_DIR` (read by
+   `shared/audit-log.ts`, `shared/adherence.ts`, and
+   `services/pharmacy-payment/server.ts`) to a path on a larger disk or a
+   dedicated volume, then restart.
+3. **Back up rotated archives off-box on a schedule**, then it's safe to
+   delete local copies once confirmed backed up. There is currently no
+   automated backup process for `data/` in this repo (the same gap noted for
+   Prometheus data in
+   [prometheus-retention.md](../observability/prometheus-retention.md)) —
+   until one exists, treat step 1's "move, don't delete" archives as your
+   only backup.
+4. **Add alerting before the disk fills**, rather than discovering it via a
+   503: alert on `df` usage percentage for the `data/` volume, and/or on the
+   audit log growing past its 10 MB rotation threshold without a
+   corresponding `.1` archive appearing (a sign rotation itself is failing).
+5. **Bound the currently-unbounded files.** `transactions.jsonl` and
+   `adherence.jsonl` have no rotation today; if this becomes a recurring
+   issue, apply the same rotation strategy already implemented for the audit
+   log (`rotateLogs()` in `shared/audit-log.ts`) to these files.
+6. **Verify the audit chain after any recovery involving the audit log:**
+   ```bash
+   npx tsx scripts/verify-audit-log.ts
+   ```
+
+**Post-mortem template**
+
+- Date / duration:
+- Root cause:
+- Detection lag:
+- Mitigation taken:
+- Remediation:
+- Action items:
+
+## Related
+
+- `shared/audit-log.ts` — rotation threshold (10 MB), archive count (12), hash chain, non-throwing write failures
+- `services/pharmacy-payment/server.ts` — `GET /ready` writability check, `MAX_BODY_SIZE`/413 handling
+- [audit-log-tamper-detected.md](audit-log-tamper-detected.md) — hash-chain verification and restore process; the same chain-integrity concerns apply to any operator action that edits the active log file
+- [prometheus-retention.md](../observability/prometheus-retention.md) — the same "no backup process today" gap, documented for a different data store
+- `docs/adr/002-pii-in-persistence.md` — why `data/` files are untracked JSON/JSONL rather than a database, and the planned SQLite migration (#111) that would remove most of this class of failure

--- a/docs/runbooks/redis-down.md
+++ b/docs/runbooks/redis-down.md
@@ -1,0 +1,156 @@
+# Runbook: Redis unavailable — degraded shared-state behaviour
+
+**Symptom**
+
+The server logs a warning at boot (or on first cache access if `REDIS_URL` is
+set but unreachable):
+
+```
+REDIS_URL not set — using in-process cache. State is not shared across instances and is lost on restart.
+```
+
+or, when `REDIS_URL` is set but the connection itself is failing:
+
+```
+redis connection error { err: "..." }
+redis get error { err: "..." }
+redis set error { err: "..." }
+```
+
+There is no crash and no 5xx spike directly attributable to this — `shared/redis.ts`
+is designed to degrade quietly, which is exactly what makes it dangerous to miss.
+
+**Impact**
+
+`shared/redis.ts` exports a `CacheClient` (`get`/`set`/`incr`/`del`/`acquireLock`).
+Today the only consumer wired into the request path is **webhook replay
+protection** (`shared/verify-webhook.ts`), which uses `cache.get`/`cache.set`
+under the `webhook:seen:<id>` key to reject duplicate `X-Webhook-Id` deliveries
+within a 10-minute window.
+
+| Mode | Behaviour |
+|---|---|
+| `REDIS_URL` set, Redis reachable | Replay keys are shared across all server instances/processes. A webhook replayed to a different instance than the one that first saw it is still caught. |
+| `REDIS_URL` unset, or Redis unreachable | Falls back to `createInMemoryClient()` — a plain in-process `Map`. Replay keys exist **only in the process that saw the original request.** |
+
+Consequences of the in-memory fallback:
+
+- **Replay protection stops working across instances.** In any multi-instance
+  or multi-process deployment (e.g. horizontally scaled Render/Docker
+  services, or a separate cron/worker process), a webhook delivered twice to
+  two different instances is treated as two distinct events instead of one
+  idempotent no-op.
+- **State does not survive a restart.** A process restart empties the `Map`,
+  so replay history resets to empty — a webhook redelivered by the sender
+  after a deploy will not be recognized as a duplicate even on the *same*
+  logical instance.
+- **No cross-instance locking.** `acquireLock` only prevents concurrent access
+  within a single process; it provides no mutual exclusion across instances
+  when Redis is down.
+
+> **Not affected by this fallback:** the agent pause flag (`shared/agent-state.ts`)
+> and the MPP payment-plan store (`services/pharmacy-payment/*` →
+> `data/mpp-store.json`) are **not** backed by `shared/redis.ts` — they are
+> in-process module state and a JSON file on disk, respectively. Neither
+> degrades when Redis is down. If you see stale pause state or MPP
+> inconsistency, look at process restarts or file-system issues (see
+> [disk-full.md](disk-full.md)) instead of Redis.
+
+On a single-instance deployment (the current default — see
+[ADR-003](../adr/unified-vs-split-server.md)), the practical blast radius is
+limited to: a webhook redelivered after a process restart will be reprocessed
+instead of deduplicated. On a scaled-out deployment, replay protection is
+effectively disabled for cross-instance duplicates for as long as Redis stays
+down.
+
+**Diagnosis**
+
+1. **Boot-time warning.** Grep server logs for the fallback message:
+   ```bash
+   docker compose logs server | grep "using in-process cache"
+   ```
+   If present, `REDIS_URL` was never configured for this instance — this is
+   the expected default in single-instance/testnet setups, not necessarily an
+   incident.
+
+2. **Runtime connection errors.** If `REDIS_URL` *is* set but Redis itself is
+   unreachable, `ioredis`'s `error` listener fires on every reconnect attempt:
+   ```bash
+   docker compose logs server | grep -E "redis (connection|get|set|incr|del|acquireLock) error"
+   ```
+   Each cache operation catches its own error and logs it individually
+   (`shared/redis.ts`), so a Redis outage shows up as a steady stream of these
+   lines rather than a single fatal error — the process keeps running.
+
+3. **Confirm the effective mode.** There is no `/ready` check for Redis today
+   (see [health-checks.md](../observability/health-checks.md) for what `/ready`
+   *does* check). To confirm which client is active, check the environment
+   directly:
+   ```bash
+   docker compose exec server sh -c 'echo REDIS_URL=$REDIS_URL'
+   ```
+   Empty output means every instance is on the in-memory fallback by design.
+
+4. **Confirm duplicate webhook processing.** If you suspect replay protection
+   silently failed, check the audit log for two entries with the same
+   upstream event/webhook id close together:
+   ```bash
+   grep '"webhookId"' data/audit.log.jsonl | tail -20
+   ```
+
+**Mitigation**
+
+- If this is a genuine Redis outage (was working, now isn't): no immediate
+  action is required to keep the service up — the fallback keeps webhook
+  processing functional on a single instance. The risk is silent duplicate
+  processing on multi-instance deployments, not downtime.
+- If webhook duplicate-delivery risk is unacceptable while Redis is down,
+  consider temporarily routing all webhook traffic to a single instance
+  (disable the others) until Redis recovers, so the in-memory replay cache is
+  at least consistent for that instance.
+
+**Remediation**
+
+1. **Restore Redis connectivity.** Fix the underlying infra issue (Redis
+   process down, network partition, auth/TLS misconfiguration, wrong
+   `REDIS_URL`).
+2. **No explicit reconnect step is needed in the app.** `ioredis` reconnects
+   automatically; once `redis connection error` lines stop appearing, the
+   `CacheClient` returned by `createRedisClient` is live again — there is no
+   separate "switch back" flag to flip.
+3. **Restart is only required if the fallback was chosen at boot.** The
+   default client is a lazy singleton (`getDefaultClient()` in
+   `shared/redis.ts`) selected once, the first time it's needed, based on
+   whether `REDIS_URL` was set *at that time*. If you add or fix `REDIS_URL`
+   on a running instance, you must restart the process — the singleton will
+   not re-evaluate the env var on its own.
+4. **Manual state reconciliation after recovery.** There is no cross-instance
+   state to reconcile: the in-memory fallback never wrote anything Redis needs
+   to catch up on, and vice versa. The only residual risk is any webhook
+   deliveries that were duplicate-processed while instances were running
+   disjoint in-memory replay caches — cross-reference `data/audit.log.jsonl`
+   for the affected window against the upstream provider's delivery log if you
+   need to confirm no duplicate side effects (e.g. duplicate payment
+   confirmations) occurred.
+5. **Multi-instance deployments:** once confirmed stable, ensure `REDIS_URL`
+   is set identically on every instance so replay protection is consistently
+   shared — see `.env.example` and [ADR-003](../adr/unified-vs-split-server.md)'s
+   note on Redis-backed rate limiting for the same consideration applied to a
+   different subsystem.
+
+**Post-mortem template**
+
+- Date / duration:
+- Root cause:
+- Detection lag:
+- Mitigation taken:
+- Remediation:
+- Action items:
+
+## Related
+
+- `shared/redis.ts` — `CacheClient`, in-memory fallback, singleton selection
+- `shared/verify-webhook.ts` — the only current consumer of the cache client
+- [ADR-003: Unified vs. Split Server](../adr/unified-vs-split-server.md) — notes Redis-backed rate limiting as a future, not-yet-activated option for multi-instance deployments
+- [disk-full.md](disk-full.md) — file-backed state (MPP store, spending/orders) that is *not* affected by Redis availability
+- [health-checks.md](../observability/health-checks.md) — what `/ready` does and does not verify today

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,54 @@
+# Operator Troubleshooting Guide
+
+A symptom-to-resolution index for on-call operators. Each row is a starting
+point, not the full fix — follow the link for diagnosis and remediation
+steps. If nothing here matches, check
+[docs/runbooks/README.md](runbooks/README.md) for the full runbook index.
+
+## Run these first
+
+Before chasing a specific symptom below, these commands establish the
+overall health of the stack and often point straight at the right row:
+
+```bash
+# Service logs (swap 'server' for 'dashboard', 'redis', 'prometheus', 'grafana')
+docker compose logs server --tail=200
+
+# Liveness — is the process up at all?
+curl -s localhost:3000/health
+
+# Readiness — are dependencies (env, Horizon, OZ facilitator) healthy?
+curl -s localhost:3000/ready | jq .
+
+# Prometheus metrics — rate limits, queue depth, concurrent requests, etc.
+curl -s localhost:3000/metrics | grep -E "ratelimit_hits_total|route_concurrent_requests|agent_waiting_jobs"
+```
+
+See [health-checks.md](observability/health-checks.md) for what `/health` vs
+`/ready` each verify, and [metrics-catalog.md](observability/metrics-catalog.md)
+for the full metric list.
+
+## Symptom → Resolution
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| **Agent spinner never resolves** (dashboard "Active"/"Paused" chip never updates after clicking run) | Agent run rate-limited or queued behind another long-running LLM call; or the request never got a response (server crash, event-loop block) | Check `docker compose logs server` for the request; check `route_concurrent_requests{route="agent_run"}` and `agent_waiting_jobs` via `/metrics`; confirm `/health` still returns `200` (a live-but-stuck process still answers `/health`, so a non-responding spinner with a healthy `/health` points at the LLM call itself — see [llm-config.md](agent/llm-config.md)) |
+| **Repeated 402s** on a paid route (`/pharmacy/compare`, `/bill/audit`, `/drug/interactions`, `/pharmacy/order`) | Missing/expired payment proof, wallet underfunded, or the OZ facilitator is degraded and rejecting/timing out payment verification | Confirm the client is retrying with a valid `X-PAYMENT` header per the challenge body (see [openapi.yml](openapi.yml) `X402PaymentChallenge` schema); check wallet balance (row below); if the facilitator itself is the problem, see [x402-facilitator-down.md](runbooks/x402-facilitator-down.md) and [oz-facilitator-outage.md](runbooks/oz-facilitator-outage.md) |
+| **Blank / stuck wallet balance** on the dashboard's Wallet tab | Horizon unreachable, wrong `NETWORK`/RPC config, or the agent wallet genuinely has zero balance | Check `/ready`'s `horizon` check; verify `AGENT_SECRET_KEY`/public key matches the funded testnet wallet; cross-check the balance directly on [stellar.expert](https://stellar.expert/explorer/testnet); if the agent has auto-paused for low balance, see [wallet-low.md](runbooks/wallet-low.md) |
+| **Dashboard shows "Disconnected"** chip in the header | One or more of the agent-info, spending, or transactions API calls the dashboard polls is failing | Hover the source-health chip next to "Disconnected" in the header (`dashboard-header.tsx`) — it lists which specific source (Agent/Spending/Transactions) is erroring; check that service's logs and confirm the backend port the dashboard is configured to hit (`dashboard/.env.local`) matches a running instance |
+| **Startup hangs / stalls on Horizon** | `https://horizon-testnet.stellar.org` (or configured RPC) is slow or unreachable at boot, and a dependency check is blocking startup | Check `/ready`'s `horizon` field; see [horizon-down.md](runbooks/horizon-down.md) for detection, in-doubt settlement verification, and recovery. Note the readiness check is hardcoded to testnet Horizon regardless of `NETWORK` — see the caveat in [health-checks.md](observability/health-checks.md) |
+| **Missing / invalid env var** at boot (`OZ_FACILITATOR_API_KEY required`, `LLM_API_KEY required`, etc.) | A required secret is unset or malformed in `.env` | Run `npx tsx scripts/check-env-vars.ts`; check `/ready`'s `env` field for the exact missing-variable list; see [QUICKSTART.md](../QUICKSTART.md#troubleshooting) for where to obtain each key |
+| **Groq / LLM provider 429** | LLM provider rate limit hit | See [QUICKSTART.md](../QUICKSTART.md#troubleshooting) — wait for reset or switch provider/model via `LLM_BASE_URL`/`LLM_API_KEY`; see [llm-config.md](agent/llm-config.md) |
+| **`413` on `/bill/audit` or other routes** | Request body exceeds the configured size limit | See the `413` response documented per-route in [openapi.yml](openapi.yml); the limit is enforced before x402 payment is charged, so no funds are taken on a rejected oversized request |
+| **`ENOSPC` / audit log write failures / disk pressure** | `data/` volume is full | See [disk-full.md](runbooks/disk-full.md) |
+| **Redis warnings, cross-instance state inconsistency** | Redis unreachable or `REDIS_URL` unset — cache falls back to in-process memory | See [redis-down.md](runbooks/redis-down.md) |
+| **Audit log verification fails / suspected tampering** | Hash chain broken | See [audit-log-tamper-detected.md](runbooks/audit-log-tamper-detected.md) |
+| **Port already in use** during local dev | Leftover process from a previous run | See [QUICKSTART.md](../QUICKSTART.md#troubleshooting) port-cleanup commands |
+
+## Related
+
+- [docs/runbooks/README.md](runbooks/README.md) — full runbook index and the incident-response template each runbook follows
+- [docs/error-codes.md](error-codes.md) — machine-readable error code registry referenced by API responses
+- [docs/observability/health-checks.md](observability/health-checks.md) — `/health` vs `/ready` semantics
+- [docs/observability/metrics-catalog.md](observability/metrics-catalog.md) — full Prometheus metric list
+- [QUICKSTART.md](../QUICKSTART.md) — setup-time troubleshooting (env keys, faucets, port cleanup)

--- a/scripts/gen-openapi.ts
+++ b/scripts/gen-openapi.ts
@@ -18,6 +18,83 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const docsDir = path.resolve(__dirname, "../docs");
 
+// Kept in sync with the registry in docs/error-codes.md — that file is the
+// source of truth for meaning/remediation; this enum is what clients can
+// validate against in the spec itself.
+const ERROR_CODES = [
+  "VALIDATION_MISSING_FIELD",
+  "VALIDATION_INVALID_INPUT",
+  "VALIDATION_INSUFFICIENT_SCORE",
+  "AUTH_TOKEN_MISSING",
+  "AUTH_TOKEN_EXPIRED",
+  "AUTH_TOKEN_INVALID",
+  "AUTH_ADMIN_REQUIRED",
+  "NOT_FOUND_DRUG",
+  "NOT_FOUND_PHARMACY",
+  "NOT_FOUND_AGENT",
+  "BODY_TOO_LARGE",
+  "POLICY_DAILY_LIMIT",
+  "POLICY_MONTHLY_LIMIT",
+  "POLICY_APPROVAL_REQUIRED",
+  "POLICY_CATEGORY_BLOCKED",
+  "PAYMENT_INSUFFICIENT_FUNDS",
+  "PAYMENT_TX_FAILED",
+  "PAYMENT_TX_TIMEOUT",
+  "RATE_LIMIT_EXCEEDED",
+  "UPSTREAM_HORIZON_DOWN",
+  "UPSTREAM_LLM_DOWN",
+  "UPSTREAM_FACILITATOR_DOWN",
+  "UPSTREAM_FACILITATOR_ERROR",
+  "UPSTREAM_TIMEOUT",
+  "SERVER_DEGRADED",
+  "SERVER_INTERNAL_ERROR",
+] as const;
+
+/** Standard 4xx/5xx response referencing the shared Error schema. */
+function errorResponse(description: string) {
+  return {
+    description,
+    content: {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/Error" },
+      },
+    },
+  };
+}
+
+/** 402 challenge response for x402-protected routes. */
+function paymentRequiredResponse() {
+  return {
+    description:
+      "Payment required. Response is an x402 payment challenge (not the shared Error schema): " +
+      "the body describes accepted payment schemes/amounts and an X-PAYMENT-related header " +
+      "identifies the facilitator. Retry the request with an X-PAYMENT header containing a " +
+      "valid payment proof for one of the accepted schemes.",
+    content: {
+      "application/json": {
+        schema: { $ref: "#/components/schemas/X402PaymentChallenge" },
+      },
+    },
+  };
+}
+
+/** 413 response for routes with an explicit body-size limit. */
+function bodyTooLargeResponse() {
+  return errorResponse(
+    "Request body exceeds the configured size limit. `code` is BODY_TOO_LARGE; `details.limit` " +
+      "reports the configured maximum in bytes.",
+  );
+}
+
+const RATE_LIMIT_RESPONSE = errorResponse(
+  "Too many requests for this route's rate-limit policy. `code` is RATE_LIMIT_EXCEEDED; " +
+    "back off and retry after the `Retry-After` header.",
+);
+
+const SERVER_ERROR_RESPONSE = errorResponse(
+  "Unhandled server error. `code` is SERVER_INTERNAL_ERROR.",
+);
+
 interface OpenAPIInfo {
   title: string;
   version: string;
@@ -118,10 +195,40 @@ export function generateSpec(): OpenAPISpec {
       schemas: {
         Error: {
           type: "object",
+          description:
+            "Standard error envelope for 4xx/5xx responses. See docs/error-codes.md for the full registry of `code` values, their meaning, and remediation.",
           properties: {
-            error: { type: "string" },
-            code: { type: "string" },
+            error: {
+              type: "string",
+              description: "Human-readable message — do NOT branch on this value.",
+            },
+            code: {
+              type: "string",
+              enum: [...ERROR_CODES],
+              description:
+                "Stable machine-readable error code. See docs/error-codes.md for the full registry.",
+            },
             details: { type: "object" },
+          },
+          required: ["error", "code"],
+        },
+        X402PaymentChallenge: {
+          type: "object",
+          description:
+            "x402 payment challenge returned on 402 responses from paid routes. Shape is defined by " +
+            "the x402 protocol (see docs/setup/x402.md), not the shared Error schema — clients must " +
+            "branch on HTTP status 402, not on a `code` field, to detect this response.",
+          properties: {
+            x402Version: { type: "integer" },
+            accepts: {
+              type: "array",
+              description: "Accepted payment schemes, assets, and amounts for this route.",
+              items: { type: "object" },
+            },
+            error: {
+              type: "string",
+              description: "Human-readable reason payment is required or was rejected.",
+            },
           },
         },
         ReadinessResponse: {
@@ -209,6 +316,8 @@ export function generateSpec(): OpenAPISpec {
                 },
               },
             },
+            "429": RATE_LIMIT_RESPONSE,
+            "500": SERVER_ERROR_RESPONSE,
           },
         },
       },
@@ -255,9 +364,13 @@ export function generateSpec(): OpenAPISpec {
             "200": {
               description: "Pharmacy query results",
             },
-            "400": {
-              description: "Invalid request",
-            },
+            "400": errorResponse(
+              "Invalid request. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.",
+            ),
+            "402": paymentRequiredResponse(),
+            "404": errorResponse("Drug or pharmacy not found. `code` is NOT_FOUND_DRUG or NOT_FOUND_PHARMACY."),
+            "429": RATE_LIMIT_RESPONSE,
+            "500": SERVER_ERROR_RESPONSE,
           },
         },
       },
@@ -297,9 +410,12 @@ export function generateSpec(): OpenAPISpec {
             "200": {
               description: "Price created or updated",
             },
-            "400": {
-              description: "Validation error",
-            },
+            "400": errorResponse(
+              "Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.",
+            ),
+            "401": errorResponse("Missing admin token. `code` is AUTH_TOKEN_MISSING."),
+            "403": errorResponse("Admin token invalid or insufficient. `code` is AUTH_TOKEN_INVALID or AUTH_ADMIN_REQUIRED."),
+            "500": SERVER_ERROR_RESPONSE,
           },
         },
       },
@@ -352,7 +468,7 @@ export function generateSpec(): OpenAPISpec {
               description: "Audit results",
             },
             "400": {
-              description: "Validation error",
+              description: "Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.",
               content: {
                 "application/json": {
                   schema: {
@@ -364,6 +480,10 @@ export function generateSpec(): OpenAPISpec {
                 },
               },
             },
+            "402": paymentRequiredResponse(),
+            "413": bodyTooLargeResponse(),
+            "429": RATE_LIMIT_RESPONSE,
+            "500": SERVER_ERROR_RESPONSE,
           },
         },
       },
@@ -390,9 +510,12 @@ export function generateSpec(): OpenAPISpec {
             "200": {
               description: "Drug interaction results",
             },
-            "400": {
-              description: "Validation error",
-            },
+            "400": errorResponse(
+              "Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT, VALIDATION_INSUFFICIENT_SCORE.",
+            ),
+            "402": paymentRequiredResponse(),
+            "429": RATE_LIMIT_RESPONSE,
+            "500": SERVER_ERROR_RESPONSE,
           },
         },
       },
@@ -433,12 +556,17 @@ export function generateSpec(): OpenAPISpec {
             "200": {
               description: "Order confirmed",
             },
-            "400": {
-              description: "Validation error",
-            },
-            "402": {
-              description: "Payment required",
-            },
+            "400": errorResponse(
+              "Validation error. `code` is one of VALIDATION_MISSING_FIELD, VALIDATION_INVALID_INPUT.",
+            ),
+            "402": paymentRequiredResponse(),
+            "429": RATE_LIMIT_RESPONSE,
+            "500": errorResponse(
+              "Order or payment processing failed. `code` is one of SERVER_INTERNAL_ERROR, PAYMENT_TX_FAILED.",
+            ),
+            "502": errorResponse(
+              "Stellar transaction timed out or an upstream dependency is unreachable. `code` is one of PAYMENT_TX_TIMEOUT, UPSTREAM_HORIZON_DOWN, UPSTREAM_FACILITATOR_DOWN, UPSTREAM_FACILITATOR_ERROR.",
+            ),
           },
         },
       },


### PR DESCRIPTION
## Summary

- Adds `docs/runbooks/redis-down.md`: what degrades when `shared/redis.ts` falls back to its in-process cache (webhook replay protection), diagnosis via log lines, and recovery — including clarifying that the agent pause flag and MPP store are *not* Redis-backed, since they're often assumed to be. Linked from the runbooks README index and ADR-003 (unified-vs-split-server), which is where Redis is discussed today.
- Adds `docs/runbooks/disk-full.md`: which `data/` files grow unbounded, diagnosis commands for free space and largest writers, and remediation that preserves the audit log's hash chain instead of truncating it. Linked from the runbooks README index.
- Extends `docs/openapi.yml` (generated via `scripts/gen-openapi.ts` — edited the generator, not the checked-in file directly) so every operation documents its 4xx/5xx responses against `components.schemas.Error`, with `Error.code` enumerated against the `docs/error-codes.md` registry. Adds a distinct `X402PaymentChallenge` schema for 402 responses on x402-protected routes (their body isn't the generic Error shape) and documents 413 body-limit responses on `/bill/audit`.
- Adds `docs/troubleshooting.md`: a symptom-to-resolution table (agent spinner stuck, repeated 402s, blank wallet balance, dashboard "Disconnected", startup hangs on Horizon, missing env) routing each to the relevant runbook or code area. Linked from `README.md` and `QUICKSTART.md`, and resolves the pre-existing TODO reference in `docs/error-codes.md`.

## Test plan

- [x] `npm run gen-openapi` run locally to regenerate `docs/openapi.yml` from the updated generator, confirming the checked-in spec matches generator output exactly (this is what `npm run validate:openapi` / CI's drift check enforces)
- [ ] Reviewer: skim the new runbooks against `shared/redis.ts` / `shared/audit-log.ts` for accuracy
- [ ] Reviewer: confirm `docs/openapi.yml` still validates as OpenAPI 3.1 in CI

closes #747,       closes #749,     closes #753,      closes #754