### PR TITLE
[codex] fix dashboard audit keys and tests

### DIFF
--- a/agent/runner.ts
+++ b/agent/runner.ts
@@ -81,7 +81,7 @@ export interface RunAgentOptions {
 
 export interface RunAgentResult {
   response: string;
-  toolCalls: Array<{ tool: string; input: Record<string, unknown>; result: ToolResult }>;
+  toolCalls: Array<{ id: string; tool: string; input: Record<string, unknown>; result: ToolResult }>;
   spending: ReturnType<typeof getSpendingSummary>;
   llmUsage: { promptTokens: number; completionTokens: number };
   truncated: boolean;
@@ -311,7 +311,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
     { role: "user", content: userTask },
   ];
 
-  const toolCalls: Array<{ tool: string; input: Record<string, unknown>; result: ToolResult }> = [];
+  const toolCalls: Array<{ id: string; tool: string; input: Record<string, unknown>; result: ToolResult }> = [];
   let finalResponse = "";
   let llmUsage = { promptTokens: 0, completionTokens: 0 };
   let runToolCalls = 0;
@@ -427,11 +427,11 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
       let result: ToolResult;
       try {
         result = await executeTool(fnName, fnArgs);
-        toolCalls.push({ tool: fnName, input: fnArgs, result });
+        toolCalls.push({ id: toolCall.id, tool: fnName, input: fnArgs, result });
       } catch (err: any) {
         logger.error({ tool: fnName, err: err.message }, "tool error");
         result = { error: err.message };
-        toolCalls.push({ tool: fnName, input: fnArgs, result });
+        toolCalls.push({ id: toolCall.id, tool: fnName, input: fnArgs, result });
       }
 
       appendAuditEntry({

--- a/dashboard/src/__tests__/agent-log.test.tsx
+++ b/dashboard/src/__tests__/agent-log.test.tsx
@@ -2,6 +2,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import Dashboard from '../app/page';
 
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+  useSearchParams: vi.fn(() => ({ get: vi.fn(() => null) })),
+}));
+
 // Mock the environment and dependencies
 vi.mock('../../lib/useProfile', () => ({
   useProfile: () => ({

--- a/dashboard/src/__tests__/aria-tabs.test.tsx
+++ b/dashboard/src/__tests__/aria-tabs.test.tsx
@@ -2,6 +2,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import Dashboard from '../app/page';
 
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+  useSearchParams: vi.fn(() => ({ get: vi.fn(() => null) })),
+}));
+
 // Mock the environment and dependencies
 vi.mock('../../lib/useProfile', () => ({
   useProfile: () => ({
@@ -42,7 +47,7 @@ describe('ARIA Tab Semantics and Keyboard Navigation', () => {
     const { container } = render(<Dashboard />);
     
     const tabs = container.querySelectorAll('[role="tab"]');
-    expect(tabs).toHaveLength(7); // overview, medications, bills, policy, wallet, activity, settings
+    expect(tabs).toHaveLength(8); // overview, medications, bills, approvals, policy, wallet, activity, settings
     
     // Check first tab (overview)
     const firstTab = tabs[0];
@@ -62,7 +67,7 @@ describe('ARIA Tab Semantics and Keyboard Navigation', () => {
     const { container } = render(<Dashboard />);
     
     const tabpanels = container.querySelectorAll('[role="tabpanel"]');
-    expect(tabpanels).toHaveLength(7);
+    expect(tabpanels).toHaveLength(8);
     
     // Check active tabpanel
     const activeTabpanel = container.querySelector('#tabpanel-overview');
@@ -107,7 +112,7 @@ describe('ARIA Tab Semantics and Keyboard Navigation', () => {
     
     // End should move to last tab
     fireEvent.keyDown(tablist!, { key: 'End' });
-    expect(tabs[6]).toHaveFocus();
+    expect(tabs[7]).toHaveFocus();
   });
 
   it('should handle Enter and Space keys', () => {

--- a/dashboard/src/__tests__/tool-call-error.test.tsx
+++ b/dashboard/src/__tests__/tool-call-error.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ActivityTab } from "../components/tabs/activity-tab";
 import type { AgentLogEntry } from "../components/types";
 
@@ -49,6 +49,10 @@ describe("Tool-call error expand/collapse", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("renders normal log entries as plain text without details", () => {
     const entries = [makeNormalEntry()];
     const { container } = render(<ActivityTab {...baseProps} agentLog={entries} />);
@@ -94,6 +98,7 @@ describe("Tool-call error expand/collapse", () => {
   });
 
   it("copies error detail to clipboard when copy button clicked", async () => {
+    vi.stubGlobal("isSecureContext", true);
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn().mockResolvedValue(undefined),

--- a/dashboard/src/components/tabs/bills-tab.tsx
+++ b/dashboard/src/components/tabs/bills-tab.tsx
@@ -28,8 +28,11 @@ export function BillsTab({ agentResult, recipient, locale = "en" }: BillsTabProp
       t.tool === "audit_medical_bill" || t.tool === "fetch_and_audit_bill",
   );
 
-  const handleDispute = useCallback(async (auditResult: any, index: number) => {
-    setGeneratingDispute(`dispute-${index}`);
+  const auditCallKey = (tc: NonNullable<typeof auditCalls>[number]) =>
+    tc.id ?? `${tc.tool}-${JSON.stringify(tc.input)}`;
+
+  const handleDispute = useCallback(async (auditResult: any, auditKey: string) => {
+    setGeneratingDispute(auditKey);
     try {
       const letter: DisputeLetter = {
         billId: `bill-${Date.now()}`,
@@ -73,9 +76,10 @@ export function BillsTab({ agentResult, recipient, locale = "en" }: BillsTabProp
       className="space-y-6"
     >
       {auditCalls && auditCalls.length > 0 ? (
-        auditCalls.map((tc, i) => (
+        auditCalls.map((tc) => (
           <div
-            key={i}
+            // The tool-call ID (or legacy payload composite) stays stable across list reordering.
+            key={auditCallKey(tc)}
             className="bg-white rounded-xl border border-slate-200 p-6"
           >
             <div className="flex items-center justify-between mb-4">
@@ -101,11 +105,11 @@ export function BillsTab({ agentResult, recipient, locale = "en" }: BillsTabProp
                 {tc.result.errorCount > 0 && (
                   <>
                     <button
-                      onClick={() => handleDispute(tc.result, i)}
-                      disabled={generatingDispute === `dispute-${i}`}
+                      onClick={() => handleDispute(tc.result, auditCallKey(tc))}
+                      disabled={generatingDispute === auditCallKey(tc)}
                       className="px-3 py-1.5 bg-red-50 text-red-700 rounded-lg text-xs font-medium hover:bg-red-100 active:bg-red-200 cursor-pointer transition-all disabled:opacity-50"
                     >
-                      {generatingDispute === `dispute-${i}` ? "Generating..." : "Dispute"}
+                      {generatingDispute === auditCallKey(tc) ? "Generating..." : "Dispute"}
                     </button>
                     <button
                       onClick={() => handleDisputeEmail(tc.result)}

--- a/dashboard/src/components/types.ts
+++ b/dashboard/src/components/types.ts
@@ -14,7 +14,7 @@ export interface AgentLlmError {
 
 export interface AgentResult {
   response: string;
-  toolCalls: Array<{ tool: string; input: unknown; result: any }>;
+  toolCalls: Array<{ id?: string; tool: string; input: unknown; result: any }>;
   spending: SpendingData;
   llmUsage?: {
     promptTokens: number;


### PR DESCRIPTION
## Summary

- preserve upstream LLM tool-call IDs and use them as stable bill-audit card identities
- keep dispute generation state attached to the same audit when calls are reordered
- fix the clipboard test by explicitly enabling jsdom's secure-context branch
- add the missing `next/navigation` mocks to the agent-log and ARIA-tab suites
- update ARIA-tab expectations for the current eight-tab dashboard

## Why

Bill audit cards were keyed and tracked by array position, so list changes could associate React state with the wrong audit. Three dashboard test files had also drifted from current runtime assumptions: jsdom is insecure by default, Next navigation hooks require mocks, and the dashboard now exposes eight tabs.

## Validation

- `git diff --cached --check` passed before commit
- targeted Vitest suites could not be run on this clean checkout: `npm ci` rejects the repository's out-of-sync `package-lock.json`, and frozen pnpm/npm installs stalled without creating `node_modules`
- existing clipboard fallback coverage remains in `dashboard/src/__tests__/clipboard.test.ts`

Closes #1103
Closes #1101
Closes #1096
Closes #1095
