### PR TITLE
fix: correct pending-scanner recipient scope, payment cap docs, and p…

### DIFF
--- a/agent/__tests__/pagination.test.ts
+++ b/agent/__tests__/pagination.test.ts
@@ -33,6 +33,14 @@ describe('Transaction Pagination', () => {
     expect(response.body.transactions.length).toBeLessThanOrEqual(10);
   });
 
+  it('should return zero transactions for an explicit limit=0 (issue #1073)', async () => {
+    const response = await auth(request(app).get('/agent/transactions?limit=0'))
+      .expect(200);
+
+    expect(response.body.pagination.limit).toBe(0);
+    expect(response.body.transactions).toEqual([]);
+  });
+
   it('should respect offset parameter', async () => {
     const response = await auth(request(app).get('/agent/transactions?limit=5&offset=10'))
       .expect(200);

--- a/agent/__tests__/pending-approvals.test.ts
+++ b/agent/__tests__/pending-approvals.test.ts
@@ -11,8 +11,10 @@ vi.mock('dotenv/config', () => ({}));
 vi.mock('fs', () => ({
   readFileSync: vi.fn().mockReturnValue('{}'),
   writeFileSync: vi.fn(),
+  appendFileSync: vi.fn(),
   existsSync: vi.fn().mockReturnValue(false),
   mkdirSync: vi.fn(),
+  readdirSync: vi.fn().mockReturnValue([{ name: 'rosa', isDirectory: () => true }]),
   renameSync: vi.fn(),
 }));
 vi.mock('@stellar/stellar-sdk', () => ({
@@ -29,6 +31,7 @@ vi.mock('@stellar/mpp/charge/client', () => ({ stellar: vi.fn().mockImplementati
 vi.mock('mppx/client', () => ({ Mppx: { create: vi.fn().mockReturnValue({ fetch: mockMppFetch }) } }));
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readdirSync } from 'fs';
 import {
   payForMedication,
   setSpendingPolicy,
@@ -37,6 +40,7 @@ import {
   approvePendingTransaction,
   processPendingTransactions,
   getSpendingTracker,
+  setCurrentRecipient,
 } from '../tools.ts';
 
 const DEFAULT_POLICY = {
@@ -49,8 +53,10 @@ const DEFAULT_POLICY = {
 
 beforeEach(() => {
   mockMppFetch.mockReset();
+  setCurrentRecipient('rosa');
   resetSpendingTracker();
   setSpendingPolicy({ ...DEFAULT_POLICY });
+  (readdirSync as any).mockReturnValue([{ name: 'rosa', isDirectory: () => true }]);
 });
 
 describe('Pending approvals flows', () => {
@@ -102,5 +108,40 @@ describe('Pending approvals flows', () => {
     const tracker = getSpendingTracker();
     const found = tracker.transactions.find((t: any) => t.id === tx.id);
     expect(found.status).toBe('completed');
+  });
+
+  it('auto-approves expired pending transactions for every recipient, not just the current one', async () => {
+    setSpendingPolicy({ ...DEFAULT_POLICY, holdTimeSeconds: 0 });
+    mockMppFetch.mockResolvedValueOnce({ json: async () => ({ success: true, order: { id: 'o-rosa' } }), headers: { get: () => null } });
+    const rRosa = await payForMedication('p1', 'Pharma', 'Drug', 80);
+    const txRosa = (rRosa as any).transaction;
+    expect(txRosa.status).toBe('pending');
+
+    setCurrentRecipient('jose');
+    setSpendingPolicy({ ...DEFAULT_POLICY, holdTimeSeconds: 0 });
+    mockMppFetch.mockResolvedValueOnce({ json: async () => ({ success: true, order: { id: 'o-jose' } }), headers: { get: () => null } });
+    const rJose = await payForMedication('p2', 'Pharma2', 'Drug2', 90);
+    const txJose = (rJose as any).transaction;
+    expect(txJose.status).toBe('pending');
+
+    (readdirSync as any).mockReturnValue([
+      { name: 'rosa', isDirectory: () => true },
+      { name: 'jose', isDirectory: () => true },
+    ]);
+
+    // The scanner must not depend on which recipient happens to be "current".
+    setCurrentRecipient('someone-else');
+
+    await processPendingTransactions();
+
+    setCurrentRecipient('rosa');
+    expect(
+      getSpendingTracker().transactions.find((t: any) => t.id === txRosa.id).status,
+    ).toBe('completed');
+
+    setCurrentRecipient('jose');
+    expect(
+      getSpendingTracker().transactions.find((t: any) => t.id === txJose.id).status,
+    ).toBe('completed');
   });
 });

--- a/agent/__tests__/tool-schema-validation.test.ts
+++ b/agent/__tests__/tool-schema-validation.test.ts
@@ -29,7 +29,7 @@ vi.mock("@stellar/stellar-sdk", () => ({
   },
 }));
 
-const { TOOL_DEFINITIONS, validateToolInput } = await import("../tools.ts");
+const { TOOL_DEFINITIONS, validateToolInput, MAX_PAYMENT } = await import("../tools.ts");
 
 describe("tool schema strictness", () => {
   it("sets additionalProperties:false on every object tool schema", () => {
@@ -56,6 +56,16 @@ describe("tool schema strictness", () => {
         unexpected: "ignored-before",
       }),
     ).toThrow(/unknown field\(s\) not allowed: unexpected/);
+  });
+
+  it("documents the same payment max in TOOL_DEFINITIONS as the enforced MAX_PAYMENT (issue #1074)", () => {
+    for (const name of ["pay_for_medication", "pay_bill"]) {
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === name)!;
+      expect(tool.description).toContain(`$0.01 and $${MAX_PAYMENT}`);
+      expect((tool.input_schema.properties as any).amount.description).toContain(
+        `max: ${MAX_PAYMENT}`,
+      );
+    }
   });
 });
 

--- a/agent/server.ts
+++ b/agent/server.ts
@@ -52,7 +52,7 @@ import { verifyWebhook } from "../shared/verify-webhook.ts";
 import { executeTool, runAgent, buildSystemPrompt } from "./runner.ts";
 import { requireApiKey } from "../shared/auth.ts";
 
-const PORT = parseInt(process.env.AGENT_PORT || "3004");
+const PORT = parseInt(process.env.AGENT_PORT || "3004", 10);
 
 if (!process.env.LLM_API_KEY) throw new Error("LLM_API_KEY required in .env");
 if (!process.env.AGENT_SECRET_KEY) throw new Error("AGENT_SECRET_KEY required in .env");

--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -28,7 +28,7 @@
 
 import 'dotenv/config';
 import { fileURLToPath } from 'url';
-import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, renameSync, promises as fsPromises } from 'fs';
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, readdirSync, renameSync, promises as fsPromises } from 'fs';
 import { z } from 'zod';
 import { logger } from '../shared/logger.ts';
 import { resolveStellarNetwork, validateSignerKeyForNetwork } from '../shared/stellar-network.ts';
@@ -145,7 +145,7 @@ if (STELLAR_CONFIG.networkType === 'public' && !process.env.USDC_ISSUER) {
 }
 
 const MIN_FEE_STROOPS = 100;
-const MAX_FEE_STROOPS = parseInt(process.env.MAX_FEE_STROOPS || '100000');
+const MAX_FEE_STROOPS = parseInt(process.env.MAX_FEE_STROOPS || '100000', 10);
 const STELLAR_TIMEBOUNDS_SECONDS = parseInt(process.env.STELLAR_TIMEBOUNDS_SECONDS || "60", 10);
 
 // Overall wall-clock budget for the fee-bump + retry path (issue #797):
@@ -991,7 +991,7 @@ function getSubmissionMutex(keypairId: string): AsyncMutex {
   return m;
 }
 
-const MAX_PAYMENT = 1000;
+export const MAX_PAYMENT = 1000;
 // Platform-level single-transaction cap (issue #83). Sits above the caregiver policy's
 // approvalThreshold so a compromised session cannot bypass it. Only changeable by redeploying.
 // Read on every call so tests can override process.env.MAX_SINGLE_TX_USDC between runs.
@@ -1964,19 +1964,38 @@ export function cancelPendingTransaction(txId: string): any {
   return { success: true, transaction: tx };
 }
 
-export async function processPendingTransactions() {
-  const tracker = spendingTracker;
-  const now = Date.now();
-  const pending = tracker.transactions.filter(
-    (t: any) =>
-      t.status === 'pending' &&
-      t.pendingUntil &&
-      new Date(t.pendingUntil).getTime() <= now,
-  );
-  for (const tx of pending) {
-    await approvePendingTransaction(tx.id);
+/** All recipient IDs with a persisted data directory on disk (Issue #1075). */
+function listRecipientIds(): string[] {
+  try {
+    return readdirSync(`${getDataDir()}/recipients`, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
   }
-  return { processed: pending.map((t: any) => t.id) };
+}
+
+export async function processPendingTransactions() {
+  const previousRecipientId = currentRecipientId;
+  const now = Date.now();
+  const processed: string[] = [];
+
+  for (const recipientId of listRecipientIds()) {
+    setCurrentRecipient(recipientId);
+    const pending = spendingTracker.transactions.filter(
+      (t: any) =>
+        t.status === 'pending' &&
+        t.pendingUntil &&
+        new Date(t.pendingUntil).getTime() <= now,
+    );
+    for (const tx of pending) {
+      await approvePendingTransaction(tx.id);
+      processed.push(tx.id);
+    }
+  }
+
+  setCurrentRecipient(previousRecipientId);
+  return { processed };
 }
 
 // --- Tool: Pay for medication via MPP Charge (real Stellar payment) ---
@@ -2694,14 +2713,14 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'pay_for_medication',
     description:
-      'Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits. Amount must be between $0.01 and $10,000. If the payment is blocked by spending policy, the result includes a budgetContext object { reason, attempted, dailyRemaining, monthlyRemaining, suggestion }: relay it to the caregiver so they can either approve a one-time override or pick a cheaper option within the remaining budget.',
+      `Pay a pharmacy for a medication order via MPP Charge on Stellar (real USDC payment). Subject to spending policy limits. Amount must be between $0.01 and $${MAX_PAYMENT}. If the payment is blocked by spending policy, the result includes a budgetContext object { reason, attempted, dailyRemaining, monthlyRemaining, suggestion }: relay it to the caregiver so they can either approve a one-time override or pick a cheaper option within the remaining budget.`,
     input_schema: strictInputSchema({
       type: 'object' as const,
       properties: {
         pharmacy_id: { type: 'string' },
         pharmacy_name: { type: 'string' },
         drug_name: { type: 'string' },
-        amount: { type: 'number', description: 'Payment amount in USD (min: 0.01, max: 10000)' },
+        amount: { type: 'number', description: `Payment amount in USD (min: 0.01, max: ${MAX_PAYMENT})` },
         days_supply: { type: 'number', description: 'Days supply for adherence tracking (default: 30)' },
         recipient_id: { type: 'string', description: 'Care recipient ID (default: rosa)' },
       },
@@ -2711,14 +2730,14 @@ export const TOOL_DEFINITIONS = [
   {
     name: 'pay_bill',
     description:
-      'Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount. Amount must be between $0.01 and $10,000.',
+      `Pay a medical bill via direct Stellar USDC transfer. Subject to spending policy limits. If the bill has been audited and errors found, pay only the corrected amount. Amount must be between $0.01 and $${MAX_PAYMENT}.`,
     input_schema: strictInputSchema({
       type: 'object' as const,
       properties: {
         provider_id: { type: 'string' },
         provider_name: { type: 'string' },
         description: { type: 'string' },
-        amount: { type: 'number', description: 'Payment amount in USD (min: 0.01, max: 10000)' },
+        amount: { type: 'number', description: `Payment amount in USD (min: 0.01, max: ${MAX_PAYMENT})` },
         recipient_id: { type: 'string', description: 'Care recipient ID (default: rosa)' },
       },
       required: ['provider_id', 'provider_name', 'description', 'amount'],

--- a/server.ts
+++ b/server.ts
@@ -914,12 +914,20 @@ app.get("/agent/spending", (_req, res) => {
   res.json(getSpendingSummary());
 });
 app.get("/agent/transactions", (req, res) => {
-  const limit = parseInt(req.query.limit as string) || 25;
-  const offset = parseInt(req.query.offset as string) || 0;
+  const parsedLimit = parseInt(req.query.limit as string, 10);
+  const limit = Number.isFinite(parsedLimit) ? parsedLimit : 25;
+  const parsedOffset = parseInt(req.query.offset as string, 10);
+  const offset = Number.isFinite(parsedOffset) ? parsedOffset : 0;
   const tracker = getSpendingTracker();
   const totalTransactions = tracker.transactions.length;
+  // Compute clamped indices explicitly rather than relying on slice()'s
+  // negative-index handling, which treats -0 (e.g. offset=0, limit=0) as
+  // literal index 0 instead of "end of array" and silently returns
+  // everything instead of nothing.
+  const end = Math.max(totalTransactions - offset, 0);
+  const start = Math.max(end - limit, 0);
   const paginatedTransactions = tracker.transactions
-    .slice(-offset - limit, -offset || undefined)
+    .slice(start, end)
     .reverse();
 
   res.json({

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -31,7 +31,7 @@ import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
 import { sanitizeUserString } from "../../shared/sanitize.ts";
 import { billAuditOversizedRejectionsTotal } from "../../shared/metrics.ts";
 
-const PORT = parseInt(process.env.BILL_AUDIT_API_PORT || "3002");
+const PORT = parseInt(process.env.BILL_AUDIT_API_PORT || "3002", 10);
 const PAY_TO = process.env.BILL_PROVIDER_PUBLIC_KEY;
 
 if (!PAY_TO) throw new Error("BILL_PROVIDER_PUBLIC_KEY required in .env");

--- a/services/drug-interaction-api/server.ts
+++ b/services/drug-interaction-api/server.ts
@@ -26,7 +26,7 @@ import {
 } from "./logic.ts";
 import type { DrugInteractionsQuery } from "./logic.ts";
 
-const PORT = parseInt(process.env.DRUG_INTERACTION_API_PORT || "3003");
+const PORT = parseInt(process.env.DRUG_INTERACTION_API_PORT || "3003", 10);
 const PAY_TO = process.env.PHARMACY_2_PUBLIC_KEY;
 
 if (!PAY_TO) throw new Error("PHARMACY_2_PUBLIC_KEY required in .env");

--- a/services/pharmacy-api/server.ts
+++ b/services/pharmacy-api/server.ts
@@ -41,7 +41,7 @@ import type {
   PharmacyRecordInput,
 } from "./logic.ts";
 
-const PORT = parseInt(process.env.PHARMACY_API_PORT || "3001");
+const PORT = parseInt(process.env.PHARMACY_API_PORT || "3001", 10);
 const PAY_TO = process.env.PHARMACY_1_PUBLIC_KEY;
 
 export interface PharmacyAppOptions {

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -28,7 +28,7 @@ import {
   type MedicationOrderInput,
 } from "./validation.ts";
 
-const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005");
+const PORT = parseInt(process.env.PHARMACY_PAYMENT_PORT || "3005", 10);
 const RECIPIENT = process.env.PHARMACY_1_PUBLIC_KEY;
 const MPP_SECRET_KEY = process.env.MPP_SECRET_KEY;
 const NETWORK = "stellar:testnet";

--- a/shared/__tests__/parseint-radix.test.ts
+++ b/shared/__tests__/parseint-radix.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+
+// Regression test for issue #1072: every parseInt() call across the backend
+// (agent/, shared/, services/, server.ts) must pass an explicit radix of 10,
+// so an unexpected env-var or query-string value like "0x64" is parsed
+// decimally instead of being silently reinterpreted as hex.
+describe('parseInt radix safety (issue #1072)', () => {
+  it('parses a hex-looking value decimally when radix 10 is passed explicitly', () => {
+    expect(parseInt('0x64', 10)).toBe(0);
+  });
+
+  it('would silently misinterpret the same value as hex without an explicit radix', () => {
+    expect(parseInt('0x64')).toBe(100);
+  });
+
+  it('parses ordinary decimal values identically with or without the radix', () => {
+    expect(parseInt('3004', 10)).toBe(3004);
+  });
+});


### PR DESCRIPTION
  ## Summary

  Fixes four correctness bugs in the agent payment/transaction backend:

  - **Multi-recipient pending-transaction scanner** — `processPendingTransactions`
    only ever scanned the single in-memory "current" recipient, so any other
    recipient's expired holds were never auto-approved.
  - **Stale payment-cap documentation** — `pay_for_medication`/`pay_bill` tool
    descriptions told the LLM the max was $10,000 while the enforced
    `MAX_PAYMENT` was $1,000, an incorrect contract that could lead the agent
    to attempt payments it knew would always be rejected.
  - **`limit=0` silently ignored** — `GET /agent/transactions` used a falsy-OR
    default (`|| 25`), so an explicit `?limit=0` returned 25 transactions
    instead of zero. Fixing the parse also surfaced a related pagination bug:
    the slice math treated `offset=0`/`limit=0` as `-0`, which `Array#slice`
    reads as "start of array" instead of "end of array", returning every
    transaction instead of none.
  - **Missing `parseInt` radix** — call sites across `agent/`, `services/`,
    and `server.ts` omitted the radix argument, risking octal/hex
    misinterpretation of unexpected env-var input (e.g. `"0x64"`).

  ## Changes

  - `agent/tools.ts`
    - `processPendingTransactions` now iterates every recipient directory
      under `data/recipients/`, switching context per recipient before
      scanning for expired holds, and restores the caller's original
      "current" recipient when done. Per-transaction approval logic
      (`approvePendingTransaction`) is untouched.
    - `pay_for_medication`/`pay_bill` `TOOL_DEFINITIONS` descriptions now
      interpolate the real `MAX_PAYMENT` constant instead of a hardcoded
      `$10,000`; `MAX_PAYMENT` is exported so this can't drift again.
    - `MAX_FEE_STROOPS` parse now passes radix 10.
  - `server.ts`
    - `GET /agent/transactions` distinguishes an explicit `0` from an
      unspecified/invalid `limit`/`offset` via `Number.isFinite`, with an
      explicit radix on both `parseInt` calls.
    - Pagination slice bounds are computed explicitly with clamped
      `Math.max(...)` instead of relying on `slice()`'s negative-index
      handling.
  - `agent/server.ts`, `services/{pharmacy-api,pharmacy-payment,bill-audit-api,drug-interaction-api}/server.ts`
    - `PORT` parsing now passes an explicit radix of 10.
  - Tests:
    - `agent/__tests__/pending-approvals.test.ts` — new test confirms two
      different recipients, each holding an expired pending transaction, are
      both auto-approved within a single scan cycle, even though neither is
      the "current" recipient at scan time.
    - `agent/__tests__/tool-schema-validation.test.ts` — new test asserts the
      TOOL_DEFINITIONS-documented max for both payment tools matches
      `MAX_PAYMENT` exactly.
    - `agent/__tests__/pagination.test.ts` — new test asserts `?limit=0`
      returns zero transactions with correct pagination metadata.
    - `shared/__tests__/parseint-radix.test.ts` — new test documents that a
      hex-looking value (`"0x64"`) parses decimally with an explicit radix
      instead of being silently reinterpreted as hex.

  ## Test plan

  - [x] `agent/__tests__/pending-approvals.test.ts` — multi-recipient
        auto-approval scenario passes
  - [x] `agent/__tests__/tool-schema-validation.test.ts` — tool-doc/cap
        consistency check passes
  - [x] `agent/__tests__/pagination.test.ts` — `limit=0` regression test
        passes
  - [x] `shared/__tests__/parseint-radix.test.ts` — radix regression test
        passes
  - [x] `tsc --noEmit` — no new type errors
  - [x] Full backend suite (`agent/`, `shared/`, `services/`, `scripts/`,
        `tests/`) run before/after this change — no new failures; 3
        previously-broken tests in `pending-approvals.test.ts` incidentally
        fixed (missing `appendFileSync` in the test's `fs` mock)

  Closes #1072
  Closes #1073
  Closes #1074
  Closes #1075
