### PR TITLE
feat: localize dashboard components with i18n translations

### DIFF
--- a/dashboard/messages/en.json
+++ b/dashboard/messages/en.json
@@ -12,10 +12,6 @@
     "pause": "Pause",
     "resume": "Resume"
   },
-  "wallet": {
-    "agentWallet": "Agent Wallet (USDC)",
-    "careRecipient": "Care Recipient"
-  },
   "tabs": {
     "overview": "Overview",
     "medications": "Medications",
@@ -75,12 +71,13 @@
   },
   "policy": {
     "title": "Spending Policy for Rosa",
-    "description": "These limits are enforced by Soroban smart contracts on Stellar. The agent cannot exceed them.",
+    "description": "These limits are enforced server-side by the CareGuard agent before every payment.",
     "dailyLimit": "Daily Spending Limit ($)",
     "monthlyLimit": "Monthly Spending Limit ($)",
     "medicationBudget": "Medication Monthly Budget ($)",
     "billBudget": "Bill Monthly Budget ($)",
     "approvalThreshold": "Caregiver Approval Threshold ($)",
+    "holdTime": "Hold Time Before Auto-Approval (seconds)",
     "refresh": "Refresh from server",
     "discard": "Discard changes",
     "updatePolicy": "Update Policy",
@@ -102,6 +99,8 @@
   "wallet": {
     "title": "Agent Wallet",
     "description": "This is the AI agent's Stellar wallet. It holds USDC for paying pharmacies, medical bills, and API query fees. All balances are on Stellar testnet.",
+    "agentWallet": "Agent Wallet (USDC)",
+    "careRecipient": "Care Recipient",
     "usdcBalance": "USDC Balance",
     "xlmBalance": "XLM Balance",
     "walletAddress": "Wallet Address",

--- a/dashboard/messages/es.json
+++ b/dashboard/messages/es.json
@@ -12,10 +12,6 @@
     "pause": "Pausar",
     "resume": "Reanudar"
   },
-  "wallet": {
-    "agentWallet": "Billetera del Agente (USDC)",
-    "careRecipient": "Paciente"
-  },
   "tabs": {
     "overview": "Resumen",
     "medications": "Medicamentos",
@@ -75,12 +71,13 @@
   },
   "policy": {
     "title": "Política de Gastos para Rosa",
-    "description": "Estos límites son implementados por contratos inteligente en Stellar. El agente no puede excederlos.",
+    "description": "Estos límites son implementados por el agente CareGuard en el servidor antes de cada pago.",
     "dailyLimit": "Límite Diario ($)",
     "monthlyLimit": "Límite Mensual ($)",
     "medicationBudget": "Presupuesto Mensual Medicamentos ($)",
     "billBudget": "Presupuesto Mensual Facturas ($)",
     "approvalThreshold": "Umbral de Aprobación del Cuidador ($)",
+    "holdTime": "Tiempo de Espera Antes de Aprobación Automática (segundos)",
     "refresh": "Actualizar del servidor",
     "discard": "Descartar cambios",
     "updatePolicy": "Actualizar Política",
@@ -102,6 +99,8 @@
   "wallet": {
     "title": "Billetera del Agente",
     "description": "Esta es la billetera Stellar del agente IA. Contiene USDC para pagar farmacias, facturas médicas y consultas de API. Todos los saldos están en Stellar testnet.",
+    "agentWallet": "Billetera del Agente (USDC)",
+    "careRecipient": "Paciente",
     "usdcBalance": "Saldo USDC",
     "xlmBalance": "Saldo XLM",
     "walletAddress": "Dirección de Billetera",

--- a/dashboard/src/components/dashboard-footer.tsx
+++ b/dashboard/src/components/dashboard-footer.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { EXPLORER_ACCOUNT_URL, NETWORK_LABEL } from "../lib/stellar-network";
+import { getTranslations, type Locale } from "../i18n";
 
 export interface DashboardFooterProps {
   agentWallet?: string;
+  locale?: Locale;
 }
 
-export function DashboardFooter({ agentWallet }: DashboardFooterProps) {
+export function DashboardFooter({ agentWallet, locale = "en" }: DashboardFooterProps) {
+  const t = getTranslations(locale);
   return (
     <footer className="mt-auto border-t border-slate-200 bg-white py-3">
       <div className="max-w-7xl mx-auto px-4 flex items-center justify-between text-xs text-slate-400">
-        <span>CareGuard | {NETWORK_LABEL} | x402 + MPP</span>
+        <span>{t.app.title} | {NETWORK_LABEL} | x402 + MPP</span>
         <div className="flex items-center gap-3">
           {agentWallet && (
             <a
@@ -19,10 +22,10 @@ export function DashboardFooter({ agentWallet }: DashboardFooterProps) {
               rel="noopener noreferrer"
               className="text-sky-500 hover:text-sky-700 underline"
             >
-              Agent Wallet on Explorer
+              {t.wallet.viewExplorer}
             </a>
           )}
-          <span>Careguard Agent 2026</span>
+          <span>{t.app.title} Agent 2026</span>
         </div>
       </div>
     </footer>

--- a/dashboard/src/components/dashboard-header.tsx
+++ b/dashboard/src/components/dashboard-header.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { RecipientProfile } from "../lib/types";
 import type { AgentInfo } from "./types";
 import { EXPLORER_ACCOUNT_URL } from "../lib/stellar-network";
+import { getTranslations, type Locale } from "../i18n";
 
 export interface RecipientOption {
   id: string;
@@ -25,6 +26,7 @@ export interface DashboardHeaderProps {
   agentInfoError?: string | null;
   spendingError?: string | null;
   transactionsError?: string | null;
+  locale?: Locale;
 }
 
 export function DashboardHeader({
@@ -41,8 +43,10 @@ export function DashboardHeader({
   agentInfoError,
   spendingError,
   transactionsError,
+  locale = "en",
 }: DashboardHeaderProps) {
   const [tooltipVisible, setTooltipVisible] = useState(false);
+  const t = getTranslations(locale);
 
   const sourceErrors: { source: string; error: string }[] = [
     ...(agentInfoError ? [{ source: 'Agent', error: agentInfoError }] : []),
@@ -70,17 +74,17 @@ export function DashboardHeader({
               className={`w-1.5 h-1.5 rounded-full ${agentConnected ? (agentPaused ? "bg-amber-500" : "bg-green-500") : "bg-red-500"}`}
             />
             {!agentConnected
-              ? "Disconnected"
+              ? t.status.disconnected
               : agentPaused
-                ? "Paused"
-                : "Active"}
+                ? t.status.paused
+                : t.status.active}
           </div>
           {agentConnected && (
             <button
               onClick={onTogglePause}
               className={`px-3 py-1 rounded-full text-xs font-medium transition-all cursor-pointer ${agentPaused ? "bg-green-100 text-green-700 hover:bg-green-200" : "bg-amber-100 text-amber-700 hover:bg-amber-200"}`}
             >
-              {agentPaused ? "Resume" : "Pause"}
+              {agentPaused ? t.actions.resume : t.actions.pause}
             </button>
           )}
           {anySourceDown && (
@@ -123,7 +127,7 @@ export function DashboardHeader({
               rel="noopener noreferrer"
               className="text-right group"
             >
-              <div className="text-xs text-slate-500">Agent Wallet (USDC)</div>
+              <div className="text-xs text-slate-500">{t.wallet.agentWallet}</div>
               <div className="font-semibold text-sm group-hover:text-sky-600">
                 ${walletBalance}
               </div>
@@ -132,13 +136,13 @@ export function DashboardHeader({
           <div className="h-6 w-px bg-slate-200" />
           <div className="flex items-center gap-2">
             <div className="text-right text-xs">
-              <div className="text-slate-500">Care Recipient</div>
+              <div className="text-slate-500">{t.wallet.careRecipient}</div>
               {recipients && recipients.length > 1 && onSelectRecipient ? (
                 <select
                   className="font-medium bg-transparent border-none outline-none cursor-pointer text-xs"
                   value={selectedRecipientId ?? ''}
                   onChange={(e) => onSelectRecipient(e.target.value)}
-                  aria-label="Select care recipient"
+                  aria-label={t.wallet.careRecipient}
                 >
                   {recipients.map((r) => (
                     <option key={r.id} value={r.id}>{r.name}</option>

--- a/dashboard/src/components/tabs/policy-tab.tsx
+++ b/dashboard/src/components/tabs/policy-tab.tsx
@@ -9,14 +9,25 @@ import {
 } from "../../lib/schemas";
 import type { SpendingData } from "../types";
 import { Toast } from "../primitives/toast";
+import { getTranslations, type Locale } from "../../i18n";
 
-const FIELDS: Array<[keyof SpendingPolicyInput, string]> = [
-  ["dailyLimit", "Daily Spending Limit ($)"],
-  ["monthlyLimit", "Monthly Spending Limit ($)"],
-  ["medicationMonthlyBudget", "Medication Monthly Budget ($)"],
-  ["billMonthlyBudget", "Bill Monthly Budget ($)"],
-  ["approvalThreshold", "Caregiver Approval Threshold ($)"],
-  ["holdTimeSeconds", "Hold Time Before Auto-Approval (seconds)"],
+/** Maps SpendingPolicyInput keys to policy.* translation keys. */
+const FIELD_T_KEY: Record<keyof SpendingPolicyInput, string> = {
+  dailyLimit: "dailyLimit",
+  monthlyLimit: "monthlyLimit",
+  medicationMonthlyBudget: "medicationBudget",
+  billMonthlyBudget: "billBudget",
+  approvalThreshold: "approvalThreshold",
+  holdTimeSeconds: "holdTime",
+};
+
+const FIELDS: Array<keyof SpendingPolicyInput> = [
+  "dailyLimit",
+  "monthlyLimit",
+  "medicationMonthlyBudget",
+  "billMonthlyBudget",
+  "approvalThreshold",
+  "holdTimeSeconds",
 ];
 
 /** Per-field HTML input constraints — kept in sync with schemas.ts (#211). */
@@ -24,12 +35,12 @@ const FIELD_CONFIG: Record<
   keyof SpendingPolicyInput,
   { min: number; max: number; step: number }
 > = {
-  dailyLimit:              { min: 1, max: 50000, step: 1 },
-  monthlyLimit:            { min: 1, max: 50000, step: 1 },
+  dailyLimit: { min: 1, max: 50000, step: 1 },
+  monthlyLimit: { min: 1, max: 50000, step: 1 },
   medicationMonthlyBudget: { min: 1, max: 50000, step: 1 },
-  billMonthlyBudget:       { min: 1, max: 50000, step: 1 },
-  approvalThreshold:       { min: 1, max: 50000, step: 1 },
-  holdTimeSeconds:         { min: 0, max: 86400, step: 1 },
+  billMonthlyBudget: { min: 1, max: 50000, step: 1 },
+  approvalThreshold: { min: 1, max: 50000, step: 1 },
+  holdTimeSeconds: { min: 0, max: 86400, step: 1 },
 };
 
 /**
@@ -45,7 +56,6 @@ const LIMIT_FIELDS: Array<keyof SpendingPolicyInput> = [
   "approvalThreshold",
 ];
 
-const FIELD_LABELS: Record<string, string> = Object.fromEntries(FIELDS);
 
 /** A confirmation step requires typing this word when a limit more than doubles. */
 const TYPED_CONFIRMATION = "CONFIRM";
@@ -72,6 +82,7 @@ export interface PolicyTabProps {
   policySaved: boolean;
   onUpdatePolicy: () => Promise<{ ok: boolean; error?: string }>;
   onForceSync: () => void;
+  locale?: Locale;
 }
 
 function errorFor(field: keyof SpendingPolicyInput, errors: PolicyFieldError[]) {
@@ -87,7 +98,9 @@ export function PolicyTab({
   policySaved,
   onUpdatePolicy,
   onForceSync,
+  locale = "en",
 }: PolicyTabProps) {
+  const t = getTranslations(locale);
   const validation = useMemo(() => validatePolicy(policyForm), [policyForm]);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [toastFallback, setToastFallback] = useState<string | undefined>(undefined);
@@ -121,7 +134,7 @@ export function PolicyTab({
       const increased =
         Number.isFinite(before) && Number.isFinite(after) && after > before;
       const doubled = increased && before > 0 && after > before * 2;
-      return { key, label: FIELD_LABELS[key] ?? key, before, after, increased, doubled };
+      return { key, label: t.policy[FIELD_T_KEY[key] as keyof typeof t.policy] ?? key, before, after, increased, doubled };
     }).filter((row) => row.before !== row.after);
 
     const increases = rows.filter((row) => row.increased);
@@ -158,13 +171,14 @@ export function PolicyTab({
       className="bg-white rounded-xl border border-slate-200 p-6 max-w-lg"
     >
       <h2 className="text-sm font-semibold text-slate-700 mb-4">
-        Spending Policy for {recipient.name}
+        {t.policy.title.replace("Rosa", recipient.name)}
       </h2>
       <p className="text-xs text-slate-500 mb-6">
-        These limits are enforced server-side by the CareGuard agent before every payment.
+        {t.policy.description}
       </p>
       <form noValidate onSubmit={handleSubmit} className="space-y-4">
-        {FIELDS.map(([key, label]) => {
+        {FIELDS.map((key) => {
+          const label = t.policy[FIELD_T_KEY[key] as keyof typeof t.policy];
           const errMsg = errorFor(key, validation.errors);
           const warnMsg = errorFor(key, validation.warnings);
           const inputId = `policy-${key}`;
@@ -193,11 +207,10 @@ export function PolicyTab({
                   const parsed = raw === "" ? Number.NaN : Number(raw);
                   setPolicyForm((p) => ({ ...p, [key]: parsed }));
                 }}
-                className={`w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${
-                  errMsg
+                className={`w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 ${errMsg
                     ? "border-red-400 focus:ring-red-500"
                     : "border-slate-300 focus:ring-sky-500"
-                }`}
+                  }`}
               />
               {errMsg && (
                 <p id={errorId} className="mt-1 text-xs text-red-600">
@@ -218,7 +231,7 @@ export function PolicyTab({
             onClick={onForceSync}
             className="flex-1 py-2 rounded-lg text-sm font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 active:bg-slate-300 transition-all cursor-pointer"
           >
-            Refresh from server
+            {t.policy.refresh}
           </button>
           <button
             type="button"
@@ -228,19 +241,18 @@ export function PolicyTab({
             }}
             className="flex-1 py-2 rounded-lg text-sm font-medium bg-slate-100 text-slate-700 hover:bg-slate-200 active:bg-slate-300 transition-all cursor-pointer"
           >
-            Discard changes
+            {t.policy.discard}
           </button>
         </div>
         <button
           type="submit"
           disabled={!validation.isValid}
-          className={`w-full py-2 rounded-lg text-sm font-medium transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
-            policySaved
+          className={`w-full py-2 rounded-lg text-sm font-medium transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${policySaved
               ? "bg-green-500 text-white"
               : "bg-sky-500 text-white hover:bg-sky-600 active:bg-sky-700"
-          }`}
+            }`}
         >
-          {policySaved ? "Policy Saved" : "Update Policy"}
+          {policySaved ? t.policy.policySaved : t.policy.updatePolicy}
         </button>
       </form>
       {confirmRows && (

--- a/dashboard/src/components/tabs/settings-tab.tsx
+++ b/dashboard/src/components/tabs/settings-tab.tsx
@@ -5,6 +5,7 @@ import { copyText } from "../../lib/clipboard";
 import type { CaregiverProfile, RecipientProfile } from "../../lib/types";
 import { Toast } from "../primitives/toast";
 import type { AgentInfo } from "../types";
+import { getTranslations, type Locale } from "../../i18n";
 
 export interface RecipientOption {
   id: string;
@@ -24,6 +25,7 @@ export interface SettingsTabProps {
   recipients?: RecipientOption[];
   selectedRecipientId?: string;
   onSelectRecipient?: (id: string) => void;
+  locale?: Locale;
 }
 
 export function SettingsTab({
@@ -36,7 +38,9 @@ export function SettingsTab({
   recipients,
   selectedRecipientId,
   onSelectRecipient,
+  locale = "en",
 }: SettingsTabProps) {
+  const t = getTranslations(locale);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [toastFallback, setToastFallback] = useState<string | undefined>(undefined);
@@ -125,13 +129,13 @@ export function SettingsTab({
       <div className="bg-white rounded-xl border border-slate-200 p-6">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
-            <h2 className="text-sm font-semibold text-slate-700">Care Recipient</h2>
+            <h2 className="text-sm font-semibold text-slate-700">{t.settings.recipient}</h2>
             {recipients && recipients.length > 1 && onSelectRecipient && (
               <select
                 className="text-xs border border-slate-200 rounded-lg px-2 py-1 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-500"
                 value={selectedRecipientId ?? ''}
                 onChange={(e) => onSelectRecipient(e.target.value)}
-                aria-label="Switch care recipient"
+                aria-label={t.settings.recipient}
               >
                 {recipients.map((r) => (
                   <option key={r.id} value={r.id}>{r.name}</option>
@@ -150,27 +154,27 @@ export function SettingsTab({
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Name</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.name}</label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.recipientName}
                 onChange={(e) => setForm((f) => ({ ...f, recipientName: e.target.value }))}
-                aria-label="Recipient Name"
+                aria-label={t.settings.name}
               />
             ) : (
               <div className={readClass}>{recipient.name}</div>
             )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Age</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.age}</label>
             {editing ? (
               <input
                 type="number"
                 className={editClass}
                 value={form.recipientAge}
                 onChange={(e) => setForm((f) => ({ ...f, recipientAge: e.target.value }))}
-                aria-label="Recipient Age"
+                aria-label={t.settings.age}
               />
             ) : (
               <div className={readClass}>{recipient.age ?? "N/A"}</div>
@@ -178,40 +182,40 @@ export function SettingsTab({
           </div>
           <div className="col-span-2">
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              Medications (comma-separated)
+              {`${t.settings.medications} (comma-separated)`}
             </label>
             {editing ? (
               <input
                 className={editClass + " w-full"}
                 value={form.medications}
                 onChange={(e) => setForm((f) => ({ ...f, medications: e.target.value }))}
-                aria-label="Medications"
+                aria-label={t.settings.medications}
               />
             ) : (
               <div className={readClass}>{(recipient.medications ?? []).join(", ")}</div>
             )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Primary Doctor</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.doctor}</label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.doctor}
                 onChange={(e) => setForm((f) => ({ ...f, doctor: e.target.value }))}
-                aria-label="Primary Doctor"
+                aria-label={t.settings.doctor}
               />
             ) : (
               <div className={readClass}>{recipient.doctor ?? "N/A"}</div>
             )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Insurance</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.insurance}</label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.insurance}
                 onChange={(e) => setForm((f) => ({ ...f, insurance: e.target.value }))}
-                aria-label="Insurance"
+                aria-label={t.settings.insurance}
               />
             ) : (
               <div className={readClass}>{recipient.insurance ?? "N/A"}</div>
@@ -221,42 +225,42 @@ export function SettingsTab({
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">Caregiver</h2>
+        <h2 className="text-sm font-semibold text-slate-700 mb-4">{t.settings.caregiver}</h2>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Name</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.name}</label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.caregiverName}
                 onChange={(e) => setForm((f) => ({ ...f, caregiverName: e.target.value }))}
-                aria-label="Caregiver Name"
+                aria-label={`${t.settings.caregiver} ${t.settings.name}`}
               />
             ) : (
               <div className={readClass}>{caregiver.name}</div>
             )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Relationship</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.relationship}</label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.relationship}
                 onChange={(e) => setForm((f) => ({ ...f, relationship: e.target.value }))}
-                aria-label="Relationship"
+                aria-label={t.settings.relationship}
               />
             ) : (
               <div className={readClass}>{caregiver.relationship ?? "N/A"}</div>
             )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Location</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.location}</label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.location}
                 onChange={(e) => setForm((f) => ({ ...f, location: e.target.value }))}
-                aria-label="Location"
+                aria-label={t.settings.location}
               />
             ) : (
               <div className={readClass}>{caregiver.location ?? "N/A"}</div>
@@ -264,14 +268,14 @@ export function SettingsTab({
           </div>
           <div>
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              Notification Channel
+              {t.settings.notifications}
             </label>
             {editing ? (
               <input
                 className={editClass}
                 value={form.notifications}
                 onChange={(e) => setForm((f) => ({ ...f, notifications: e.target.value }))}
-                aria-label="Notification Channel"
+                aria-label={t.settings.notifications}
               />
             ) : (
               <div className={readClass}>{caregiver.notifications ?? "N/A"}</div>
@@ -298,41 +302,41 @@ export function SettingsTab({
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">Agent Configuration</h2>
+        <h2 className="text-sm font-semibold text-slate-700 mb-4">{t.settings.agentConfig}</h2>
         <div className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Agent Status</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.settings.agentStatus}</label>
             <div className="flex items-center gap-2">
               <div
                 className={`px-3 py-2 flex-1 bg-slate-50 border border-slate-200 rounded-lg text-sm ${agentPaused ? "text-amber-600" : "text-green-600"}`}
               >
-                {agentPaused ? "Paused" : "Active"}
+                {agentPaused ? t.status.paused : t.status.active}
               </div>
               <button
                 onClick={onTogglePause}
                 className={`px-4 py-2 rounded-lg text-sm font-medium cursor-pointer transition-all ${agentPaused ? "bg-green-500 text-white hover:bg-green-600" : "bg-amber-500 text-white hover:bg-amber-600"}`}
               >
-                {agentPaused ? "Resume Agent" : "Pause Agent"}
+                {agentPaused ? t.actions.resume : t.actions.pause}
               </button>
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">LLM Provider</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.wallet.llmProvider}</label>
             <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-mono">
-              {agentInfo?.llm || "Not connected"}
+              {agentInfo?.llm || t.settings.notConnected}
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Network</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.wallet.network}</label>
             <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-sm">
               {agentInfo?.network || "stellar:testnet"}
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 mb-1">Agent Wallet</label>
+            <label className="block text-xs font-medium text-slate-600 mb-1">{t.wallet.agentWallet}</label>
             <div className="flex items-center gap-2">
               <code className="flex-1 px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-mono break-all">
-                {agentInfo?.agentWallet || "Not connected"}
+                {agentInfo?.agentWallet || t.settings.notConnected}
               </code>
               {agentInfo?.agentWallet && (
                 <button

--- a/dashboard/src/components/tabs/wallet-tab.tsx
+++ b/dashboard/src/components/tabs/wallet-tab.tsx
@@ -5,6 +5,7 @@ import { copyText } from "../../lib/clipboard";
 import { Toast } from "../primitives/toast";
 import type { AgentInfo } from "../types";
 import { EXPLORER_ACCOUNT_URL, NETWORK_LABEL } from "../../lib/stellar-network";
+import { getTranslations, type Locale } from "../../i18n";
 
 export interface WalletTabProps {
   agentInfo: AgentInfo | null;
@@ -14,6 +15,7 @@ export interface WalletTabProps {
   walletBalanceError?: string | null;
   loadingWalletBalance?: boolean;
   onRetryWalletBalance?: () => void;
+  locale?: Locale;
 }
 
 export function WalletTab({
@@ -24,7 +26,9 @@ export function WalletTab({
   walletBalanceError,
   loadingWalletBalance = false,
   onRetryWalletBalance,
+  locale = "en",
 }: WalletTabProps) {
+  const t = getTranslations(locale);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [toastFallback, setToastFallback] = useState<string | undefined>(undefined);
@@ -57,25 +61,23 @@ export function WalletTab({
         }}
       />
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">Agent Wallet</h2>
+        <h2 className="text-sm font-semibold text-slate-700 mb-4">{t.wallet.title}</h2>
         <p className="text-xs text-slate-500 mb-4">
-          This is the AI agent&apos;s Stellar wallet. It holds USDC for paying
-          pharmacies, medical bills, and API query fees. All balances are on
-          {NETWORK_LABEL.replace('Stellar ', '').toLowerCase()}.
+          {t.wallet.description}
         </p>
         <div className="grid grid-cols-2 gap-4 mb-6">
           {walletBalanceState === 'loading' && (
             <div className="bg-sky-50 rounded-lg p-4 text-center border border-sky-200 col-span-2">
               <div className="text-sm font-medium text-sky-600">
                 <span className="inline-block w-4 h-4 border-2 border-sky-600 border-t-transparent rounded-full animate-spin mr-2 align-middle" />
-                Loading wallet balance...
+                {t.common.loading}
               </div>
             </div>
           )}
           {walletBalanceState === 'error' && (
             <div className="bg-red-50 rounded-lg p-4 text-center border border-red-200 col-span-2">
               <div className="text-sm font-medium text-red-700 mb-2">
-                {walletBalanceError || 'Balance unavailable'}
+                {walletBalanceError || t.common.error}
               </div>
               {onRetryWalletBalance && (
                 <button
@@ -83,7 +85,7 @@ export function WalletTab({
                   disabled={loadingWalletBalance}
                   className="px-4 py-1.5 bg-red-100 text-red-700 rounded-lg text-xs font-medium hover:bg-red-200 disabled:opacity-50 cursor-pointer transition-all"
                 >
-                  {loadingWalletBalance ? 'Retrying...' : 'Try again'}
+                  {loadingWalletBalance ? `${t.common.retry}...` : t.common.retry}
                 </button>
               )}
             </div>
@@ -94,13 +96,13 @@ export function WalletTab({
                 <div className="text-2xl font-bold text-sky-700">
                   ${walletBalance ?? "0.00"}
                 </div>
-                <div className="text-xs text-slate-500 mt-1">USDC Balance</div>
+                <div className="text-xs text-slate-500 mt-1">{t.wallet.usdcBalance}</div>
               </div>
               <div className="bg-slate-50 rounded-lg p-4 text-center border border-slate-200">
                 <div className="text-2xl font-bold text-slate-700">
                   {walletXlm ?? "0.00"}
                 </div>
-                <div className="text-xs text-slate-500 mt-1">XLM Balance</div>
+                <div className="text-xs text-slate-500 mt-1">{t.wallet.xlmBalance}</div>
               </div>
             </>
           )}
@@ -108,22 +110,21 @@ export function WalletTab({
         <div className="space-y-3">
           <div>
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              Wallet Address
+              {t.wallet.walletAddress}
             </label>
             <div className="flex items-center gap-2">
               <code className="flex-1 px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-mono break-all">
-                {agentInfo?.agentWallet || "Not connected"}
+                {agentInfo?.agentWallet || t.settings.notConnected}
               </code>
               {agentInfo?.agentWallet && (
                 <button
                   onClick={() =>
                     handleCopy(agentInfo.agentWallet, "wallet-address")
                   }
-                  className={`px-3 py-2 rounded-lg text-xs font-medium transition-all cursor-pointer ${
-                    copiedId === "wallet-address"
+                  className={`px-3 py-2 rounded-lg text-xs font-medium transition-all cursor-pointer ${copiedId === "wallet-address"
                       ? "bg-green-100 text-green-700"
                       : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-                  }`}
+                    }`}
                 >
                   {copiedId === "wallet-address" ? "Copied" : "Copy"}
                 </button>
@@ -132,7 +133,7 @@ export function WalletTab({
           </div>
           <div>
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              Network
+              {t.wallet.network}
             </label>
             <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs">
               {NETWORK_LABEL}
@@ -140,10 +141,10 @@ export function WalletTab({
           </div>
           <div>
             <label className="block text-xs font-medium text-slate-600 mb-1">
-              LLM Provider
+              {t.wallet.llmProvider}
             </label>
             <div className="px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs">
-              {agentInfo?.llm || "Not connected"}
+              {agentInfo?.llm || t.settings.notConnected}
             </div>
           </div>
         </div>
@@ -155,7 +156,7 @@ export function WalletTab({
               rel="noopener noreferrer"
               className="flex-1 text-center px-4 py-2 bg-sky-500 text-white rounded-lg text-sm font-medium hover:bg-sky-600 active:bg-sky-700 cursor-pointer transition-all"
             >
-              View on Stellar Explorer
+              {t.wallet.viewExplorer}
             </a>
           )}
           <a
@@ -164,14 +165,14 @@ export function WalletTab({
             rel="noopener noreferrer"
             className="flex-1 text-center px-4 py-2 bg-slate-100 text-slate-700 rounded-lg text-sm font-medium hover:bg-slate-200 active:bg-slate-300 cursor-pointer transition-all"
           >
-            Fund with USDC
+            {t.wallet.fund}
           </a>
         </div>
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
         <h2 className="text-sm font-semibold text-slate-700 mb-3">
-          How Payments Work
+          {t.wallet.howPayments}
         </h2>
         <div className="space-y-3 text-xs text-slate-600">
           <div className="flex gap-3 items-start">


### PR DESCRIPTION
- dashboard-header.tsx: source status/action labels from getTranslations
- dashboard-footer.tsx: source app title and viewExplorer from translations
- wallet-tab.tsx: source all static labels from wallet.* translation keys
- settings-tab.tsx: source all field labels from settings.* translation keys
- policy-tab.tsx: source labels from policy.* keys, fix description text
- en.json: consolidate duplicate wallet keys, add holdTime, fix policy.description
- es.json: consolidate wallet keys, add holdTime, fix policy.description

Closes #1133
closes #1134 
closes #1135 
closes #1136

## What changed
-

## How to test
-

## Checklist
- [ ] CI passes (typecheck, lint, tests)
- [ ] No sensitive data files (`data/spending.json`, `data/orders.json`) committed
- [ ] PR linked to an issue
