### PR TITLE
Fix issues 1138, 1139, 1140, 1141

### DIFF
--- a/dashboard/messages/es.json
+++ b/dashboard/messages/es.json
@@ -20,7 +20,7 @@
     "overview": "Resumen",
     "medications": "Medicamentos",
     "bills": "Facturas",
-    "policy": "Politica",
+    "policy": "Política",
     "wallet": "Billetera",
     "activity": "Actividad",
     "settings": "Ajustes"
@@ -28,27 +28,27 @@
   "overview": {
     "monthlySpending": "Gasto Mensual",
     "savingsFound": "Ahorros Encontrados",
-    "billingErrors": "Errores de Facturacion",
+    "billingErrors": "Errores de Facturación",
     "agentApiCosts": "Costos de API del Agente",
     "budgetStatus": "Estado del Presupuesto",
     "agentActions": "Acciones del Agente",
     "agentResponse": "Respuesta del Agente",
-    "limit": "limite",
+    "limit": "límite",
     "bySwitching": "cambiando de farmacia",
     "inOvercharges": "en sobrecargos identificados",
-    "queries": "consultas via x402"
+    "queries": "consultas vía x402"
   },
   "budget": {
     "medications": "Medicamentos",
-    "medicalBills": "Facturas Medicas"
+    "medicalBills": "Facturas Médicas"
   },
   "tasks": {
     "comparePrices": "Comparar Precios de Medicamentos",
-    "findCheapest": "Encontrarfarmacias mas economicas para los 4 medicamentos de Rosa",
+    "findCheapest": "Encontrar farmacias más económicas para los 4 medicamentos de Rosa",
     "auditBill": "Auditar Factura Hospitalaria",
     "scanBill": "Escanear factura de Rosa buscar errores",
     "overBudget": "Intentar Pago Excedente",
-    "demoPayment": "Demo: agente intenta $600 (sobre limite de $500)",
+    "demoPayment": "Demo: agente intenta $600 (sobre límite de $500)",
     "agentPaused": "Agente pausado",
     "working": "Agente trabajando..."
   },
@@ -56,35 +56,35 @@
     "title": "Medicamentos de Rosa",
     "downloadPdf": "Descargar PDF",
     "best": "Mejor",
-    "notYetCompared": "Aun no comparado",
+    "notYetCompared": "Aún no comparado",
     "save": "Ahorrar",
     "savings": "ahorro",
     "drugInteractions": "Interacciones Medicamentosas"
   },
   "bills": {
-    "title": "Resultados de Auditoria",
+    "title": "Resultados de Auditoría",
     "downloadPdf": "Descargar PDF",
     "errorsFound": "errores encontrados",
     "totalCharged": "Total Cargado",
     "overcharges": "Sobrecargos",
     "correctAmount": "Monto Correcto",
-    "lineItems": "lineas",
+    "lineItems": "líneas",
     "showErrors": "Mostrar solo errores",
     "showAll": "Mostrar todo",
     "notAudited": "No hay facturas auditadas. Ejecute \"Auditar Factura\" desde Resumen."
   },
   "policy": {
-    "title": "Politica de Gastos para Rosa",
-    "description": "Estos limites son implementados por contratos inteligente en Stellar. El agente no puede excederlos.",
-    "dailyLimit": "Limite Diario ($)",
-    "monthlyLimit": "Limite Mensual ($)",
+    "title": "Política de Gastos para Rosa",
+    "description": "Estos límites son implementados por contratos inteligente en Stellar. El agente no puede excederlos.",
+    "dailyLimit": "Límite Diario ($)",
+    "monthlyLimit": "Límite Mensual ($)",
     "medicationBudget": "Presupuesto Mensual Medicamentos ($)",
     "billBudget": "Presupuesto Mensual Facturas ($)",
-    "approvalThreshold": "Umbral de Aprobacion del Cuidador ($)",
+    "approvalThreshold": "Umbral de Aprobación del Cuidador ($)",
     "refresh": "Actualizar del servidor",
     "discard": "Descartar cambios",
-    "updatePolicy": "Actualizar Politica",
-    "policySaved": "Politica Guardada"
+    "updatePolicy": "Actualizar Política",
+    "policySaved": "Política Guardada"
   },
   "activity": {
     "title": "Registro de Transacciones",
@@ -94,44 +94,44 @@
     "noTransactions": "Sin transacciones",
     "time": "Hora",
     "type": "Tipo",
-    "description": "Descripcion",
+    "description": "Descripción",
     "amount": "Monto",
     "status": "Estado",
     "stellarTx": "Tx Stellar"
   },
   "wallet": {
     "title": "Billetera del Agente",
-    "description": "Esta es la billetera Stellar del agente IA. Contiene USDC para pagar farmacias, facturas medicas y consultas de API. Todos los saldos estan en Stellar testnet.",
+    "description": "Esta es la billetera Stellar del agente IA. Contiene USDC para pagar farmacias, facturas médicas y consultas de API. Todos los saldos están en Stellar testnet.",
     "usdcBalance": "Saldo USDC",
     "xlmBalance": "Saldo XLM",
-    "walletAddress": "Direccion de Billetera",
+    "walletAddress": "Dirección de Billetera",
     "network": "Red",
     "llmProvider": "Proveedor LLM",
     "networkStellar": "Stellar Testnet",
     "viewExplorer": "Ver en Stellar Explorer",
     "fund": "Recargar con USDC",
-    "howPayments": "Como Funcionan los Pagos"
+    "howPayments": "Cómo Funcionan los Pagos"
   },
   "settings": {
     "recipient": "Paciente",
     "name": "Nombre",
     "age": "Edad",
     "medications": "Medicamentos",
-    "doctor": "Medico Principal",
+    "doctor": "Médico Principal",
     "insurance": "Seguro",
     "caregiver": "Cuidador",
     "relationship": "Parentesco",
-    "location": "Ubicacion",
+    "location": "Ubicación",
     "notifications": "Notificaciones",
-    "agentConfig": "Configuracion del Agente",
+    "agentConfig": "Configuración del Agente",
     "agentStatus": "Estado del Agente",
     "notConnected": "No conectado"
   },
   "pdf": {
     "careguard": "CareGuard",
     "subtitle": "Agente de Salud con IA en Stellar",
-    "billAudit": "Informe de Auditoria de Factura Medica",
-    "medication": "Informe de Comparacion de Precios",
+    "billAudit": "Informe de Auditoría de Factura Médica",
+    "medication": "Informe de Comparación de Precios",
     "transaction": "Informe de Transacciones",
     "generated": "Generado"
   },

--- a/dashboard/src/components/primitives/bar.tsx
+++ b/dashboard/src/components/primitives/bar.tsx
@@ -1,22 +1,27 @@
+import { formatCurrency, type Locale } from "../../i18n";
+
 export interface BarProps {
   label: string;
   spent: number;
   budget: number;
+  // #1138 — defaults to "en" so existing callers that don't pass a locale
+  // render identically to before this change.
+  locale?: Locale;
 }
 
-export function Bar({ label, spent, budget }: BarProps) {
+export function Bar({ label, spent, budget, locale = "en" }: BarProps) {
   const s = spent ?? 0;
   const b = budget ?? 0;
   const raw = b === 0 ? 0 : (s / b) * 100;
   const pct = Number.isFinite(raw) ? Math.min(Math.max(raw, 0), 100) : 0;
   const color = pct > 90 ? "bg-red-500" : pct > 70 ? "bg-amber-500" : "bg-sky-500";
-  const displaySpent = Number.isFinite(s) ? s.toFixed(2) : "0.00";
+  const displaySpent = Number.isFinite(s) ? s : 0;
   return (
     <div>
       <div className="flex items-center justify-between text-xs mb-1">
         <span className="font-medium text-slate-600">{label}</span>
         <span className="text-slate-400">
-          ${displaySpent} / ${b}
+          {formatCurrency(displaySpent, locale)} / {formatCurrency(b, locale, 0)}
         </span>
       </div>
       <div className="h-2 bg-slate-100 rounded-full overflow-hidden">

--- a/dashboard/src/components/tabs/activity-tab.tsx
+++ b/dashboard/src/components/tabs/activity-tab.tsx
@@ -6,6 +6,7 @@ import { copyText } from "../../lib/clipboard";
 import type { RecipientProfile } from "../../lib/types";
 import { ConfirmDialog } from "../primitives/confirm-dialog";
 import { TxLink } from "../primitives/tx-link";
+import { formatTime, type Locale } from "../../i18n";
 import type {
   AgentLogEntry,
   PaginationData,
@@ -29,6 +30,9 @@ export interface ActivityTabProps {
   onResetAgent: () => void;
   loadingTransactions?: boolean;
   loadingSpending?: boolean;
+  // #1139 — defaults to "en" so existing callers that don't pass a locale
+  // render identically to before this change.
+  locale?: Locale;
 }
 
 export function ActivityTab({
@@ -44,6 +48,7 @@ export function ActivityTab({
   setPageSize,
   spending,
   onResetAgent,
+  locale = "en",
 }: ActivityTabProps) {
   const [showAllLogEntries, setShowAllLogEntries] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -294,7 +299,7 @@ export function ActivityTab({
                       return (
                         <tr key={item.id} className="border-b border-slate-100 last:border-0 bg-slate-50/50">
                           <td className="hidden md:table-cell px-4 py-2 text-xs text-slate-400">
-                            {new Date(au.timestamp).toLocaleTimeString()}
+                            {formatTime(new Date(au.timestamp), locale)}
                           </td>
                           <td className="px-4 py-2">
                             <span className="px-2 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-200">
@@ -318,7 +323,7 @@ export function ActivityTab({
                         className="border-b border-slate-100 last:border-0"
                       >
                         <td className="hidden md:table-cell px-4 py-2 text-xs text-slate-400">
-                          {new Date(tx.timestamp).toLocaleTimeString()}
+                          {formatTime(new Date(tx.timestamp), locale)}
                         </td>
                         <td className="px-4 py-2">
                           <span

--- a/dashboard/src/components/tabs/approvals-tab.tsx
+++ b/dashboard/src/components/tabs/approvals-tab.tsx
@@ -6,13 +6,17 @@ import { Card } from "../primitives/card";
 import type { Transaction } from "../types";
 import { AGENT_URL } from "../../lib/agent-url";
 import { agentFetch } from "../../lib/agent-fetch";
+import { formatDateTime, type Locale } from "../../i18n";
 
 
 export interface ApprovalsTabProps {
   agentConnected: boolean;
+  // #1139 — defaults to "en" so existing callers that don't pass a locale
+  // render identically to before this change.
+  locale?: Locale;
 }
 
-export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
+export function ApprovalsTab({ agentConnected, locale = "en" }: ApprovalsTabProps) {
   const [approvals, setApprovals] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(false);
   const [, setTick] = useState(0);
@@ -99,7 +103,7 @@ export function ApprovalsTab({ agentConnected }: ApprovalsTabProps) {
                       Amount: ${tx.amount.toFixed(2)} | Category: {tx.category}
                     </div>
                     <div className="text-xs text-slate-400 mt-1">
-                      {new Date(tx.timestamp).toLocaleString()}
+                      {formatDateTime(new Date(tx.timestamp), locale)}
                     </div>
                     {tx.pendingUntil && (
                       <div className="text-xs text-amber-600 mt-1">

--- a/dashboard/src/components/tabs/overview-tab.tsx
+++ b/dashboard/src/components/tabs/overview-tab.tsx
@@ -7,6 +7,7 @@ import { Card } from "../primitives/card";
 import type { AgentResult, AgentLlmError, SpendingData } from "../types";
 import type { RecipientProfile } from "../../lib/types";
 import { agentFetch } from "../../lib/agent-fetch";
+import { formatCurrency, type Locale } from "../../i18n";
 
 export interface OverviewTabProps {
   spending: SpendingData | null;
@@ -17,6 +18,9 @@ export interface OverviewTabProps {
   onRunTask: (task: string, label: string) => void;
   onCancelTask?: () => void;
   recipient?: RecipientProfile;
+  // #1138 — defaults to "en" so existing callers that don't pass a locale
+  // render identically to before this change.
+  locale?: Locale;
 }
 
 const TASKS = {
@@ -34,6 +38,7 @@ export function OverviewTab({
   onRunTask,
   onCancelTask,
   recipient,
+  locale = "en",
 }: OverviewTabProps) {
   const savings = agentResult
     ? agentResult.toolCalls
@@ -68,32 +73,32 @@ export function OverviewTab({
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card
           label="Monthly Spending"
-          value={`$${spending?.spending.total.toFixed(2) || "0.00"}`}
-          sub={`of $${spending?.policy.monthlyLimit || 500} limit`}
+          value={formatCurrency(spending?.spending.total ?? 0, locale)}
+          sub={`of ${formatCurrency(spending?.policy.monthlyLimit ?? 500, locale, 0)} limit`}
           color="sky"
         />
         <Card
           label="Savings Found"
-          value={agentResult ? `$${savings.toFixed(2)}/mo` : "$0.00/mo"}
+          value={agentResult ? `${formatCurrency(savings, locale)}/mo` : `${formatCurrency(0, locale)}/mo`}
           sub="by switching pharmacies"
           color="green"
         />
         <Card
           label="Billing Errors Caught"
-          value={agentResult ? `$${overcharges.toFixed(2)}` : "$0.00"}
+          value={agentResult ? formatCurrency(overcharges, locale) : formatCurrency(0, locale)}
           sub="in overcharges identified"
           color="amber"
         />
         <Card
           label="Agent API Costs"
-          value={`$${spending?.spending.serviceFees.toFixed(4) || "0.0000"}`}
+          value={formatCurrency(spending?.spending.serviceFees ?? 0, locale, 4)}
           sub={`${spending?.transactionCount || 0} queries via x402`}
           color="slate"
         />
         <Card
           label="LLM Tokens"
           value={agentResult ? `${llmTokens} tokens` : "0 tokens"}
-          sub={`≈ $${llmCost} this run`}
+          sub={`≈ ${formatCurrency(Number(llmCost), locale, 4)} this run`}
           color="sky"
         />
       </div>

--- a/dashboard/src/i18n.ts
+++ b/dashboard/src/i18n.ts
@@ -14,10 +14,13 @@ export function isValidLocale(locale: string): locale is Locale {
   return locales.includes(locale as Locale);
 }
 
-export function formatCurrency(amount: number, locale: Locale): string {
+export function formatCurrency(amount: number, locale: Locale, decimals?: number): string {
   const formatter = new Intl.NumberFormat(locale === "es" ? "es-ES" : "en-US", {
     style: "currency",
     currency: "USD",
+    ...(decimals !== undefined
+      ? { minimumFractionDigits: decimals, maximumFractionDigits: decimals }
+      : {}),
   });
   return formatter.format(amount);
 }

--- a/dashboard/src/i18n.ts
+++ b/dashboard/src/i18n.ts
@@ -31,6 +31,21 @@ export function formatDate(date: Date | string, locale: Locale): string {
   });
 }
 
+// #1139 — time-only formatter mirroring formatDate(), for call sites that
+// previously used a bare toLocaleTimeString() with no locale argument.
+export function formatTime(date: Date | string, locale: Locale): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleTimeString(locale === "es" ? "es-ES" : "en-US");
+}
+
+// #1139 — combined date+time formatter mirroring formatDate(), for call
+// sites that previously used a bare toLocaleString() with no locale
+// argument (which renders both date and time, unlike toLocaleDateString()).
+export function formatDateTime(date: Date | string, locale: Locale): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleString(locale === "es" ? "es-ES" : "en-US");
+}
+
 export function formatNumber(num: number, locale: Locale): string {
   return new Intl.NumberFormat(locale === "es" ? "es-ES" : "en-US").format(num);
 }


### PR DESCRIPTION
Closes #1138, Closes #1139, Closes #1140, Closes #1141

- **#1138**: `OverviewTab`'s 5 summary cards and `Bar`'s spent/budget label now use `i18n.ts`'s `formatCurrency()` instead of manual `$${...}` template literals. Added an optional `locale?: Locale` prop to both components, defaulting to `"en"` so nothing changes visually for existing callers (neither component currently receives a real user locale from anywhere in the app — more on that below). Also extended `formatCurrency()` with an optional `decimals` parameter, since two of the five cards (Agent API Costs, and the LLM-cost sub-line) display 4 decimal places rather than the standard 2 — using the helper as-is would have silently rounded those values, which the issue's own "English-locale rendering is visually unchanged" criterion rules out.
- **#1139**: `activity-tab.tsx`'s two `toLocaleTimeString()` call sites and `approvals-tab.tsx`'s one `toLocaleString()` call site now use locale-aware helpers. Note: the issue asked to use the existing `formatDate()`, but `formatDate()` only formats the date portion (year/month/day) — swapping it in would have dropped the time-of-day entirely, which isn't what either component displays today. Added `formatTime()` (mirrors `toLocaleTimeString()`) and `formatDateTime()` (mirrors `toLocaleString()`, i.e. date+time) to `i18n.ts` instead, following the same pattern as the existing `formatDate()`, so the actual displayed content is unchanged for English while becoming locale-aware.
- **#1140**: corrected missing diacritics throughout `es.json` — política, facturación, configuración, descripción, ubicación, auditoría, límite, aún, médica(s), aprobación, dirección, vía, cómo, and a few more. Verified via a structural key-diff against the original that no keys were renamed or values otherwise altered.
- **#1141**: fixed `tasks.findCheapest`'s "Encontrarfarmacias" → "Encontrar farmacias", plus its accents ("más económicas") as part of the same value.

## Two things worth knowing about
1. **`es.json` has a duplicate top-level `"wallet"` key** (one near the top with `agentWallet`/`careRecipient`, a second later with `title`/`description`/etc.) — in JSON, the second silently wins and the first is discarded when parsed. This exists identically in `en.json` too, so it's a pre-existing structural bug unrelated to these 4 issues, not something I touched here — flagging it since it's a real, separate problem worth its own issue.
2. **Neither `OverviewTab`, `Bar`, `ActivityTab`, nor `ApprovalsTab` currently receive a locale from anywhere in the app** — there's no language switcher, no locale routing, no context provider; `i18n.ts`'s helpers really were completely unused before this PR, exactly as both #1138 and #1139 describe. This PR makes the 4 components locale-*capable* (optional prop, safe default) per the issues' explicit scope, but doesn't wire up actual end-to-end locale selection/detection for the app — that's a distinct, larger feature not covered by these 4 issues.

## Method note
All changes made directly via the GitHub Contents API against a branch on my fork (`mhikel66/careguard`) — no local clone was used, so this is unverified by a real `npm test`/`tsc` run. Cross-checked the existing `bar.test.tsx` and `activity-tab.test.tsx` test files by hand to confirm neither asserts on the exact currency/time string text that changed.