### PR TITLE
fix #1076: push tool call cap reached event

### DIFF
--- a/agent/__tests__/tool-call-cap.test.ts
+++ b/agent/__tests__/tool-call-cap.test.ts
@@ -114,6 +114,7 @@ describe("tool call cap", () => {
     expect(res.status).toBe(200);
     expect(res.body.truncated).toBe(true);
     expect(res.body.toolCalls.length).toBe(3);
+    expect(res.body.events).toContainEqual({ kind: "tool_call_cap_reached" });
   });
 
   it("does not truncate when under cap", async () => {

--- a/agent/runner.ts
+++ b/agent/runner.ts
@@ -402,6 +402,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
 
     if (runToolCalls + message.tool_calls.length > maxToolCallsPerRun) {
       truncated = true;
+      events.push({ kind: "tool_call_cap_reached" });
       appendAuditEntry({
         event: "agent.tool_cap_exceeded",
         actor: "agent",


### PR DESCRIPTION
Closes #1076 

This PR pushes a `{ kind: "tool_call_cap_reached" }` event into the agent run's `events` list immediately before terminating the execution loop on tool-cap boundary breaches. This guarantees symmetry between iteration-limit and tool-cap truncations. Additionally, the unit test verifying boundary enforcement has been updated to assert that this event is correctly populated.

## What changed
*   **[runner.ts](file:///Users/favoureze/careguard/agent/runner.ts)**: Added `events.push({ kind: "tool_call_cap_reached" })` block inside the tool call cap condition checks to resolve #1076.
*   **[tool-call-cap.test.ts](file:///Users/favoureze/careguard/agent/__tests__/tool-call-cap.test.ts)**: Added assertions expecting `{ kind: "tool_call_cap_reached" }` event in responses when the agent execution exceeds the per-run tool call cap.
