### PR TITLE
fix(audit): accept cptCode parameter in default getThreshold fallback (#1087)

### DIFF
--- a/shared/bill-audit.ts
+++ b/shared/bill-audit.ts
@@ -109,7 +109,7 @@ export function auditBill(lineItems: any[], options: AuditBillOptions = {}) {
   const network = options.network ?? "stellar:testnet";
   const payTo = options.payTo ?? process.env.BILL_PROVIDER_PUBLIC_KEY ?? "";
   const allowlist = options.duplicateAllowlist ?? new Set(["96372", "97110"]);
-  const getThreshold = options.getAuditThreshold ?? (() => options.overchargeMultiplier ?? 1.5);
+  const getThreshold = options.getAuditThreshold ?? ((_cptCode?: string) => options.overchargeMultiplier ?? 1.5);
   const suggestedMultiplier = options.suggestedMultiplier ?? 1.2;
   const upcodedMultiplier = options.upcodedMultiplier ?? 3.0;
   const ratesAsOf = options.ratesAsOf ?? "2026-01-01";


### PR DESCRIPTION
Closes #1087
Closes #1086

### Summary of Changes
- Updated the default `getThreshold` fallback in `auditBill` to explicitly accept the `_cptCode` argument.

### Changes
- `shared/bill-audit.ts`: Modified default `getThreshold` arrow function signature from `() => ...` to `(_cptCode?: string) => ...` matching the expected parameter type.

### Testing
- Code inspection verifying parameter signature alignment in `shared/bill-audit.ts`. (No build, install, or test suite execution per instruction).
