### PR TITLE
i18n: source tab component static labels from translations instead of…

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { isValidLocale, type Locale } from "../i18n";
 import { DashboardFooter } from "../components/dashboard-footer";
 import { DashboardHeader } from "../components/dashboard-header";
 import { DashboardTabsNav } from "../components/dashboard-tabs-nav";
@@ -53,6 +54,8 @@ export default function Dashboard() {
       : "overview";
   }, [searchParams]);
 
+  const localeParam = searchParams.get("locale");
+  const locale: Locale = isValidLocale(localeParam || "") ? localeParam as Locale : "en";
   const state = useAgentState({ activeTab });
 
   const ariaLogRef = useRef<number | null>(null);
@@ -113,18 +116,21 @@ export default function Dashboard() {
             onRunTask={state.runAgentTask}
             onCancelTask={state.cancelAgentTask}
             recipient={recipient}
+            locale={locale}
           />
         )}
         {activeTab === "medications" && (
           <MedicationsTab
             agentResult={state.agentResult}
             recipient={recipient}
+            locale={locale}
           />
         )}
         {activeTab === "bills" && (
           <BillsTab
             agentResult={state.agentResult}
             recipient={recipient}
+            locale={locale}
           />
         )}
         {activeTab === "approvals" && (
@@ -170,6 +176,7 @@ export default function Dashboard() {
             onResetAgent={state.resetAgent}
             loadingTransactions={state.loadingTransactions}
             loadingSpending={state.loadingSpending}
+            locale={locale}
           />
         )}
         {activeTab === "settings" && (

--- a/dashboard/src/components/tabs/activity-tab.tsx
+++ b/dashboard/src/components/tabs/activity-tab.tsx
@@ -6,7 +6,7 @@ import { copyText } from "../../lib/clipboard";
 import type { RecipientProfile } from "../../lib/types";
 import { ConfirmDialog } from "../primitives/confirm-dialog";
 import { TxLink } from "../primitives/tx-link";
-import { formatTime, type Locale } from "../../i18n";
+import { formatTime, getTranslations, type Locale } from "../../i18n";
 import type {
   AgentLogEntry,
   PaginationData,
@@ -30,8 +30,6 @@ export interface ActivityTabProps {
   onResetAgent: () => void;
   loadingTransactions?: boolean;
   loadingSpending?: boolean;
-  // #1139 — defaults to "en" so existing callers that don't pass a locale
-  // render identically to before this change.
   locale?: Locale;
 }
 
@@ -52,6 +50,7 @@ export function ActivityTab({
 }: ActivityTabProps) {
   const [showAllLogEntries, setShowAllLogEntries] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const t = getTranslations(locale).activity;
 
   // allTransactions arrives pre-sorted newest-first from fetchTransactions (#220).
   // useMemo ensures the merge only reruns when transactions or audit events change,
@@ -96,9 +95,8 @@ export function ActivityTab({
       <ConfirmDialog
         open={confirmOpen}
         title="Reset all agent data?"
-        description={`This will delete ${allTransactions.length} transaction${
-          allTransactions.length === 1 ? "" : "s"
-        }, the agent log, and all audit results. This cannot be undone.`}
+        description={`This will delete ${allTransactions.length} transaction${allTransactions.length === 1 ? "" : "s"
+          }, the agent log, and all audit results. This cannot be undone.`}
         confirmLabel="Delete everything"
         cancelLabel="Cancel"
         destructive
@@ -109,7 +107,7 @@ export function ActivityTab({
         }}
       />
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-slate-700">Transaction Log</h2>
+        <h2 className="text-sm font-semibold text-slate-700">{t.title}</h2>
         <div className="flex items-center gap-3">
           {allTransactions.length > 0 && (
             <button
@@ -118,7 +116,7 @@ export function ActivityTab({
               }
               className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
             >
-              Download Report
+              {t.downloadReport}
             </button>
           )}
           <button
@@ -131,7 +129,7 @@ export function ActivityTab({
             onClick={() => setConfirmOpen(true)}
             className="text-xs text-red-500 hover:text-red-700 hover:underline active:text-red-800 cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500 rounded px-1"
           >
-            Reset All
+            {t.reset}
           </button>
         </div>
       </div>
@@ -141,7 +139,7 @@ export function ActivityTab({
       >
         <div aria-hidden="true">
           {agentLog.length === 0 ? (
-            <span className="text-slate-500">No agent activity yet...</span>
+            <span className="text-slate-500">{t.noActivity}</span>
           ) : (
             <>
               {!showAllLogEntries && agentLog.length > 50 && (
@@ -213,7 +211,7 @@ export function ActivityTab({
       <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
         {mergedTimeline.length === 0 && !pagination ? (
           <div className="p-8 text-center text-sm text-slate-400">
-            No activity yet
+            {t.noTransactions}
           </div>
         ) : (
           <>
@@ -273,22 +271,22 @@ export function ActivityTab({
                 <thead className="bg-slate-50 border-b border-slate-200">
                   <tr>
                     <th className="hidden md:table-cell text-left px-4 py-2 text-xs font-medium text-slate-500">
-                      Time
+                      {t.time}
                     </th>
                     <th className="text-left px-4 py-2 text-xs font-medium text-slate-500">
-                      Type
+                      {t.type}
                     </th>
                     <th className="text-left px-4 py-2 text-xs font-medium text-slate-500">
-                      Description
+                      {t.description}
                     </th>
                     <th className="text-right px-4 py-2 text-xs font-medium text-slate-500">
-                      Amount
+                      {t.amount}
                     </th>
                     <th className="text-right px-4 py-2 text-xs font-medium text-slate-500">
-                      Status
+                      {t.status}
                     </th>
                     <th className="text-right px-4 py-2 text-xs font-medium text-slate-500">
-                      Stellar Tx
+                      {t.stellarTx}
                     </th>
                   </tr>
                 </thead>
@@ -327,13 +325,12 @@ export function ActivityTab({
                         </td>
                         <td className="px-4 py-2">
                           <span
-                            className={`px-2 py-0.5 rounded text-xs font-medium ${
-                              tx.type === "medication"
-                                ? "bg-blue-100 text-blue-700"
-                                : tx.type === "bill"
-                                  ? "bg-purple-100 text-purple-700"
-                                  : "bg-slate-100 text-slate-600"
-                            }`}
+                            className={`px-2 py-0.5 rounded text-xs font-medium ${tx.type === "medication"
+                              ? "bg-blue-100 text-blue-700"
+                              : tx.type === "bill"
+                                ? "bg-purple-100 text-purple-700"
+                                : "bg-slate-100 text-slate-600"
+                              }`}
                           >
                             {tx.type}
                           </span>
@@ -347,13 +344,12 @@ export function ActivityTab({
                         </td>
                         <td className="px-4 py-2 text-right">
                           <span
-                            className={`px-2 py-0.5 rounded text-xs ${
-                              tx.status === "completed"
-                                ? "bg-green-100 text-green-700"
-                                : tx.status === "blocked"
-                                  ? "bg-red-100 text-red-700"
-                                  : "bg-amber-100 text-amber-700"
-                            }`}
+                            className={`px-2 py-0.5 rounded text-xs ${tx.status === "completed"
+                              ? "bg-green-100 text-green-700"
+                              : tx.status === "blocked"
+                                ? "bg-red-100 text-red-700"
+                                : "bg-amber-100 text-amber-700"
+                              }`}
                           >
                             {tx.status}
                           </span>

--- a/dashboard/src/components/tabs/bills-tab.tsx
+++ b/dashboard/src/components/tabs/bills-tab.tsx
@@ -10,15 +10,18 @@ import {
 } from "../../lib/types";
 import { BillLineItemsVirtualized } from "../primitives/bill-line-items-virtualized";
 import type { AgentResult } from "../types";
+import { getTranslations, type Locale } from "../../i18n";
 
 export interface BillsTabProps {
   agentResult: AgentResult | null;
   recipient: RecipientProfile;
+  locale?: Locale;
 }
 
-export function BillsTab({ agentResult, recipient }: BillsTabProps) {
+export function BillsTab({ agentResult, recipient, locale = "en" }: BillsTabProps) {
   const [showErrorsOnly, setShowErrorsOnly] = useState(false);
   const [generatingDispute, setGeneratingDispute] = useState<string | null>(null);
+  const b = getTranslations(locale).bills;
 
   const auditCalls = agentResult?.toolCalls.filter(
     (t) =>
@@ -70,20 +73,20 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
       className="space-y-6"
     >
       {auditCalls && auditCalls.length > 0 ? (
-        auditCalls.map((t, i) => (
+        auditCalls.map((tc, i) => (
           <div
             key={i}
             className="bg-white rounded-xl border border-slate-200 p-6"
           >
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-sm font-semibold text-slate-700">
-                Bill Audit Results
+                {b.title}
               </h2>
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => {
                     try {
-                      downloadBillAuditPDF(BillAuditResultSchema.parse(t.result), {
+                      downloadBillAuditPDF(BillAuditResultSchema.parse(tc.result), {
                         errorsOnly: showErrorsOnly,
                         recipient,
                       });
@@ -93,19 +96,19 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
                   }}
                   className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
                 >
-                  Download PDF
+                  {b.downloadPdf}
                 </button>
-                {t.result.errorCount > 0 && (
+                {tc.result.errorCount > 0 && (
                   <>
                     <button
-                      onClick={() => handleDispute(t.result, i)}
+                      onClick={() => handleDispute(tc.result, i)}
                       disabled={generatingDispute === `dispute-${i}`}
                       className="px-3 py-1.5 bg-red-50 text-red-700 rounded-lg text-xs font-medium hover:bg-red-100 active:bg-red-200 cursor-pointer transition-all disabled:opacity-50"
                     >
                       {generatingDispute === `dispute-${i}` ? "Generating..." : "Dispute"}
                     </button>
                     <button
-                      onClick={() => handleDisputeEmail(t.result)}
+                      onClick={() => handleDisputeEmail(tc.result)}
                       className="px-3 py-1.5 bg-amber-50 text-amber-700 rounded-lg text-xs font-medium hover:bg-amber-100 active:bg-amber-200 cursor-pointer transition-all"
                     >
                       Email Text
@@ -113,58 +116,57 @@ export function BillsTab({ agentResult, recipient }: BillsTabProps) {
                   </>
                 )}
                 <span
-                  className={`px-3 py-1 rounded-full text-xs font-medium ${
-                    t.result.errorCount > 0
-                      ? "bg-red-100 text-red-700"
-                      : "bg-green-100 text-green-700"
-                  }`}
+                  className={`px-3 py-1 rounded-full text-xs font-medium ${tc.result.errorCount > 0
+                    ? "bg-red-100 text-red-700"
+                    : "bg-green-100 text-green-700"
+                    }`}
                 >
-                  {t.result.errorCount} errors found
+                  {tc.result.errorCount} {b.errorsFound}
                 </span>
               </div>
             </div>
             <div className="grid grid-cols-3 gap-4 mb-4">
               <div className="bg-slate-50 rounded-lg p-3 text-center">
-                <div className="text-lg font-bold">${t.result.totalCharged}</div>
-                <div className="text-xs text-slate-500">Total Charged</div>
+                <div className="text-lg font-bold">${tc.result.totalCharged}</div>
+                <div className="text-xs text-slate-500">{b.totalCharged}</div>
               </div>
               <div className="bg-red-50 rounded-lg p-3 text-center">
                 <div className="text-lg font-bold text-red-600">
-                  ${t.result.totalOvercharge}
+                  ${tc.result.totalOvercharge}
                 </div>
-                <div className="text-xs text-slate-500">Overcharges</div>
+                <div className="text-xs text-slate-500">{b.overcharges}</div>
               </div>
               <div className="bg-green-50 rounded-lg p-3 text-center">
                 <div className="text-lg font-bold text-green-600">
-                  ${t.result.totalCorrect}
+                  ${tc.result.totalCorrect}
                 </div>
-                <div className="text-xs text-slate-500">Correct Amount</div>
+                <div className="text-xs text-slate-500">{b.correctAmount}</div>
               </div>
             </div>
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs text-slate-500">
-                {t.result.lineItems.length} line items
+                {tc.result.lineItems.length} {b.lineItems}
               </span>
               <button
                 onClick={() => setShowErrorsOnly(!showErrorsOnly)}
                 className="text-xs text-sky-600 hover:text-sky-800 cursor-pointer"
               >
-                {showErrorsOnly ? "Show all items" : "Show errors only"}
+                {showErrorsOnly ? b.showAll : b.showErrors}
               </button>
             </div>
             <BillLineItemsVirtualized
-              lineItems={t.result.lineItems.filter(
+              lineItems={tc.result.lineItems.filter(
                 (item: any) => !showErrorsOnly || item.status !== "valid",
               )}
             />
             <p className="mt-4 text-sm font-medium text-slate-700">
-              {t.result.recommendation}
+              {tc.result.recommendation}
             </p>
           </div>
         ))
       ) : (
         <div className="bg-white rounded-xl border border-slate-200 p-12 text-center text-sm text-slate-400">
-          No bills audited yet. Run &quot;Audit Hospital Bill&quot; from Overview.
+          {b.notAudited}
         </div>
       )}
     </div>

--- a/dashboard/src/components/tabs/medications-tab.tsx
+++ b/dashboard/src/components/tabs/medications-tab.tsx
@@ -8,15 +8,18 @@ import {
   type RecipientProfile,
 } from "../../lib/types";
 import type { AgentResult } from "../types";
+import { getTranslations, type Locale } from "../../i18n";
 
 const MEDS = ["Lisinopril", "Metformin", "Atorvastatin", "Amlodipine"] as const;
 
 export interface MedicationsTabProps {
   agentResult: AgentResult | null;
   recipient: RecipientProfile;
+  locale?: Locale;
 }
 
-export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) {
+export function MedicationsTab({ agentResult, recipient, locale = "en" }: MedicationsTabProps) {
+  const t = getTranslations(locale).medications;
   const hasPriceResults = agentResult?.toolCalls.some(
     (t) => t.tool === "compare_pharmacy_prices",
   );
@@ -35,7 +38,7 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-sm font-semibold text-slate-700">
-            {recipient.name}&apos;s Medications
+            {t.title}
           </h2>
           {hasPriceResults && (
             <button
@@ -62,7 +65,7 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
               }}
               className="px-3 py-1.5 bg-sky-50 text-sky-700 rounded-lg text-xs font-medium hover:bg-sky-100 active:bg-sky-200 cursor-pointer transition-all"
             >
-              Download PDF
+              {t.downloadPdf}
             </button>
           )}
         </div>
@@ -82,17 +85,17 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
                   <div className="font-medium text-sm">{drug}</div>
                   <div className="text-xs text-slate-500">
                     {r
-                      ? `Best: ${r.cheapest.pharmacyName} at $${r.cheapest.price}`
-                      : "Not yet compared"}
+                      ? `${t.best}: ${r.cheapest.pharmacyName} at $${r.cheapest.price}`
+                      : t.notYetCompared}
                   </div>
                 </div>
                 {r && (
                   <div className="text-right">
                     <div className="text-sm font-medium text-green-600">
-                      Save ${r.potentialSavings}/mo
+                      {t.save} ${r.potentialSavings}/mo
                     </div>
                     <div className="text-xs text-slate-400">
-                      {r.savingsPercent}% savings
+                      {r.savingsPercent}% {t.savings}
                     </div>
                   </div>
                 )}
@@ -104,7 +107,7 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
       {interactionCalls && interactionCalls.length > 0 && (
         <div className="bg-white rounded-xl border border-slate-200 p-6">
           <h2 className="text-sm font-semibold text-slate-700 mb-4">
-            Drug Interactions
+            {t.drugInteractions}
           </h2>
           {interactionCalls.map((t, i) => (
             <div key={i} className="space-y-2">
@@ -112,13 +115,12 @@ export function MedicationsTab({ agentResult, recipient }: MedicationsTabProps) 
               {t.result.interactions?.map((ix: any, j: number) => (
                 <div
                   key={j}
-                  className={`p-3 rounded-lg text-sm ${
-                    ix.severity === "severe"
-                      ? "bg-red-50 border border-red-200"
-                      : ix.severity === "moderate"
-                        ? "bg-amber-50 border border-amber-200"
-                        : "bg-blue-50 border border-blue-200"
-                  }`}
+                  className={`p-3 rounded-lg text-sm ${ix.severity === "severe"
+                    ? "bg-red-50 border border-red-200"
+                    : ix.severity === "moderate"
+                      ? "bg-amber-50 border border-amber-200"
+                      : "bg-blue-50 border border-blue-200"
+                    }`}
                 >
                   <div className="font-medium">
                     {ix.drug1} + {ix.drug2} ({ix.severity})

--- a/dashboard/src/components/tabs/overview-tab.tsx
+++ b/dashboard/src/components/tabs/overview-tab.tsx
@@ -7,7 +7,7 @@ import { Card } from "../primitives/card";
 import type { AgentResult, AgentLlmError, SpendingData } from "../types";
 import type { RecipientProfile } from "../../lib/types";
 import { agentFetch } from "../../lib/agent-fetch";
-import { formatCurrency, type Locale } from "../../i18n";
+import { formatCurrency, getTranslations, type Locale } from "../../i18n";
 
 export interface OverviewTabProps {
   spending: SpendingData | null;
@@ -18,8 +18,6 @@ export interface OverviewTabProps {
   onRunTask: (task: string, label: string) => void;
   onCancelTask?: () => void;
   recipient?: RecipientProfile;
-  // #1138 — defaults to "en" so existing callers that don't pass a locale
-  // render identically to before this change.
   locale?: Locale;
 }
 
@@ -40,17 +38,18 @@ export function OverviewTab({
   recipient,
   locale = "en",
 }: OverviewTabProps) {
+  const t = getTranslations(locale);
   const savings = agentResult
     ? agentResult.toolCalls
-        .filter((t) => t.tool === "compare_pharmacy_prices")
-        .reduce((s, t) => s + (t.result?.potentialSavings || 0), 0)
+      .filter((t) => t.tool === "compare_pharmacy_prices")
+      .reduce((s, t) => s + (t.result?.potentialSavings || 0), 0)
     : 0;
   const overcharges = agentResult
     ? agentResult.toolCalls
-        .filter(
-          (t) => t.tool === "audit_medical_bill" || t.tool === "fetch_and_audit_bill",
-        )
-        .reduce((s, t) => s + (t.result?.totalOvercharge || 0),0)
+      .filter(
+        (t) => t.tool === "audit_medical_bill" || t.tool === "fetch_and_audit_bill",
+      )
+      .reduce((s, t) => s + (t.result?.totalOvercharge || 0), 0)
     : 0;
 
   const llmTokens = agentResult?.llmUsage
@@ -72,27 +71,27 @@ export function OverviewTab({
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card
-          label="Monthly Spending"
+          label={t.overview.monthlySpending}
           value={formatCurrency(spending?.spending.total ?? 0, locale)}
-          sub={`of ${formatCurrency(spending?.policy.monthlyLimit ?? 500, locale, 0)} limit`}
+          sub={`of ${formatCurrency(spending?.policy.monthlyLimit ?? 500, locale, 0)} ${t.overview.limit}`}
           color="sky"
         />
         <Card
-          label="Savings Found"
+          label={t.overview.savingsFound}
           value={agentResult ? `${formatCurrency(savings, locale)}/mo` : `${formatCurrency(0, locale)}/mo`}
-          sub="by switching pharmacies"
+          sub={t.overview.bySwitching}
           color="green"
         />
         <Card
-          label="Billing Errors Caught"
+          label={t.overview.billingErrors}
           value={agentResult ? formatCurrency(overcharges, locale) : formatCurrency(0, locale)}
-          sub="in overcharges identified"
+          sub={t.overview.inOvercharges}
           color="amber"
         />
         <Card
-          label="Agent API Costs"
+          label={t.overview.agentApiCosts}
           value={formatCurrency(spending?.spending.serviceFees ?? 0, locale, 4)}
-          sub={`${spending?.transactionCount || 0} queries via x402`}
+          sub={`${spending?.transactionCount || 0} ${t.overview.queries}`}
           color="slate"
         />
         <Card
@@ -104,15 +103,15 @@ export function OverviewTab({
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">Budget Status</h2>
+        <h2 className="text-sm font-semibold text-slate-700 mb-4">{t.overview.budgetStatus}</h2>
         <div className="space-y-4">
           <Bar
-            label="Medications"
+            label={t.budget.medications}
             spent={spending?.spending.medications || 0}
             budget={spending?.policy.medicationMonthlyBudget || 300}
           />
           <Bar
-            label="Medical Bills"
+            label={t.budget.medicalBills}
             spent={spending?.spending.bills || 0}
             budget={spending?.policy.billMonthlyBudget || 500}
           />
@@ -120,34 +119,34 @@ export function OverviewTab({
       </div>
 
       <div className="bg-white rounded-xl border border-slate-200 p-6">
-        <h2 className="text-sm font-semibold text-slate-700 mb-4">Agent Actions</h2>
+        <h2 className="text-sm font-semibold text-slate-700 mb-4">{t.overview.agentActions}</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
           <Btn
-            label="Compare Medication Prices"
+            label={t.tasks.comparePrices}
             desc={
               agentPaused
-                ? "Agent is paused"
-                : "Find cheapest pharmacies for Rosa's 4 medications"
+                ? t.tasks.agentPaused
+                : t.tasks.findCheapest
             }
             busy={(loading && activeTask === "meds") || agentPaused}
             onClick={() => onRunTask(TASKS.meds, "meds")}
           />
           <Btn
-            label="Audit Hospital Bill"
+            label={t.tasks.auditBill}
             desc={
               agentPaused
-                ? "Agent is paused"
-                : "Scan Rosa's bill for errors and overcharges"
+                ? t.tasks.agentPaused
+                : t.tasks.scanBill
             }
             busy={(loading && activeTask === "bill") || agentPaused}
             onClick={() => onRunTask(TASKS.bill, "bill")}
           />
           <Btn
-            label="Try Over-Budget Payment"
+            label={t.tasks.overBudget}
             desc={
               agentPaused
-                ? "Agent is paused"
-                : "Demo: agent attempts $600 payment (over $500 bill limit)"
+                ? t.tasks.agentPaused
+                : t.tasks.demoPayment
             }
             busy={(loading && activeTask === "block") || agentPaused}
             onClick={() => onRunTask(TASKS.block, "block")}
@@ -156,7 +155,7 @@ export function OverviewTab({
         {loading && (
           <div className="mt-4 flex items-center gap-3 text-sm text-sky-600">
             <div className="w-4 h-4 border-2 border-sky-600 border-t-transparent rounded-full animate-spin" />
-            Agent working...
+            {t.tasks.working}
             {onCancelTask && (
               <button
                 onClick={onCancelTask}
@@ -189,7 +188,7 @@ export function OverviewTab({
           aria-atomic="true"
         >
           <h2 className="text-sm font-semibold text-slate-700 mb-3">
-            Agent Response
+            {t.overview.agentResponse}
           </h2>
           <p className="text-sm text-slate-600 whitespace-pre-wrap">
             {agentResult.response}
@@ -244,7 +243,7 @@ function AdherencePrompt() {
     agentFetch("/agent/adherence/pending?recipient_id=rosa")
       .then((r) => r.json())
       .then((data) => setAdherence(data))
-      .catch(() => {});
+      .catch(() => { });
   }, []);
 
   const handleConfirm = async (recordId: string) => {
@@ -255,7 +254,7 @@ function AdherencePrompt() {
         body: JSON.stringify({ record_id: recordId }),
       });
       setAdherence((prev) => prev ? { ...prev, pending: prev.pending.filter((p) => p.id !== recordId) } : prev);
-    } catch {}
+    } catch { }
   };
 
   if (!adherence || (adherence.pending.length === 0 && adherence.flagged.length === 0)) return null;


### PR DESCRIPTION
… hardcoded strings

- ActivityTab: labels sourced from getTranslations(locale).activity
- MedicationsTab: labels sourced from getTranslations(locale).medications
- OverviewTab: labels sourced from getTranslations(locale).overview/.budget/.tasks
- BillsTab: labels sourced from getTranslations(locale).bills
- page.tsx: reads ?locale= query param and passes locale to tab components
- Set to 'es' via ?locale=es query parameter to render Spanish translations

Closes  #1129
closes  #1130
closes  #1131
closes  #1132

## What changed
-

## How to test
-

## Checklist
- [ ] CI passes (typecheck, lint, tests)
- [ ] No sensitive data files (`data/spending.json`, `data/orders.json`) committed
- [ ] PR linked to an issue
