### PR TITLE
Fix issues #1089, #1091, #1108, #1109

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Run tests
+      - name: Run root tests
         run: npm test
+
+      - name: Run dashboard tests
+        run: npx vitest run --config dashboard/vitest.config.ts

--- a/dashboard/src/app/error.tsx
+++ b/dashboard/src/app/error.tsx
@@ -9,6 +9,15 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
     captureException(error, { digest: error.digest });
   }, [error]);
 
+  const handleResetAgent = async () => {
+    try {
+      await fetch("/agent/reset", { method: "POST" });
+    } catch {
+      // Silently ignore network errors during reset
+    }
+    window.location.reload();
+  };
+
   return (
     <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-xl border border-slate-200 p-8 max-w-md text-center">
@@ -36,7 +45,7 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
           </button>
         </div>
         <button
-          onClick={reset}
+          onClick={handleResetAgent}
           className="mt-3 w-full py-2 px-4 border border-slate-300 text-slate-600 rounded-lg text-sm font-medium hover:bg-slate-50 active:bg-slate-100 transition-all cursor-pointer"
         >
           Reset Agent

--- a/dashboard/src/components/primitives/bill-line-items-virtualized.tsx
+++ b/dashboard/src/components/primitives/bill-line-items-virtualized.tsx
@@ -101,9 +101,10 @@ export function BillLineItemsVirtualized({ lineItems }: BillLineItemsVirtualized
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
             const item = lineItems[virtualItem.index];
+            const stableKey = `${item.description}:${item.cptCode ?? ""}:${item.chargedAmount}`;
             return (
               <div
-                key={virtualItem.index}
+                key={stableKey}
                 style={{
                   position: "absolute",
                   top: 0,

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
+  root: __dirname,
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
Resolves four issues in a single PR:

### [#1109](https://github.com/harystyleseze/careguard/issues/1109) [frontend] error.tsx Reset Agent button is functionally identical to Try Again

- Changed Reset Agent button to call /agent/reset endpoint via fetch() instead of the same reset prop as Try Again
- Added handleResetAgent handler that POSTs to the reset endpoint then reloads the page
- Try Again re-renders the error boundary; Reset Agent clears agent state via the API

### [#1091](https://github.com/harystyleseze/careguard/issues/1091) [test] dashboard/vitest.config.ts relative paths resolve against CWD, not the config file

- Added root: __dirname to dashboard/vitest.config.ts so all relative paths resolve against the config file directory
- Ensures npx vitest run --config dashboard/vitest.config.ts from repo root picks up dashboard tests correctly

### [#1089](https://github.com/harystyleseze/careguard/issues/1089) [ci] ci.yml never actually executes the dashboard vitest suite

- Split Run tests step into Run root tests and Run dashboard tests
- New step runs npx vitest run --config dashboard/vitest.config.ts on every push/PR
- Root test step continues to run unaffected

### [#1108](https://github.com/harystyleseze/careguard/issues/1108) [frontend] BillLineItemsVirtualized keys rows by virtualItem.index, which is unstable when the Show errors only filter toggles

- Changed virtualized row key from virtualItem.index to stable composite key: ${item.description}:${item.cptCode ?? ""}:${item.chargedAmount}
- Prevents React from reusing DOM/animation state for a different logical item when filter toggles
- Eliminates stale content and flicker for lists with >50 items

Closes [#1089](https://github.com/harystyleseze/careguard/issues/1089)
Closes [#1091](https://github.com/harystyleseze/careguard/issues/1091)
Closes [#1108](https://github.com/harystyleseze/careguard/issues/1108)
Closes [#1109](https://github.com/harystyleseze/careguard/issues/1109)