### PR TITLE
fix(dashboard): align approvals and transaction displays

### DIFF
--- a/dashboard/src/__tests__/approvals-tab.test.tsx
+++ b/dashboard/src/__tests__/approvals-tab.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApprovalsTab } from "../components/tabs/approvals-tab";
+import type { Transaction } from "../lib/types";
+
+const APPROVAL: Transaction = {
+  id: "approval-1",
+  timestamp: "2026-07-29T10:00:00.000Z",
+  type: "bill",
+  description: "Hospital bill",
+  amount: 80,
+  recipient: "Rosa",
+  status: "pending",
+  category: "bills",
+};
+
+describe("ApprovalsTab", () => {
+  it("renders approvals from props and delegates approve and cancel actions", () => {
+    const onApprove = vi.fn().mockResolvedValue(undefined);
+    const onCancel = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ApprovalsTab
+        agentConnected
+        approvals={[APPROVAL]}
+        loading={false}
+        onApprove={onApprove}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByText("Hospital bill")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onApprove).toHaveBeenCalledWith("approval-1");
+    expect(onCancel).toHaveBeenCalledWith("approval-1");
+  });
+});

--- a/dashboard/src/__tests__/policy-tab.test.tsx
+++ b/dashboard/src/__tests__/policy-tab.test.tsx
@@ -42,13 +42,14 @@ function buildProps(overrides: Partial<PolicyTabProps> = {}): PolicyTabProps {
 }
 
 describe("PolicyTab — rendering (Issue #47)", () => {
-  it("renders all 5 number input fields", () => {
+  it("renders all 6 number input fields", () => {
     render(<PolicyTab {...buildProps()} />);
     expect(screen.getByLabelText(/Daily Spending Limit/i)).toBeTruthy();
     expect(screen.getByLabelText(/Monthly Spending Limit/i)).toBeTruthy();
     expect(screen.getByLabelText(/Medication Monthly Budget/i)).toBeTruthy();
     expect(screen.getByLabelText(/Bill Monthly Budget/i)).toBeTruthy();
     expect(screen.getByLabelText(/Caregiver Approval Threshold/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Hold Time Before Auto-Approval/i)).toBeTruthy();
   });
 
   it("populates fields with values from spending.policy (the policyForm prop)", () => {

--- a/dashboard/src/__tests__/tx-link.test.tsx
+++ b/dashboard/src/__tests__/tx-link.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TxLink } from "../components/primitives/tx-link";
+
+describe("TxLink transaction hash display", () => {
+  it("uses the shared display length while retaining the full hash in the link", () => {
+    const hash = "a".repeat(64);
+    render(<TxLink hash={hash} />);
+
+    const link = screen.getByRole("link");
+    expect(link.textContent).toBe(`${"a".repeat(16)}...`);
+    expect(link.getAttribute("href")).toContain(hash);
+    expect(link.getAttribute("title")).toContain(hash);
+  });
+});

--- a/dashboard/src/app/__tests__/pdf-transaction-hash.test.ts
+++ b/dashboard/src/app/__tests__/pdf-transaction-hash.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Transaction } from "../../lib/types";
+
+const autoTableCalls: Array<{ body: unknown[][] }> = [];
+const save = vi.fn();
+
+vi.mock("jspdf", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    setProperties: vi.fn(),
+    setFontSize: vi.fn(),
+    setTextColor: vi.fn(),
+    text: vi.fn(),
+    setDrawColor: vi.fn(),
+    line: vi.fn(),
+    getNumberOfPages: vi.fn(() => 1),
+    setPage: vi.fn(),
+    save,
+  })),
+}));
+
+vi.mock("jspdf-autotable", () => ({
+  default: vi.fn().mockImplementation((_doc: unknown, options: { body: unknown[][] }) => {
+    autoTableCalls.push(options);
+  }),
+}));
+
+import {
+  downloadTransactionPDF,
+  formatTxHashDisplay,
+} from "../pdf";
+
+describe("transaction hash PDF formatting", () => {
+  beforeEach(() => {
+    autoTableCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("uses the shared truncation length for valid Stellar hashes", () => {
+    expect(formatTxHashDisplay("a".repeat(64))).toEqual({
+      display: `${"a".repeat(16)}...`,
+      decodeFailed: false,
+    });
+  });
+
+  it("visually distinguishes undecodable hashes in a mixed transaction PDF", () => {
+    const base: Omit<Transaction, "id" | "stellarTxHash"> = {
+      timestamp: new Date().toISOString(),
+      type: "medication",
+      description: "Prescription",
+      amount: 10,
+      recipient: "Rosa",
+      status: "completed",
+      category: "meds",
+    };
+    downloadTransactionPDF(
+      [
+        { ...base, id: "valid", stellarTxHash: "a".repeat(64) },
+        { ...base, id: "invalid", stellarTxHash: "not-a-stellar-hash" },
+      ],
+      null,
+    );
+
+    const body = autoTableCalls[0].body;
+    expect(body[0][5]).toBe(`${"a".repeat(16)}...`);
+    expect(body[1][5]).toMatchObject({
+      content: expect.stringContaining("?"),
+      styles: { fontStyle: "italic", textColor: [185, 28, 28] },
+    });
+    expect(save).toHaveBeenCalledWith("careguard-transaction-report.pdf");
+  });
+});

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -137,7 +137,14 @@ export default function Dashboard() {
           />
         )}
         {activeTab === "approvals" && (
-          <ApprovalsTab agentConnected={state.agentConnected} />
+          <ApprovalsTab
+            agentConnected={state.agentConnected}
+            approvals={state.approvals}
+            loading={state.approvalsLoading}
+            onApprove={state.approveTransaction}
+            onCancel={state.cancelTransaction}
+            locale={locale}
+          />
         )}
         {activeTab === "policy" && (
           <PolicyTab

--- a/dashboard/src/app/pdf.ts
+++ b/dashboard/src/app/pdf.ts
@@ -4,14 +4,15 @@ import { toast } from "sonner";
 import type { BillAuditResult, DrugInteractionResult, PharmacyCompareResult, SpendingData, Transaction, DisputeLetter } from "../lib/types";
 import { DEFAULT_PDF_THEME, type PdfTheme } from "../lib/pdf-theme";
 import type { RecipientProfile } from "../lib/types";
+import { TX_HASH_DISPLAY_LENGTH, truncateTransactionHash } from "../lib/tx-hash";
 
 type AutoTableDoc = jsPDF & { lastAutoTable?: { finalY: number } };
 
-function formatTxHashDisplay(hash?: string): { display: string; decodeFailed: boolean } {
+export function formatTxHashDisplay(hash?: string): { display: string; decodeFailed: boolean } {
   if (!hash) return { display: "-", decodeFailed: false };
 
   if (hash.length === 64 && /^[0-9a-f]{64}$/i.test(hash)) {
-    return { display: `${hash.slice(0, 16)}...`, decodeFailed: false };
+    return { display: truncateTransactionHash(hash), decodeFailed: false };
   }
 
   if (hash.length > 64) {
@@ -19,16 +20,18 @@ function formatTxHashDisplay(hash?: string): { display: string; decodeFailed: bo
       const decoded = JSON.parse(atob(hash)) as Record<string, unknown>;
       const extracted = (decoded.transaction || decoded.reference || decoded.hash) as unknown;
       if (typeof extracted === "string") {
-        const trimmed = extracted.length > 16 ? `${extracted.slice(0, 16)}...` : extracted;
+        const trimmed = extracted.length > TX_HASH_DISPLAY_LENGTH
+          ? truncateTransactionHash(extracted)
+          : extracted;
         return { display: trimmed, decodeFailed: false };
       }
-      return { display: `${hash.slice(0, 16)}... ?`, decodeFailed: true };
+      return { display: `${truncateTransactionHash(hash)} ?`, decodeFailed: true };
     } catch {
-      return { display: `${hash.slice(0, 16)}... ?`, decodeFailed: true };
+      return { display: `${truncateTransactionHash(hash)} ?`, decodeFailed: true };
     }
   }
 
-  return { display: `${hash.slice(0, 16)}... ?`, decodeFailed: true };
+  return { display: `${truncateTransactionHash(hash)} ?`, decodeFailed: true };
 }
 
 function formatRecipient(recipient: RecipientProfile): string {
@@ -342,14 +345,19 @@ export function downloadTransactionPDF(
     startY: y,
     head: [["Time", "Type", "Description", "Amount", "Status", "Stellar Tx"]],
     body: transactions.map((tx) => {
-      const { display } = formatTxHashDisplay(tx.stellarTxHash);
+      const { display, decodeFailed } = formatTxHashDisplay(tx.stellarTxHash);
       return [
         new Date(tx.timestamp).toLocaleString(),
         tx.type,
         tx.description.slice(0, 40),
         `$${tx.amount < 0.01 ? tx.amount.toFixed(4) : tx.amount.toFixed(2)}`,
         tx.status,
-        display,
+        decodeFailed
+          ? {
+              content: display,
+              styles: { fontStyle: "italic", textColor: [185, 28, 28] },
+            }
+          : display,
       ];
     }),
     headStyles: { fillColor: theme.headerColor, fontSize: 7 },

--- a/dashboard/src/components/primitives/tx-link.tsx
+++ b/dashboard/src/components/primitives/tx-link.tsx
@@ -1,4 +1,5 @@
 import { EXPLORER_TX_URL } from "../../lib/stellar-network";
+import { truncateTransactionHash } from "../../lib/tx-hash";
 
 // Backend guarantees stellarTxHash is always a real 64-char hex hash or
 // undefined (#14) — no more base64/receipt decoding needed here.
@@ -33,7 +34,7 @@ export function TxLink({ hash, txHashStatus }: TxLinkProps) {
       className="text-xs text-sky-600 hover:text-sky-800 underline font-mono"
       title={`View on Stellar Explorer: ${hash}`}
     >
-      {hash.slice(0, 8)}...
+      {truncateTransactionHash(hash)}
     </a>
   );
 }

--- a/dashboard/src/components/tabs/approvals-tab.tsx
+++ b/dashboard/src/components/tabs/approvals-tab.tsx
@@ -1,73 +1,35 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Btn } from "../primitives/btn";
-import { Card } from "../primitives/card";
+import { useEffect, useState } from "react";
 import type { Transaction } from "../types";
-import { AGENT_URL } from "../../lib/agent-url";
-import { agentFetch } from "../../lib/agent-fetch";
 import { formatDateTime, type Locale } from "../../i18n";
 
 
 export interface ApprovalsTabProps {
   agentConnected: boolean;
+  approvals: Transaction[];
+  loading: boolean;
+  onApprove: (txId: string) => Promise<void>;
+  onCancel: (txId: string) => Promise<void>;
   // #1139 — defaults to "en" so existing callers that don't pass a locale
   // render identically to before this change.
   locale?: Locale;
 }
 
-export function ApprovalsTab({ agentConnected, locale = "en" }: ApprovalsTabProps) {
-  const [approvals, setApprovals] = useState<Transaction[]>([]);
-  const [loading, setLoading] = useState(false);
+export function ApprovalsTab({
+  agentConnected,
+  approvals,
+  loading,
+  onApprove,
+  onCancel,
+  locale = "en",
+}: ApprovalsTabProps) {
   const [, setTick] = useState(0);
 
-  const fetchApprovals = async () => {
-    try {
-      const res = await agentFetch(`${AGENT_URL}/agent/pending-approvals`);
-      if (!res.ok) return;
-      const data = await res.json();
-      setApprovals(data.approvals || []);
-    } catch {}
-  };
-
   useEffect(() => {
-    fetchApprovals();
-    fetchApprovals();
-    const i = setInterval(fetchApprovals, 5000);
     const t = setInterval(() => setTick((s) => s + 1), 1000);
-    return () => {
-      clearInterval(i);
-      clearInterval(t);
-    };
+    return () => clearInterval(t);
   }, []);
-
-  const handleApprove = async (txId: string) => {
-    setLoading(true);
-    try {
-      const res = await agentFetch(`${AGENT_URL}/agent/approvals/${txId}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ approve: true }),
-      });
-      if (res.ok) fetchApprovals();
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleCancel = async (txId: string) => {
-    setLoading(true);
-    try {
-      const res = await agentFetch(`${AGENT_URL}/agent/approvals/${txId}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ approve: false }),
-      });
-      if (res.ok) fetchApprovals();
-    } finally {
-      setLoading(false);
-    }
-  };
 
   return (
     <div
@@ -121,14 +83,14 @@ export function ApprovalsTab({ agentConnected, locale = "en" }: ApprovalsTabProp
                   </div>
                   <div className="flex gap-2">
                     <button
-                      onClick={() => handleApprove(tx.id)}
+                      onClick={() => onApprove(tx.id)}
                       disabled={loading}
                       className="px-3 py-1.5 bg-green-600 text-white text-xs font-medium rounded-lg hover:bg-green-700 disabled:opacity-50 cursor-pointer"
                     >
                       Approve
                     </button>
                     <button
-                      onClick={() => handleCancel(tx.id)}
+                      onClick={() => onCancel(tx.id)}
                       disabled={loading}
                       className="px-3 py-1.5 bg-red-600 text-white text-xs font-medium rounded-lg hover:bg-red-700 disabled:opacity-50 cursor-pointer"
                     >

--- a/dashboard/src/hooks/use-agent-state.ts
+++ b/dashboard/src/hooks/use-agent-state.ts
@@ -68,6 +68,8 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   const [policyDirty, setPolicyDirty] = useState(false);
   const [policySaved, setPolicySaved] = useState(false);
   const [abortController, setAbortController] = useState<AbortController | null>(null);
+  const [approvals, setApprovals] = useState<Transaction[]>([]);
+  const [approvalsLoading, setApprovalsLoading] = useState(false);
 
   // Individual loading states for each data source (Issue #283)
   const [loadingAgentInfo, setLoadingAgentInfo] = useState(false);
@@ -89,6 +91,45 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
   useEffect(() => {
     policyDirtyRef.current = policyDirty;
   }, [policyDirty]);
+
+  const fetchApprovals = useCallback(async () => {
+    try {
+      const res = await agentFetch(`${AGENT_URL}/agent/pending-approvals`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setApprovals(data.approvals || []);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (activeTab !== 'approvals') return;
+    void fetchApprovals();
+    const interval = setInterval(fetchApprovals, 5000);
+    return () => clearInterval(interval);
+  }, [activeTab, fetchApprovals]);
+
+  const updateApproval = useCallback(async (txId: string, approve: boolean) => {
+    setApprovalsLoading(true);
+    try {
+      const res = await agentFetch(`${AGENT_URL}/agent/approvals/${txId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ approve }),
+      });
+      if (res.ok) await fetchApprovals();
+    } finally {
+      setApprovalsLoading(false);
+    }
+  }, [fetchApprovals]);
+
+  const approveTransaction = useCallback(
+    (txId: string) => updateApproval(txId, true),
+    [updateApproval],
+  );
+  const cancelTransaction = useCallback(
+    (txId: string) => updateApproval(txId, false),
+    [updateApproval],
+  );
 
   useEffect(() => {
     const connectionState = !agentConnected
@@ -565,6 +606,8 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     policyDirty,
     setPolicyDirty,
     policySaved,
+    approvals,
+    approvalsLoading,
     // individual loading states (Issue #283)
     loadingAgentInfo,
     loadingSpending,
@@ -581,5 +624,7 @@ export function useAgentState({ activeTab }: UseAgentStateOptions) {
     resetAgent,
     togglePause,
     addLogEntry,
+    approveTransaction,
+    cancelTransaction,
   };
 }

--- a/dashboard/src/lib/tx-hash.ts
+++ b/dashboard/src/lib/tx-hash.ts
@@ -1,0 +1,5 @@
+export const TX_HASH_DISPLAY_LENGTH = 16;
+
+export function truncateTransactionHash(hash: string): string {
+  return `${hash.slice(0, TX_HASH_DISPLAY_LENGTH)}...`;
+}


### PR DESCRIPTION
## Summary
- move approvals polling and mutations into `useAgentState`, leaving `ApprovalsTab` presentational
- share one 16-character Stellar transaction-hash display helper between the live UI and PDF exports
- visually flag undecodable PDF hashes and cover mixed valid/invalid transaction exports
- correct policy field coverage to assert all six numeric inputs

## Tests
- `vitest run src/__tests__/policy-tab.test.tsx src/__tests__/approvals-tab.test.tsx src/__tests__/tx-link.test.tsx src/app/__tests__/pdf-transaction-hash.test.ts` (27 passed)
- targeted ESLint: new/changed scoped code is clean; the command still reports pre-existing errors in `page.tsx` and `use-agent-state.ts`
- dashboard TypeScript check still reports pre-existing project errors, including duplicate props and stale unrelated tests

Closes #1115
Closes #1116
Closes #1117
Closes #1119