### PR TITLE
fix(config): fix #1474 resolve dangling tsconfig todo comments

### DIFF
--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  // TODO: consider enabling noUncheckedIndexedAccess and noImplicitOverride in future ADR
+  // noUncheckedIndexedAccess / noImplicitOverride: deferred, see docs/adr/005-strict-type-checking-flags.md
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/docs/adr/005-strict-type-checking-flags.md
+++ b/docs/adr/005-strict-type-checking-flags.md
@@ -1,0 +1,44 @@
+# ADR-005: Deferred Adoption of `noUncheckedIndexedAccess` and `noImplicitOverride`
+
+- **Status:** Proposed
+- **Date:** 2026-08-27
+
+## Context
+
+Both `tsconfig.json` and `dashboard/tsconfig.json` already set `"strict": true`. A comment on line 2 of each file additionally flagged two compiler options that are **not** part of the `strict` umbrella and must be opted into individually:
+
+- **`noUncheckedIndexedAccess`** (TypeScript 4.1+) — adds `undefined` to the result type of any index-signature access (e.g. `record[key]`, `array[i]`), forcing an explicit check before use instead of assuming the value is present.
+- **`noImplicitOverride`** (TypeScript 4.3+) — requires the `override` keyword on any subclass member that overrides a base class member, so a base class rename or removal surfaces as a compile error instead of silently detaching the override.
+
+The comment read `// TODO: consider enabling noUncheckedIndexedAccess and noImplicitOverride in future ADR`, with no link to an actual decision record, since 2026-06-27 (root) / 2026-06-28 (dashboard). It never resolved into a decision (issue #1474).
+
+## Decision
+
+**Defer enabling both flags for now.** Neither flag changes runtime behavior, but each is a non-trivial adoption:
+
+- `noUncheckedIndexedAccess` turns every existing indexed access without a prior narrowing check into a new compile error. This codebase uses index/bracket access in multiple places (e.g. dictionary-style lookups in `shared/`, `agent/tools.ts`, and dashboard components) that would need per-call-site review, not a blanket suppression.
+- `noImplicitOverride` requires auditing every subclass method across the codebase and adding `override` where it's a genuine override, which is comparatively lower-risk but still a distinct, reviewable change on its own.
+
+Bundling either flag into an unrelated change would obscure the diff and make review harder. This ADR formally records the option, its rationale, and what enabling it would require, so it can be picked up as dedicated, reviewable work instead of remaining an unlinked comment.
+
+This decision does not change either `tsconfig.json`'s `compilerOptions`.
+
+### Related tracked work
+
+Issue #573 ("Enable `noUncheckedIndexedAccess` in dashboard tsconfig") already tracks the `noUncheckedIndexedAccess` half of this decision specifically for `dashboard/tsconfig.json`, naming concrete unguarded call sites (`DASHBOARD_TABS[newIndex]` in `dashboard-tabs-nav.tsx`, `lineItems[virtualItem.index]` in the bill-line-items virtualizer). That issue remains the actionable ticket for enabling the flag in the dashboard project. This ADR additionally covers the root `tsconfig.json` (not in scope of #573) and `noImplicitOverride` for both projects (not in scope of #573 either), neither of which currently has a tracked issue of its own.
+
+## Consequences
+
+### Positive
+- Replaces an unlinked TODO with a discoverable, permanent decision record (this repo's established pattern per `docs/adr/README.md`).
+- Anyone picking up the flag later has the rationale and scope already written down, instead of having to reconstruct it.
+
+### Negative
+- The type-safety benefits of both flags (catching out-of-bounds/dictionary access and detached overrides) remain unrealized until each is separately adopted.
+
+### Neutral
+- Enabling either flag is future work, not scoped here. Each should land as its own change: enable the flag, run `tsc --noEmit` in the affected project, and fix every resulting error at its call site (not via a blanket type assertion).
+
+## Compliance
+
+Not applicable — this ADR records a deferral, not an enforced rule. When either flag is later enabled, compliance is `tsc --noEmit` passing cleanly in the affected `tsconfig.json`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ This directory contains records of key architectural decisions made in the CareG
 | **001** | [001-pharmacy-zip.md](001-pharmacy-zip.md) — Zip Code-Aware Pharmacy Pricing Model | Accepted | 2026-06-25 |
 | **002** | [002-pii-in-persistence.md](002-pii-in-persistence.md) — PII-Sensitive Data in Local Persistence | Accepted | 2026-06-29 |
 | **004** | [004-pharmacy-pricing-source.md](004-pharmacy-pricing-source.md) — Pharmacy Pricing Source Integration | Accepted | 2026-07-10 |
+| **005** | [005-strict-type-checking-flags.md](005-strict-type-checking-flags.md) — Deferred Adoption of noUncheckedIndexedAccess and noImplicitOverride | Proposed | 2026-08-27 |
 | **006** | [006-typescript-runtime.md](006-typescript-runtime.md) — TypeScript Runtime Strategy | Accepted | 2026-07-22 |
 | **008** | [008-audit-log-hash-chain.md](008-audit-log-hash-chain.md) — Append-Only Hash-Chained Audit Log Design | Accepted | 2026-07-27 |
 | **—**   | [unified-vs-split-server.md](unified-vs-split-server.md) — Unified vs Split Server Architecture | Accepted | 2026-07-15 |
@@ -58,7 +59,7 @@ Every ADR has one of the following statuses:
 | 002 | [PII in Persistence and Audit](002-pii-in-persistence.md) | Accepted |
 | 003 | [Unified vs. Split Server](unified-vs-split-server.md) | Accepted |
 | 004 | [Pharmacy Pricing Source](004-pharmacy-pricing-source.md) | Accepted |
-| 005 | *(vacant — reserved)* | — |
+| 005 | [Deferred Adoption of noUncheckedIndexedAccess and noImplicitOverride](005-strict-type-checking-flags.md) | Proposed |
 | 006 | [TypeScript Runtime Strategy](006-typescript-runtime.md) | Accepted |
 
 > **Note:** ADR 003 was originally documented as `unified-vs-split-server.md`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  // TODO: consider enabling noUncheckedIndexedAccess and noImplicitOverride in future ADR
+  // noUncheckedIndexedAccess / noImplicitOverride: deferred, see docs/adr/005-strict-type-checking-flags.md
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",


### PR DESCRIPTION
### Problem

Closes #1474.

`tsconfig.json:2` and `dashboard/tsconfig.json:2` carried an identical comment —
`// TODO: consider enabling noUncheckedIndexedAccess and noImplicitOverride in future ADR` —
with no link to an actual ADR or tracking issue. It had sat unaddressed since the commits that
introduced it (`adc5fda`, `12d627f`), giving no pointer for anyone to follow up on and no record
of why the flags weren't already on.

Tracing where the "future ADR" was actually supposed to live (rather than inventing a new
location) turned up `docs/adr/README.md`'s own index, which already reserved **ADR-005** as a
vacant slot between ADR-004 (accepted 2026-07-10) and ADR-006 (accepted 2026-07-22) — exactly
where a decision about these two `compilerOptions` flags belongs. The TODO was never turned into
that ADR.

A repo-wide search before finalizing this also surfaced **issue #573** ("Enable
`noUncheckedIndexedAccess` in dashboard tsconfig"), an existing, still-open, untouched issue
scoped specifically to the `noUncheckedIndexedAccess` half of `dashboard/tsconfig.json`, naming
concrete unguarded call sites (`DASHBOARD_TABS[newIndex]` in `dashboard-tabs-nav.tsx`,
`lineItems[virtualItem.index]` in the bill-line-items virtualizer). That issue is not superseded
by this PR — it remains the actionable ticket for actually enabling that one flag on that one
file. This PR's scope is narrower and different: resolve the *dangling comment*, not enable the
flags.

### What changed and how the flow works now

Both `tsconfig.json:2` and `dashboard/tsconfig.json:2` (#1474) now read:

```jsonc
// noUncheckedIndexedAccess / noImplicitOverride: deferred, see docs/adr/005-strict-type-checking-flags.md
```

That path resolves to a real, indexed file — `docs/adr/005-strict-type-checking-flags.md` (#1474)
— which fills the previously-reserved ADR-005 slot. It documents, with each flag's TypeScript
version and exact runtime effect (verified against the official TypeScript `tsconfig` reference
and the TS 4.1 / 4.3 release notes, since neither flag is part of the `strict` umbrella both
projects already enable):

- `noUncheckedIndexedAccess` (TS 4.1+) — adds `undefined` to the result type of any index-signature
  access (e.g. `record[key]`, `array[i]`), forcing an explicit check instead of assuming presence.
- `noImplicitOverride` (TS 4.3+) — requires the `override` keyword on any subclass member that
  overrides a base class member, so a base class rename/removal surfaces as a compile error
  instead of silently detaching the override.

The ADR's decision is to **defer enabling both flags**, because each is a distinct, reviewable
migration (auditing existing indexed-access call sites for the first, auditing class hierarchies
for the second) that shouldn't be bundled into a comment cleanup. A "Related tracked work" section
in the ADR cross-references #573 explicitly, so the ADR and the issue tracker don't silently
diverge — #573 tracks the actionable dashboard-side sub-piece; the ADR additionally covers root
`tsconfig.json` and `noImplicitOverride` for both projects, neither of which has its own tracked
issue yet.

`docs/adr/README.md` (#1474) is updated in both of its index tables to register ADR-005 — it
previously listed the slot as `*(vacant — reserved)*`.

### Why this matters

A TODO with no link is a dead end: it tells a reader something was deferred but gives them nothing
to act on or verify against. Now, following the comment leads to an actual decision record with
real rationale, version-accurate flag semantics, and a cross-reference to the one piece of this
that's already independently tracked — instead of a comment that could sit unresolved indefinitely
with no way to tell if it was ever revisited.

## Changed

- `tsconfig.json` (#1474) — line 2 only: dangling TODO replaced with a reference to
  `docs/adr/005-strict-type-checking-flags.md`. No `compilerOptions` changed.
- `dashboard/tsconfig.json` (#1474) — identical line-2-only replacement. No `compilerOptions`
  changed.
- `docs/adr/005-strict-type-checking-flags.md` (#1474) — new. Fills the previously-reserved
  ADR-005 slot; documents both flags and defers enabling them; cross-references issue #573.
- `docs/adr/README.md` (#1474) — both index tables updated to register ADR-005 in place of the
  `*(vacant — reserved)*` placeholder.

## Testing

```bash
git diff tsconfig.json dashboard/tsconfig.json
npx tsc --noEmit -p tsconfig.json
cd dashboard && npx tsc --noEmit -p tsconfig.json
```

- Both tsconfig files: comment-line-only diff confirmed via `git diff` — zero `compilerOptions`
  changes.
- Both tsconfig files: parse successfully as valid JSON once comments/trailing commas are
  stripped, confirming valid JSONC syntax.
- Root `tsconfig.json`: `tsc --noEmit` output compared byte-for-byte before/after (via `git
  stash`) — identical, pre-existing unrelated errors only, zero new errors.
- `dashboard/tsconfig.json`: `tsc --noEmit` output compared the same way — byte-identical
  before/after, zero new errors.

## Scope Notes

- Config/docs-only change: touches `tsconfig.json`, `dashboard/tsconfig.json`, and `docs/adr/`.
  No source files, no `compilerOptions` values, no frontend or backend logic touched.
- Does not enable `noUncheckedIndexedAccess` or `noImplicitOverride` — explicitly out of scope
  per #1474's own acceptance criteria ("No changes to actual compilerOptions values") and is
  deferred work, tracked separately (#573 for the dashboard `noUncheckedIndexedAccess` piece; no
  issue yet for root `tsconfig.json` or for `noImplicitOverride` on either project).
- `implementation.md`, `CODEBASE_INDEX.md`, `.cursor/`, and `PR_NOTES.md` are intentionally
  excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)