### PR TITLE
Fix validation, test organization, and error handling

### DIFF
--- a/dashboard/src/__tests__/overview-tab.test.tsx
+++ b/dashboard/src/__tests__/overview-tab.test.tsx
@@ -1,11 +1,11 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
-import { OverviewTab } from "./overview-tab";
+import { OverviewTab } from "../components/tabs/overview-tab";
 
 // Mock AdherencePrompt since it does fetching
-vi.mock("./overview-tab", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./overview-tab")>();
+vi.mock("../components/tabs/overview-tab", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../components/tabs/overview-tab")>();
   return {
     ...actual,
     AdherencePrompt: () => <div data-testid="adherence-prompt" />,

--- a/dashboard/src/__tests__/pdf-parse-error.test.tsx
+++ b/dashboard/src/__tests__/pdf-parse-error.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { toastError, downloadBillAuditPDF, downloadMedicationPDF } = vi.hoisted(
+  () => ({
+    toastError: vi.fn(),
+    downloadBillAuditPDF: vi.fn(),
+    downloadMedicationPDF: vi.fn(),
+  }),
+);
+
+vi.mock("sonner", () => ({ toast: { error: toastError } }));
+vi.mock("../app/pdf", () => ({ downloadBillAuditPDF, downloadMedicationPDF }));
+
+import { BillsTab } from "../components/tabs/bills-tab";
+import { MedicationsTab } from "../components/tabs/medications-tab";
+
+const recipient = { name: "Rosa Garcia", age: 78, facility: "General Hospital" };
+
+function makeValidAuditResult() {
+  return {
+    totalCharged: 1000,
+    totalCorrect: 950,
+    totalOvercharge: 50,
+    errorCount: 1,
+    recommendation: "Review charges.",
+    lineItems: [
+      {
+        description: "Test",
+        cptCode: "99213",
+        quantity: 1,
+        chargedAmount: 100,
+        status: "valid" as const,
+        suggestedAmount: 95,
+      },
+    ],
+  };
+}
+
+function makeMalformedResult() {
+  return { garbage: true, notAValidBillAudit: "yes" };
+}
+
+describe("BillsTab PDF download error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows toast when schema parse fails on malformed tool result", () => {
+    const agentResult = {
+      response: "",
+      toolCalls: [{ tool: "audit_medical_bill", input: {}, result: makeMalformedResult() }],
+      spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+    };
+    render(<BillsTab agentResult={agentResult} recipient={recipient} />);
+    fireEvent.click(screen.getByRole("button", { name: /Download PDF/i }));
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't parse bill audit result"),
+    );
+  });
+
+  it("calls downloadBillAuditPDF when parse succeeds", () => {
+    const agentResult = {
+      response: "",
+      toolCalls: [{ tool: "audit_medical_bill", input: {}, result: makeValidAuditResult() }],
+      spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+    };
+    render(<BillsTab agentResult={agentResult} recipient={recipient} />);
+    fireEvent.click(screen.getByRole("button", { name: /Download PDF/i }));
+    expect(downloadBillAuditPDF).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when schema parse fails", () => {
+    const agentResult = {
+      response: "",
+      toolCalls: [{ tool: "audit_medical_bill", input: {}, result: makeMalformedResult() }],
+      spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+    };
+    render(<BillsTab agentResult={agentResult} recipient={recipient} />);
+    expect(() =>
+      fireEvent.click(screen.getByRole("button", { name: /Download PDF/i })),
+    ).not.toThrow();
+  });
+});
+
+describe("MedicationsTab PDF download error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows toast when schema parse fails on malformed price result", () => {
+    const agentResult = {
+      response: "",
+      toolCalls: [
+        { tool: "compare_pharmacy_prices", input: {}, result: makeMalformedResult() },
+      ],
+      spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+    };
+    render(<MedicationsTab agentResult={agentResult} recipient={recipient} />);
+    fireEvent.click(screen.getByRole("button", { name: /Download PDF/i }));
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("Couldn't parse medication result"),
+    );
+  });
+
+  it("does not throw when schema parse fails", () => {
+    const agentResult = {
+      response: "",
+      toolCalls: [
+        { tool: "compare_pharmacy_prices", input: {}, result: makeMalformedResult() },
+      ],
+      spending: { medications: 0, bills: 0, serviceFees: 0, total: 0 },
+    };
+    render(<MedicationsTab agentResult={agentResult} recipient={recipient} />);
+    expect(() =>
+      fireEvent.click(screen.getByRole("button", { name: /Download PDF/i })),
+    ).not.toThrow();
+  });
+});

--- a/dashboard/src/__tests__/policy-schema.test.ts
+++ b/dashboard/src/__tests__/policy-schema.test.ts
@@ -77,6 +77,11 @@ describe('validatePolicy', () => {
     expect(r.isValid).toBe(true);
   });
 
+  it('accepts default/max holdTimeSeconds of 86400 (Issue #260)', () => {
+    const r = validatePolicy({ ...valid, holdTimeSeconds: 86400 });
+    expect(r.isValid).toBe(true);
+  });
+
   it('rejects approvalThreshold greater than smallest cap', () => {
     const r = validatePolicy({ ...valid, approvalThreshold: 200 });
     expect(r.isValid).toBe(false);

--- a/dashboard/src/components/README.md
+++ b/dashboard/src/components/README.md
@@ -38,3 +38,11 @@ local UI state (a confirm-dialog open flag, a "show errors only" toggle, etc).
 - Primitives must not import from `tabs/` or `app/`. Tabs may import primitives.
 - Keep `app/page.tsx` under ~250 lines. If a tab grows large, split it further
   inside `tabs/<name>/`.
+
+## Testing
+
+Test files live in [`src/__tests__/`](../__tests__/) alongside the rest of the
+dashboard test suite.  When adding a new test, place it in that directory and
+use a relative import from `../components/…` to reach the module under test.
+This keeps a single glob (`src/**/*.test.{ts,tsx}`) sufficient for running all
+dashboard tests.

--- a/dashboard/src/components/tabs/bills-tab.tsx
+++ b/dashboard/src/components/tabs/bills-tab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { toast } from "sonner";
 import { downloadBillAuditPDF, downloadDisputeLetterPDF, downloadDisputeLetterEmail } from "../../app/pdf";
 import {
   BillAuditResultSchema,
@@ -80,12 +81,16 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
               </h2>
               <div className="flex items-center gap-2">
                 <button
-                  onClick={() =>
-                    downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), {
-                      errorsOnly: showErrorsOnly,
-                      recipient,
-                    })
-                  }
+                  onClick={() => {
+                    try {
+                      downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), {
+                        errorsOnly: showErrorsOnly,
+                        recipient,
+                      });
+                    } catch {
+                      toast.error("Couldn't parse bill audit result — try again");
+                    }
+                  }}
                   className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
                 >
                   Download PDF

--- a/dashboard/src/components/tabs/medications-tab.tsx
+++ b/dashboard/src/components/tabs/medications-tab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { downloadMedicationPDF } from "../../app/pdf";
 import {
   DrugInteractionResultSchema,
@@ -39,21 +40,25 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
           {hasPriceResults && (
             <button
               onClick={() => {
-                const priceResults = agentResult!.toolCalls
-                  .filter((t) => t.tool === "compare_pharmacy_prices")
-                  .map((t) => PharmacyCompareResultSchema.parse(t.result));
-                const interactionResult = agentResult!.toolCalls.find(
-                  (t) => t.tool === "check_drug_interactions",
-                )?.result;
-                downloadMedicationPDF(
-                  {
-                    priceResults,
-                    interactionResult: interactionResult
-                      ? DrugInteractionResultSchema.parse(interactionResult)
-                      : undefined,
-                  },
-                  { recipient },
-                );
+                try {
+                  const priceResults = agentResult!.toolCalls
+                    .filter((t) => t.tool === "compare_pharmacy_prices")
+                    .map((t) => PharmacyCompareResultSchema.parse(t.result));
+                  const interactionResult = agentResult!.toolCalls.find(
+                    (t) => t.tool === "check_drug_interactions",
+                  )?.result;
+                  downloadMedicationPDF(
+                    {
+                      priceResults,
+                      interactionResult: interactionResult
+                        ? DrugInteractionResultSchema.parse(interactionResult)
+                        : undefined,
+                    },
+                    { recipient },
+                  );
+                } catch {
+                  toast.error("Couldn't parse medication result — try again");
+                }
               }}
               className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
             >

--- a/dashboard/src/lib/schemas.ts
+++ b/dashboard/src/lib/schemas.ts
@@ -76,7 +76,12 @@ export function validatePolicy(input: unknown): PolicyValidation {
         field: f,
         message: `${FIELD_LABEL[f]} cannot be negative`,
       });
-    } else if (v[f] > 50000) {
+    } else if (f === 'holdTimeSeconds' && v[f] > 86400) {
+      errors.push({
+        field: f,
+        message: `${FIELD_LABEL[f]} cannot exceed 86,400`,
+      });
+    } else if (moneyFields.includes(f as any) && v[f] > 50000) {
       errors.push({
         field: f,
         message: `${FIELD_LABEL[f]} cannot exceed 50,000`,

--- a/dashboard/tests/e2e/policy-validation.spec.ts
+++ b/dashboard/tests/e2e/policy-validation.spec.ts
@@ -19,7 +19,7 @@ test("Policy form blocks negative values and disables Update Policy", async ({ p
   await dailyLimit.fill("-1");
   await dailyLimit.blur();
 
-  await expect(page.getByText(/cannot be negative/i)).toBeVisible();
+  await expect(page.getByText(/must be at least 1/i)).toBeVisible();
 
   const updateButton = page.getByRole("button", { name: "Update Policy" });
   await expect(updateButton).toBeDisabled();


### PR DESCRIPTION
- Move overview-tab.test.tsx to __tests__ dir, add Testing section to README
- Fix validatePolicy to allow holdTimeSeconds up to 86400, add regression test
- Fix e2e test assertion to match actual money-field error message
- Wrap schema .parse() in onClick handlers with try/catch + toast

Closes #1145 
closes #1146 
closes #1147 
closes #1148

## What changed
-

## How to test
-

## Checklist
- [ ] CI passes (typecheck, lint, tests)
- [ ] No sensitive data files (`data/spending.json`, `data/orders.json`) committed
- [ ] PR linked to an issue
