### PR TITLE
fix(docs): fix #1473 use npm consistently in readme test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,16 +190,17 @@ hosting setup, CI validation, and how the x402 `X-PAYMENT` auth scheme works.
 
 ```bash
 # Install dependencies (if not already done)
-pnpm install
+npm install --legacy-peer-deps
+cd dashboard && npm install --legacy-peer-deps && cd ..
 
 # Run all tests (root backend + dashboard)
-pnpm test
+npm run test:all
 
 # Watch mode
-pnpm test:watch
+npm run test:watch
 
 # Run tests with coverage
-pnpm test -- --coverage
+npm test -- --coverage
 ```
 
 Tests are organized in two workspaces:


### PR DESCRIPTION
### Problem

Closes #1473.

`README.md`'s Quick Start section instructed `npm install --legacy-peer-deps`, `npm run setup`,
and `npm run dev` for getting the project running, while its Running Tests section a few lines
later instructed `pnpm install` and `pnpm test` for the same repository. A new contributor
following the doc top-to-bottom would install dependencies twice, with two different package
managers, for no reason grounded in how the project actually works.

Rather than pick a package manager by guesswork, this traced the repo's actual signals before
deciding: `.npmrc` sets `legacy-peer-deps=true` (an npm-specific key), `package-lock.json` is
actively maintained in both `package.json` and `dashboard/package.json`, and — most decisively —
`pnpm-workspace.yaml` contains only an `allowBuilds` block with no `packages:` field, meaning this
isn't a real pnpm monorepo; a bare `pnpm install`/`pnpm test` at the root was never actually
managing the dashboard as a linked workspace member. `.github/workflows/ci.yml` — the one place
that has to actually work, unconditionally — runs `npm ci --legacy-peer-deps` (root), a separate
`npm ci` (dashboard), and `npm run test:all`. **npm is unambiguously the project's real package
manager**; pnpm's presence in the repo is vestigial.

### What changed and how the flow works now

`README.md`'s "Running Tests" section (#1473) — the only place in the entire file that used
`pnpm`, confirmed by grepping the whole file before and after — now reads:

```bash
# Install dependencies (if not already done)
npm install --legacy-peer-deps
cd dashboard && npm install --legacy-peer-deps && cd ..

# Run all tests (root backend + dashboard)
npm run test:all

# Watch mode
npm run test:watch

# Run tests with coverage
npm test -- --coverage
```

Two decisions worth explaining:

1. **The separate `cd dashboard && npm install` line is new** — it wasn't part of the original
   single `pnpm install` line. It's there because it's empirically required: `dashboard/node_modules`
   was confirmed missing even after the root-level install had already run, so without this line
   the very next command (claiming to test "root backend + dashboard") would fail for a fresh
   clone. It also mirrors the two-step install pattern `QUICKSTART.md` and CI already use.
2. **`npm run test:all`, not plain `npm test`, for the "run all tests" line** — `vitest.workspace.ts`
   itself carries a code comment naming `npm run test:all` as the intended invocation. (Empirically,
   Vitest auto-detects the root `vitest.workspace.ts` regardless of invocation — confirmed against
   Vitest's own documentation — so `npm test` would technically do the same thing today, but
   `test:all` is the self-documenting, maintainer-named command and was kept for that reason.)

`QUICKSTART.md` (#1473) was checked per the issue's second acceptance criterion and found already
100% npm-consistent — zero `pnpm` mentions anywhere in the file. No change was needed there.

### Why this matters

A setup doc that silently switches package managers mid-read either wastes a new contributor's
time (two installs, two lockfile ecosystems touching the same `node_modules`) or, worse, points
them at a command (`pnpm test`) that doesn't actually do what its own comment claims, since pnpm
was never wired into this repo as a real workspace. Now every documented command in `README.md`
uses the package manager this project actually runs on — the same one CI already uses — end to
end.

## Changed

- `README.md` (#1473) — Running Tests section: `pnpm install` / `pnpm test` / `pnpm test:watch` /
  `pnpm test -- --coverage` replaced with `npm install --legacy-peer-deps` (root + dashboard) /
  `npm run test:all` / `npm run test:watch` / `npm test -- --coverage`. This was the only `pnpm`
  usage anywhere in the file.
- `QUICKSTART.md` (#1473) — checked, no changes needed; already fully npm-consistent.

## Testing

```bash
grep -n "pnpm" README.md
grep -n "pnpm" QUICKSTART.md
npm install --legacy-peer-deps
cd dashboard && npm install --legacy-peer-deps
npm run test:all
npm run test:watch
npm test -- --coverage shared/__tests__/redact.test.ts
```

- `grep -n "pnpm" README.md` → no matches (was 4 matches before this fix).
- `grep -n "pnpm" QUICKSTART.md` → no matches (unchanged, was already 0).
- `npm install --legacy-peer-deps` (root): succeeded.
- `npm install --legacy-peer-deps` (dashboard): succeeded, 745 packages — confirmed necessary,
  since `dashboard/node_modules` was missing even after the root install alone.
- `npm run test:all`: executed both projects — dashboard test files appeared in the run output
  prefixed `|dashboard|` (e.g. `|dashboard| src/__tests__/overview-tab.test.tsx`), confirming real
  cross-workspace execution, not just root-only.
- `npm run test:watch`: starts correctly (verified with a bounded timeout; watch mode itself runs
  indefinitely by design).
- `npm test -- --coverage`: verified against a fast single test file — real coverage report
  generated (`@vitest/coverage-v8` is present as a devDependency).
- Test *failures* observed during verification (missing `LLM_API_KEY`, `OZ_FACILITATOR_API_KEY`,
  `NEXT_PUBLIC_API_URL`, unfunded testnet wallets) are pre-existing environment/secrets gaps, not
  something this doc-only change introduces — identical in nature to what the old `pnpm` commands
  would have hit.
- Cross-checked the `.github/workflows/ci.yml` command sequence directly: it already runs
  `npm ci --legacy-peer-deps` (root), a separate `npm ci` (dashboard), and `npm run test:all` —
  the strongest available confirmation that the commands now documented are the actually-correct,
  already-proven-working ones.

## Scope Notes

- Documentation-only change: touches `README.md` only. `QUICKSTART.md` was checked but needed no
  edits.
- No `package.json`, `dashboard/package.json`, or `.github/workflows/ci.yml` changes — verified via
  `git diff --stat` against each, confirming zero modifications, satisfying the issue's "no
  functional change to CI or package.json scripts" requirement.
- No frontend or backend logic touched.
- Found, but intentionally **not** touched (outside #1473's named scope of `README.md` and
  `QUICKSTART.md`): `dashboard/README.md` lists `pnpm` as a Prerequisite while its own Local Setup
  steps use `npm install`/`npm run dev` — the same class of inconsistency. `docs/load-testing.md`,
  `docs/INDEPENDENT_FETCHES.md`, and `docs/agent/llm-config.md` also reference `pnpm` commands.
  Flagging these as a related follow-up rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)