### PR TITLE
fix(config): import DEFAULT_ZIP_CODE in PharmacyCompareQuerySchema (#1084)

### DIFF
--- a/services/pharmacy-api/logic.ts
+++ b/services/pharmacy-api/logic.ts
@@ -4,13 +4,14 @@ import {
   optionalFreeTextSchema,
   zipCodeSchema,
 } from "../../shared/free-text.ts";
+import { DEFAULT_ZIP_CODE } from "../../shared/pharmacy-pricing.ts";
 import { toDisplayName } from "./db.ts";
 
 export const PharmacyCompareQuerySchema = z
   .object({
     drug: freeTextSchema("drug"),
     dosage: optionalFreeTextSchema("dosage"),
-    zip: zipCodeSchema.optional().default("90210"),
+    zip: zipCodeSchema.optional().default(DEFAULT_ZIP_CODE),
   })
   .strict();
 export type PharmacyCompareQuery = z.infer<typeof PharmacyCompareQuerySchema>;


### PR DESCRIPTION
Closes #1084
Closes #1088

### Summary of Changes
- Replaced hardcoded default zip code string `"90210"` in `PharmacyCompareQuerySchema` with imported `DEFAULT_ZIP_CODE` constant from `shared/pharmacy-pricing.ts`.

### Changes
- `services/pharmacy-api/logic.ts`: Imported `DEFAULT_ZIP_CODE` and updated `PharmacyCompareQuerySchema.zip` default to reference it dynamically.

### Testing
- Verified schema definition imports and uses canonical `DEFAULT_ZIP_CODE` constant. (No build, install, or test suite execution per instruction).
