### PR TITLE
fix(dashboard): CI unit tests, loading skeleton, flaky timer, recipients error

### DIFF
--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -7,6 +7,37 @@ on:
       - ".github/workflows/dashboard-e2e.yml"
 
 jobs:
+  # Dashboard unit tests (#1092).
+  #
+  # The e2e job below only lints and runs Playwright, and the root `npm test`
+  # (ci.yml) deliberately excludes dashboard/** from its vitest include globs —
+  # so the dashboard's ~15 vitest suites had zero execution path anywhere in CI.
+  #
+  # The dashboard's vitest config (dashboard/vitest.config.ts) is designed to run
+  # from the repo-root install: it references ../tests/setup.ts and relies on the
+  # root's vitest, @vitejs/plugin-react, jsdom, @testing-library/* and the shared
+  # runtime deps (react, next, sonner, …). So this job installs the root deps and
+  # runs that config directly. Any unit-test failure fails the workflow.
+  unit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install root deps
+        run: npm ci --legacy-peer-deps
+
+      - name: Run dashboard unit tests (vitest)
+        run: npx vitest run --config dashboard/vitest.config.ts
+
   e2e:
     runs-on: ubuntu-latest
     defaults:

--- a/dashboard/src/__tests__/useRecipients.test.tsx
+++ b/dashboard/src/__tests__/useRecipients.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tests for Issue #1112 — useRecipients must surface an error state when the
+ * /recipients fetch fails, instead of silently resolving to an empty list.
+ *
+ * Follows the per-source health pattern (#213) used for agentInfo/spending/
+ * transactions, so a failed request shows up in DashboardHeader's "Data issue"
+ * chip rather than looking identical to "no recipients returned".
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { useRecipients } from '../lib/useRecipients';
+
+const recipients = [
+  {
+    id: 'rosa_garcia',
+    name: 'Rosa Garcia',
+    age: 72,
+    medications: [],
+    primary_doctor: null,
+    insurance: null,
+  },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useRecipients — error state (Issue #1112)', () => {
+  it('exposes an error when the request rejects', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('connection refused'));
+
+    const { result } = renderHook(() => useRecipients(vi.fn()));
+
+    await waitFor(() => expect(result.current.error).toBe('connection refused'));
+    expect(result.current.recipients).toEqual([]);
+  });
+
+  it('exposes an error when the response is not ok', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('nope', { status: 503 }),
+    );
+
+    const { result } = renderHook(() => useRecipients(vi.fn()));
+
+    await waitFor(() =>
+      expect(result.current.error).toBe('Recipients returned 503'),
+    );
+    expect(result.current.recipients).toEqual([]);
+  });
+
+  it('stays healthy (error null) and loads data when the fetch succeeds', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(recipients), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { result } = renderHook(() => useRecipients(vi.fn()));
+
+    await waitFor(() => expect(result.current.recipients).toHaveLength(1));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/dashboard/src/app/loading.tsx
+++ b/dashboard/src/app/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "../components/ui/skeleton";
+import { DASHBOARD_TABS } from "../components/types";
 
 export default function Loading() {
   return (
@@ -17,7 +18,14 @@ export default function Loading() {
 
       <div className="max-w-7xl mx-auto px-4 py-6">
         <nav className="flex gap-1 mb-6 bg-white rounded-lg p-1 border border-slate-200 w-fit">
-          {["Overview", "Medications", "Bills", "Policy", "Wallet", "Activity", "Settings"].map((tab) => (
+          {/*
+            Derive the skeleton placeholders from DASHBOARD_TABS (the single
+            source of truth for the real nav) so the count/order can never drift
+            from the tab bar that replaces it. A hardcoded array previously
+            omitted 'Approvals', rendering 7 placeholders for an 8-tab nav and
+            causing a layout shift on first paint (#1111).
+          */}
+          {DASHBOARD_TABS.map((tab) => (
             <Skeleton key={tab} className="px-4 py-2 rounded-md w-20" />
           ))}
         </nav>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -35,7 +35,7 @@ export default function Dashboard() {
   }
 
   const { recipient, caregiver, updateProfile } = useProfile();
-  const { recipients, selectedId, selectRecipient } = useRecipients((profile) => {
+  const { recipients, selectedId, selectRecipient, error: recipientsError } = useRecipients((profile) => {
     updateProfile({ recipient: profile });
   });
   const pathname = usePathname();
@@ -105,6 +105,7 @@ export default function Dashboard() {
         agentInfoError={state.agentInfoError}
         spendingError={state.spendingError}
         transactionsError={state.transactionsError}
+        recipientsError={recipientsError}
       />
       <div className="max-w-7xl mx-auto px-4 py-6">
         <DashboardTabsNav activeTab={activeTab} pathname={pathname} locale={locale} />

--- a/dashboard/src/components/dashboard-header.tsx
+++ b/dashboard/src/components/dashboard-header.tsx
@@ -26,6 +26,7 @@ export interface DashboardHeaderProps {
   agentInfoError?: string | null;
   spendingError?: string | null;
   transactionsError?: string | null;
+  recipientsError?: string | null;
   locale?: Locale;
 }
 
@@ -43,6 +44,7 @@ export function DashboardHeader({
   agentInfoError,
   spendingError,
   transactionsError,
+  recipientsError,
   locale = "en",
 }: DashboardHeaderProps) {
   const [tooltipVisible, setTooltipVisible] = useState(false);
@@ -52,6 +54,7 @@ export function DashboardHeader({
     ...(agentInfoError ? [{ source: 'Agent', error: agentInfoError }] : []),
     ...(spendingError ? [{ source: 'Spending', error: spendingError }] : []),
     ...(transactionsError ? [{ source: 'Transactions', error: transactionsError }] : []),
+    ...(recipientsError ? [{ source: 'Recipients', error: recipientsError }] : []),
   ];
   const anySourceDown = sourceErrors.length > 0;
   return (

--- a/dashboard/src/lib/useRecipients.ts
+++ b/dashboard/src/lib/useRecipients.ts
@@ -16,6 +16,12 @@ export interface RecipientListItem {
 export function useRecipients(onSelect: (profile: RecipientProfile) => void) {
   const [recipients, setRecipients] = useState<RecipientListItem[]>([]);
   const [selectedId, setSelectedId] = useState<string>('rosa_garcia');
+  // Per-source health (Issue #1112, following the #213 pattern in
+  // use-agent-state.ts): null = healthy, string = error message. Previously a
+  // failed /recipients request was swallowed and treated identically to "no
+  // recipients", leaving a caregiver with multiple recipients no indication
+  // that the switcher data failed to load.
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!AGENT_URL) return;
@@ -24,11 +30,17 @@ export function useRecipients(onSelect: (profile: RecipientProfile) => void) {
       : undefined;
     const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {};
     fetch(`${AGENT_URL}/recipients`, { headers })
-      .then((res) => res.ok ? res.json() : [])
+      .then((res) => {
+        if (!res.ok) throw new Error(`Recipients returned ${res.status}`);
+        return res.json();
+      })
       .then((data: RecipientListItem[]) => {
         if (Array.isArray(data) && data.length > 0) setRecipients(data);
+        setError(null);
       })
-      .catch(() => {});
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Recipients unavailable');
+      });
   }, []);
 
   const selectRecipient = useCallback(
@@ -47,5 +59,5 @@ export function useRecipients(onSelect: (profile: RecipientProfile) => void) {
     [recipients, onSelect],
   );
 
-  return { recipients, selectedId, selectRecipient };
+  return { recipients, selectedId, selectRecipient, error };
 }

--- a/dashboard/tests/independent-fetches.test.ts
+++ b/dashboard/tests/independent-fetches.test.ts
@@ -133,38 +133,46 @@ describe('Independent Dashboard Fetches (Issue #283)', () => {
     });
 
     it('should allow transaction fetch timeout without blocking agent info', async () => {
-      const timeouts = {
-        agentInfoTimeout: 100,
-        spendingTimeout: 150,
-        transactionsTimeout: 5000, // Much slower
-      };
+      // Use fake timers so the 5000ms "slow" fetch is advanced virtually rather
+      // than awaited for real. Awaiting a real 5000ms setTimeout under Vitest's
+      // default 5000ms per-test timeout made this test time out / flake (#1102).
+      vi.useFakeTimers();
+      try {
+        const timeouts = {
+          agentInfoTimeout: 100,
+          spendingTimeout: 150,
+          transactionsTimeout: 5000, // Much slower
+        };
 
-      const results: Record<string, string> = {};
+        const results: Record<string, string> = {};
 
-      // Simulate parallel fetches with different timeouts
-      const fetchAgentInfo = new Promise(resolve => {
-        setTimeout(() => {
-          results.agentInfo = 'loaded';
-          resolve('agentInfo');
-        }, timeouts.agentInfoTimeout);
-      });
+        // Simulate parallel fetches with different timeouts
+        void new Promise((resolve) => {
+          setTimeout(() => {
+            results.agentInfo = 'loaded';
+            resolve('agentInfo');
+          }, timeouts.agentInfoTimeout);
+        });
 
-      const fetchTransactions = new Promise(resolve => {
-        setTimeout(() => {
-          results.transactions = 'loaded';
-          resolve('transactions');
-        }, timeouts.transactionsTimeout);
-      });
+        void new Promise((resolve) => {
+          setTimeout(() => {
+            results.transactions = 'loaded';
+            resolve('transactions');
+          }, timeouts.transactionsTimeout);
+        });
 
-      // After 200ms, only agentInfo should be loaded
-      await new Promise(resolve => setTimeout(resolve, 200));
+        // After 200ms, only agentInfo should be loaded
+        await vi.advanceTimersByTimeAsync(200);
 
-      expect(results.agentInfo).toBe('loaded');
-      expect(results.transactions).toBeUndefined();
+        expect(results.agentInfo).toBe('loaded');
+        expect(results.transactions).toBeUndefined();
 
-      // Later, transactions will be loaded
-      await new Promise(resolve => setTimeout(resolve, 5000));
-      expect(results.transactions).toBe('loaded');
+        // Later, transactions will be loaded
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(results.transactions).toBe('loaded');
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
Resolves four dashboard issues, each scoped to its acceptance criteria.

## Changes
- **CI (#1092):** `dashboard-e2e.yml` gains a `unit` job that installs the root deps and runs the dashboard vitest config (`dashboard/vitest.config.ts`, which references `../tests/setup.ts` and the root's vitest / `@vitejs/plugin-react` / jsdom tooling). Fails the workflow on any unit-test failure; the existing `dashboard/**` path filter still applies. A comment in the workflow documents the gap.
- **Loading skeleton (#1111):** `loading.tsx` now derives its tab-bar placeholders from `DASHBOARD_TABS` instead of a second hardcoded array that omitted `Approvals` (7 vs 8), so the skeleton can't drift from the real nav.
- **Flaky test (#1102):** the `should allow transaction fetch timeout without blocking agent info` test used a real 5000ms `setTimeout` under Vitest's 5000ms default timeout. Converted to fake timers (`vi.useFakeTimers` + `advanceTimersByTimeAsync`), restored in a `finally` so no other test is slowed.
- **Recipients error state (#1112):** `useRecipients` now exposes an `error` state (per-source health pattern from #213) surfaced through `DashboardHeader`'s "Data issue" chip, instead of silently swallowing `/recipients` failures. New test covers the reject, non-ok, and success paths.

## Validation
- New/changed tests pass: `independent-fetches` (incl. the #1102 case, now ~0.16s instead of timing out), `useRecipients` (3 new), and `source-health` — 22/22.
- Verified the remaining pre-existing dashboard test failures are unchanged by this branch (fixes 1, adds 3, touches none of the others).

## Issues Resolved
Closes #1092
Closes #1111
Closes #1102
Closes #1112