### PR TITLE
chore(ui): add aria attributes to tabs, throttle screen reader countdown, and fix wallet tests

### DIFF
--- a/dashboard/src/__tests__/wallet-tab.test.tsx
+++ b/dashboard/src/__tests__/wallet-tab.test.tsx
@@ -20,6 +20,7 @@ function buildProps(overrides: Partial<WalletTabProps> = {}): WalletTabProps {
     } as any,
     walletBalance: "42.50",
     walletXlm: "10.20",
+    walletBalanceState: "ok",
     ...overrides,
   };
 }
@@ -55,6 +56,17 @@ describe("WalletTab — balance display (Issue #49)", () => {
   it("Horizon error (both null) shows $0.00 placeholder for USDC", () => {
     render(<WalletTab {...buildProps({ walletBalance: null, walletXlm: null })} />);
     expect(screen.getByText("$0.00")).toBeTruthy();
+  });
+
+  it("shows loading spinner when walletBalanceState is 'loading'", () => {
+    const { container } = render(<WalletTab {...buildProps({ walletBalanceState: "loading" })} />);
+    // Relying on the loading spinner class or loading text
+    expect(container.querySelector(".animate-spin")).toBeTruthy();
+  });
+
+  it("shows error state when walletBalanceState is 'error'", () => {
+    render(<WalletTab {...buildProps({ walletBalanceState: "error", walletBalanceError: "Custom error" })} />);
+    expect(screen.getByText("Custom error")).toBeTruthy();
   });
 });
 

--- a/dashboard/src/components/dashboard-tabs-nav.tsx
+++ b/dashboard/src/components/dashboard-tabs-nav.tsx
@@ -63,6 +63,10 @@ export function DashboardTabsNav({ activeTab, pathname, locale = "en" }: Dashboa
         const isActive = activeTab === tab;
         const href = tab === "overview" ? pathname : `${pathname}?tab=${tab}`;
         return (
+          // Issue #1124: We use next/link for bookmarkable URLs despite role="tab"
+          // and a roving tabIndex. Screen readers' "browse by link" may bypass the 
+          // tabIndex=-1, but activating the link will correctly navigate, making it
+          // an acceptable trade-off for shareable URLs.
           <Link
             key={tab}
             href={href}

--- a/dashboard/src/components/tabs/approvals-tab.tsx
+++ b/dashboard/src/components/tabs/approvals-tab.tsx
@@ -73,7 +73,15 @@ export function ApprovalsTab({
                           try {
                             const ms = new Date(tx.pendingUntil).getTime() - Date.now();
                             const sec = Math.max(0, Math.ceil(ms / 1000));
-                            return `Auto-approve in ${sec}s`;
+                            const announcedSec = sec <= 5 ? sec : Math.ceil(sec / 10) * 10;
+                            return (
+                              <>
+                                <span aria-hidden="true">Auto-approve in {sec}s</span>
+                                <span className="sr-only" aria-live="polite">
+                                  Auto-approve in {announcedSec} seconds
+                                </span>
+                              </>
+                            );
                           } catch {
                             return null;
                           }

--- a/dashboard/src/components/tabs/bills-tab.tsx
+++ b/dashboard/src/components/tabs/bills-tab.tsx
@@ -153,6 +153,7 @@ export function BillsTab({ agentResult, recipient, locale = "en" }: BillsTabProp
               </span>
               <button
                 onClick={() => setShowErrorsOnly(!showErrorsOnly)}
+                aria-pressed={showErrorsOnly}
                 className="text-xs text-sky-600 hover:text-sky-800 cursor-pointer"
               >
                 {showErrorsOnly ? b.showAll : b.showErrors}


### PR DESCRIPTION
## Description
This PR addresses several UI accessibility improvements across the dashboard and fixes a failing test suite in the wallet tab.

### Changes Made
* **Bills Tab Toggle ( Closes #1121 ):** Added the `aria-pressed` attribute to the "Show errors only" / "Show all items" button, ensuring its toggle state is properly announced by screen readers.
* **Approvals Countdown ( Closes #1120 ):** Added a throttled `aria-live="polite"` region to the auto-approve countdown. Screen readers will now announce the remaining time every 10 seconds, and every second when under 5 seconds, avoiding unnecessary spam.
* **Dashboard Tabs Nav ( Closes #1124 ):** Added documentation regarding the tension between the ARIA tabs roving-tabindex convention and our use of `next/link` anchors for shareable URLs, clarifying that the current setup remains functional and is a known trade-off.
* **Wallet Tab Tests ( Closes #1099 ):** Updated `buildProps()` in `wallet-tab.test.tsx` to pass `walletBalanceState: 'ok'` by default, which fixes the 6 failing balance-display tests. Added dedicated explicit tests to cover the `loading` and `error` states. 
