### PR TITLE
fix(scripts): fix #1471 remove redundant root lint script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,5 @@ jobs:
       - name: Typecheck dashboard
         run: cd dashboard && npx tsc --noEmit
 
-      - name: Lint
-        run: npm run lint
-
       - name: Run tests
         run: npm run test:all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,8 @@ ADR index.
 
 ## Code Style
 
-- TypeScript strict mode — no `any` without justification
-- ESLint + Prettier (run `npm run lint` before pushing)
+- TypeScript strict mode — no `any` without justification (run `npm run typecheck` before pushing)
+- Dashboard additionally runs ESLint (`cd dashboard && npm run lint`)
 - Keep services self-contained; shared code goes in `shared/`
 
 ## API Changes

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dev": "node --import tsx server.ts",
     "typecheck": "tsc -b",
     "build": "tsc -p tsconfig.build.json",
-    "lint": "tsc --noEmit",
     "gen-openapi": "node --import tsx scripts/gen-openapi.ts",
     "validate:openapi": "node --import tsx scripts/validate-openapi.ts",
     "test": "vitest run",


### PR DESCRIPTION
### Problem

Closes #1471.

Root `package.json` defined both `"typecheck": "tsc -b"` and `"lint": "tsc --noEmit"` — the same
underlying tool (`tsc`) under two different script names, with no ESLint invocation anywhere at
the root. The `'lint'` name implied a linter was running when it was actually just a second
type-check.

Rather than pick "remove," "rename," or "wire to a real linter" by guesswork, this traced every
actual caller of `npm run lint` across the repo before deciding. `.github/workflows/ci.yml`
line 36 called `npm run lint` (no `working-directory` override, so it resolved to root's
`package.json`), but the **same workflow, two steps earlier**, already ran `npx tsc --noEmit` —
textually the identical command, on the identical project. CI was running `tsc --noEmit` on root
**twice** under two different step names; the "Lint" step contributed zero additional coverage.
Separately, `.github/workflows/dashboard-e2e.yml` also calls `npm run lint`, but that job sets
`working-directory: dashboard`, so it resolves to `dashboard/package.json`'s own
`"lint": "eslint"` — a real, correctly-named ESLint invocation (`dashboard/eslint.config.mjs`
exists) that is entirely unrelated to this issue and was left untouched.

`CONTRIBUTING.md` also claimed `npm run lint` runs "ESLint + Prettier" — already false before this
fix (no ESLint or Prettier dependency exists at root; Prettier doesn't exist anywhere in the repo).
Removing the script would have turned this into an outright broken command reference for anyone
following the contributing guide, so it's corrected as part of this fix.

Also verified empirically (and confirmed against the official TypeScript project-references docs)
that `"typecheck": "tsc -b"` and the removed `"lint": "tsc --noEmit"` were never truly
interchangeable: build mode (`-b`) writes a `.tsbuildinfo` cache file to disk as a side effect,
while `--noEmit` has none. This is exactly why CI's real typecheck steps use raw
`npx tsc --noEmit` rather than `npm run typecheck` by name — and why this fix does not touch those
steps or try to make CI call `npm run typecheck`, which would add a new disk side effect to CI runs
and violate the issue's "no net change in what actually gets checked" requirement.

### What changed and how the flow works now

Root `package.json` (#1471) now has exactly one, unambiguously-named type-checking script:
`"typecheck": "tsc -b"`. The `"lint"` entry is gone.

`.github/workflows/ci.yml` (#1471) had its redundant "Lint" step removed. The workflow's actual
type-checking coverage is **unchanged** — "Typecheck root" (`npx tsc --noEmit`) and "Typecheck
dashboard" (`cd dashboard && npx tsc --noEmit`) still run exactly as before; only the duplicate
third run of the same root command, previously labeled "Lint," is gone.

`CONTRIBUTING.md` (#1471) now accurately says: TypeScript strict mode is enforced via
`npm run typecheck` (root, run before pushing), and the dashboard separately runs its own real
ESLint via `cd dashboard && npm run lint` — replacing the previous, already-inaccurate "ESLint +
Prettier (run `npm run lint`)" line, which would have become a broken command reference once the
root script was removed.

### Why this matters

A script named `'lint'` that's actually just a duplicate type-check is actively misleading — a
contributor or reviewer reading `package.json` or CI logs would reasonably assume real linting is
happening at the root when it isn't, and would have no idea a "Lint" failure in CI is identical
information to a "Typecheck root" failure two steps above it. Removing the duplicate makes
`package.json`'s script list and CI's step list both honestly reflect what's actually checked, with
zero loss of coverage.

## Changed

- `package.json` (#1471) — removed `"lint": "tsc --noEmit"`. `"typecheck": "tsc -b"` remains as
  the single, accurately-named type-checking script.
- `.github/workflows/ci.yml` (#1471) — removed the "Lint" step (`npm run lint`), which was
  running the textually identical command as the unmodified "Typecheck root" step two lines
  above it. No other step touched.
- `CONTRIBUTING.md` (#1471) — corrected the stale "ESLint + Prettier (run `npm run lint`)" claim,
  which named the exact script this fix removes, to reference `npm run typecheck` (root) and the
  dashboard's separate, real `npm run lint` (ESLint).

## Testing

```bash
npm run lint
npx tsc --noEmit
(cd dashboard && npx tsc --noEmit)
grep -rn "npm run lint" --include="*.md" --include="*.yml" --include="*.yaml" --include="*.json" .
```

- `npm run lint` → `npm error Missing script: "lint"` — confirms clean removal.
- `npx tsc --noEmit` (root) and `cd dashboard && npx tsc --noEmit` (dashboard) — both still run
  exactly as before; their command text in `ci.yml` was not modified by this change.
- Repo-wide grep for `npm run lint` after the fix found only two remaining references, both
  correct and unrelated to the removed script: `CONTRIBUTING.md` (this fix's own corrected,
  dashboard-scoped mention) and `.github/workflows/dashboard-e2e.yml` (pre-existing, real,
  dashboard-scoped ESLint call — unaffected, since it resolves via that job's
  `working-directory: dashboard` to `dashboard/package.json`, not root).
- `package.json` validated as parseable JSON after the edit.
- Cross-checked the `tsc -b` vs `tsc --noEmit` behavioral difference against the official
  TypeScript project-references documentation: build mode (`-b`) "effectively acts as if
  `noEmitOnError` is enabled" and writes a `.tsbuildinfo` cache file even when it doesn't emit
  `.js`/`.d.ts` output — confirming the two scripts were never truly interchangeable, and
  confirming why CI's real typecheck steps intentionally use raw `npx tsc --noEmit` rather than
  `npm run typecheck`.

## Scope Notes

- Config/CI/docs-only change: touches `package.json`, `.github/workflows/ci.yml`, and
  `CONTRIBUTING.md`. No source files, no `compilerOptions` values, no frontend or backend logic
  touched.
- CI's actual type-checking coverage is provably unchanged — the only step removed was a verified,
  textual duplicate of an adjacent, untouched step.
- `.github/workflows/dashboard-e2e.yml` was intentionally **not** touched — its `npm run lint` is
  a real, dashboard-scoped ESLint call, unrelated to the root's misleading script this issue
  targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)