### PR TITLE
fix(shutdown): fix #1070 extract shared graceful-shutdown helper

### DIFF
--- a/agent/server.ts
+++ b/agent/server.ts
@@ -23,6 +23,7 @@ import { rateLimiters } from "../shared/rate-limit.ts";
 import { agentQueue } from "../shared/agent-queue.ts";
 import { requestContextMiddleware } from "../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../shared/request-logger.ts";
+import { gracefulShutdown } from "../shared/graceful-shutdown.ts";
 import {
   metricsHandler,
   agentRunsTotal,
@@ -656,15 +657,4 @@ const server = app.listen(PORT, async () => {
   await verifyWallet();
 });
 
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM received. Draining server...");
-  isDraining = true;
-  server.close(() => {
-    logger.info("Server closed. Exiting process.");
-    process.exit(0);
-  });
-  setTimeout(() => {
-    logger.error("Graceful shutdown timeout. Forcing exit.");
-    process.exit(1);
-  }, 30000);
-});
+gracefulShutdown({ server, onDrainStart: () => { isDraining = true; } });

--- a/server.ts
+++ b/server.ts
@@ -44,6 +44,7 @@ import { initSentry } from "./shared/sentry.ts";
 // Observability
 import { requestContextMiddleware } from "./shared/request-context.ts";
 import { requestLoggerMiddleware } from "./shared/request-logger.ts";
+import { gracefulShutdown } from "./shared/graceful-shutdown.ts";
 import {
   metricsHandler,
   agentRunsTotal,
@@ -1084,16 +1085,5 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     await startWalletBalanceScheduler();
   });
 
-  process.on("SIGTERM", () => {
-    logger.info("SIGTERM received. Draining server...");
-    isDraining = true;
-    server.close(() => {
-      logger.info("Server closed. Exiting process.");
-      process.exit(0);
-    });
-    setTimeout(() => {
-      logger.error("Graceful shutdown timeout. Forcing exit.");
-      process.exit(1);
-    }, 30000);
-  });
+  gracefulShutdown({ server, onDrainStart: () => { isDraining = true; } });
 }

--- a/services/drug-interaction-api/server.ts
+++ b/services/drug-interaction-api/server.ts
@@ -20,6 +20,7 @@ import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
+import { gracefulShutdown } from "../../shared/graceful-shutdown.ts";
 import {
   checkInteractions,
   DrugInteractionsQuerySchema,
@@ -91,15 +92,4 @@ export const server = app.listen(PORT, () => {
   logger.info({ port: PORT, network: NETWORK, facilitator: OZ_FACILITATOR_URL, payTo: PAY_TO }, "Drug Interaction API started");
 });
 
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM received. Draining server...");
-  isDraining = true;
-  server.close(() => {
-    logger.info("Server closed. Exiting process.");
-    process.exit(0);
-  });
-  setTimeout(() => {
-    logger.error("Graceful shutdown timeout. Forcing exit.");
-    process.exit(1);
-  }, 30000);
-});
+gracefulShutdown({ server, onDrainStart: () => { isDraining = true; } });

--- a/services/pharmacy-payment/server.ts
+++ b/services/pharmacy-payment/server.ts
@@ -22,6 +22,7 @@ import { applySecurityMiddleware } from "../../shared/security-middleware.ts";
 import { logger } from "../../shared/logger.ts";
 import { requestContextMiddleware } from "../../shared/request-context.ts";
 import { requestLoggerMiddleware } from "../../shared/request-logger.ts";
+import { gracefulShutdown } from "../../shared/graceful-shutdown.ts";
 import { sanitizeUserString } from "../../shared/sanitize.ts";
 import {
   MedicationOrderSchema,
@@ -250,15 +251,4 @@ export const server = app.listen(PORT, () => {
   logger.info({ port: PORT, network: NETWORK, recipient: RECIPIENT, currency: USDC_SAC_TESTNET }, "Pharmacy Payment Service (MPP Charge) started");
 });
 
-process.on("SIGTERM", () => {
-  logger.info("SIGTERM received. Draining server...");
-  isDraining = true;
-  server.close(() => {
-    logger.info("Server closed. Exiting process.");
-    process.exit(0);
-  });
-  setTimeout(() => {
-    logger.error("Graceful shutdown timeout. Forcing exit.");
-    process.exit(1);
-  }, 30000);
-});
+gracefulShutdown({ server, onDrainStart: () => { isDraining = true; } });

--- a/shared/__tests__/graceful-shutdown.test.ts
+++ b/shared/__tests__/graceful-shutdown.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { gracefulShutdown, DEFAULT_SHUTDOWN_TIMEOUT_MS } from "../graceful-shutdown.ts";
+
+function fakeLogger() {
+  return { info: vi.fn(), error: vi.fn() };
+}
+
+/** A server whose close() never invokes its callback — simulates a hung drain. */
+function hangingServer() {
+  return { close: vi.fn() };
+}
+
+/** A server whose close() invokes its callback synchronously — simulates a clean drain. */
+function cleanServer() {
+  return { close: vi.fn((cb: () => void) => cb()) };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  delete process.env.SHUTDOWN_TIMEOUT_MS;
+});
+
+afterEach(() => {
+  process.removeAllListeners("SIGTERM");
+  vi.useRealTimers();
+});
+
+describe("gracefulShutdown", () => {
+  it("force-exits after the configured timeout when close() hangs", () => {
+    const server = hangingServer();
+    const logger = fakeLogger();
+    const exit = vi.fn();
+
+    gracefulShutdown({ server, logger, exit, timeoutMs: 5000 });
+    process.emit("SIGTERM");
+
+    expect(exit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(5000);
+
+    expect(exit).toHaveBeenCalledExactlyOnceWith(1);
+    expect(logger.error).toHaveBeenCalledWith("Graceful shutdown timeout. Forcing exit.");
+  });
+
+  it("does not force-exit before the configured timeout elapses", () => {
+    const server = hangingServer();
+    const exit = vi.fn();
+
+    gracefulShutdown({ server, logger: fakeLogger(), exit, timeoutMs: 5000 });
+    process.emit("SIGTERM");
+    vi.advanceTimersByTime(4999);
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("defaults the timeout to 30000ms when no override or env var is set", () => {
+    const server = hangingServer();
+    const exit = vi.fn();
+
+    gracefulShutdown({ server, logger: fakeLogger(), exit });
+    process.emit("SIGTERM");
+
+    vi.advanceTimersByTime(DEFAULT_SHUTDOWN_TIMEOUT_MS - 1);
+    expect(exit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(exit).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  it("honors SHUTDOWN_TIMEOUT_MS from the environment when no explicit override is given", () => {
+    process.env.SHUTDOWN_TIMEOUT_MS = "1000";
+    const server = hangingServer();
+    const exit = vi.fn();
+
+    gracefulShutdown({ server, logger: fakeLogger(), exit });
+    process.emit("SIGTERM");
+    vi.advanceTimersByTime(1000);
+
+    expect(exit).toHaveBeenCalledExactlyOnceWith(1);
+  });
+
+  it.each(["abc", "-100", "0", ""])(
+    "falls back to the default timeout when SHUTDOWN_TIMEOUT_MS is malformed (%s)",
+    (raw) => {
+      process.env.SHUTDOWN_TIMEOUT_MS = raw;
+      const server = hangingServer();
+      const exit = vi.fn();
+
+      gracefulShutdown({ server, logger: fakeLogger(), exit });
+      process.emit("SIGTERM");
+
+      vi.advanceTimersByTime(DEFAULT_SHUTDOWN_TIMEOUT_MS - 1);
+      expect(exit).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(exit).toHaveBeenCalledExactlyOnceWith(1);
+    }
+  );
+
+  it("exits cleanly with code 0 once close() completes, without waiting for the timeout", () => {
+    const server = cleanServer();
+    const exit = vi.fn();
+
+    gracefulShutdown({ server, logger: fakeLogger(), exit, timeoutMs: 5000 });
+    process.emit("SIGTERM");
+
+    expect(exit).toHaveBeenCalledExactlyOnceWith(0);
+    expect(server.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDrainStart before draining begins", () => {
+    const server = hangingServer();
+    const onDrainStart = vi.fn(() => {
+      expect(server.close).not.toHaveBeenCalled();
+    });
+
+    gracefulShutdown({ server, logger: fakeLogger(), exit: vi.fn(), onDrainStart, timeoutMs: 5000 });
+    process.emit("SIGTERM");
+
+    expect(onDrainStart).toHaveBeenCalledTimes(1);
+    expect(server.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses process.on, not .once — a second SIGTERM re-runs the handler, matching every original handler's behavior", () => {
+    const server = cleanServer();
+    const exit = vi.fn();
+
+    gracefulShutdown({ server, logger: fakeLogger(), exit, timeoutMs: 5000 });
+    process.emit("SIGTERM");
+    process.emit("SIGTERM");
+
+    expect(server.close).toHaveBeenCalledTimes(2);
+    expect(exit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/shared/graceful-shutdown.ts
+++ b/shared/graceful-shutdown.ts
@@ -1,0 +1,64 @@
+import type { Server } from "node:http";
+import { logger as defaultLogger } from "./logger.ts";
+
+/** Force-exit grace period if SHUTDOWN_TIMEOUT_MS is unset or invalid. */
+export const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30000;
+
+/**
+ * Resolve the force-exit timeout: explicit `override` > `SHUTDOWN_TIMEOUT_MS` env var >
+ * `DEFAULT_SHUTDOWN_TIMEOUT_MS`. A malformed or non-positive env value falls back to the
+ * default rather than producing an effectively-immediate force exit.
+ */
+function resolveTimeoutMs(override: number | undefined): number {
+  if (override !== undefined) return override;
+  const raw = process.env.SHUTDOWN_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_SHUTDOWN_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return DEFAULT_SHUTDOWN_TIMEOUT_MS;
+  return parsed;
+}
+
+export interface GracefulShutdownOptions {
+  /** The HTTP server to drain — anything exposing Node's `http.Server#close` signature. */
+  server: Pick<Server, "close">;
+  /** Called synchronously when SIGTERM is received, before `server.close()` — e.g. to flip a readiness flag so `/ready` starts returning 503. */
+  onDrainStart?: () => void;
+  /** Overrides `SHUTDOWN_TIMEOUT_MS` / the 30000ms default. */
+  timeoutMs?: number;
+  /** Overrides the shared logger — mainly for tests. */
+  logger?: Pick<typeof defaultLogger, "info" | "error">;
+  /** Overrides `process.exit` — mainly for tests. */
+  exit?: (code: number) => void;
+}
+
+/**
+ * Registers a SIGTERM handler implementing the drain-then-force-exit pattern previously
+ * duplicated across agent/server.ts, server.ts, services/pharmacy-payment/server.ts, and
+ * services/drug-interaction-api/server.ts: on SIGTERM, drain `server` via `close()`, exiting
+ * cleanly once it completes, or force-exiting after `timeoutMs` if `close()` hasn't finished
+ * by then.
+ *
+ * Uses `process.on`, not `.once` — matching every original handler's behavior exactly, and
+ * per Node's own guidance, `.once` is unsafe for signal handlers: after the listener
+ * auto-removes on the first signal, a second SIGTERM would fall through to the OS's default
+ * disposition (immediate termination) instead of running this handler again.
+ */
+export function gracefulShutdown(options: GracefulShutdownOptions): void {
+  const { server, onDrainStart, logger = defaultLogger, exit = (code: number) => process.exit(code) } = options;
+  const timeoutMs = resolveTimeoutMs(options.timeoutMs);
+
+  process.on("SIGTERM", () => {
+    logger.info("SIGTERM received. Draining server...");
+    onDrainStart?.();
+
+    server.close(() => {
+      logger.info("Server closed. Exiting process.");
+      exit(0);
+    });
+
+    setTimeout(() => {
+      logger.error("Graceful shutdown timeout. Forcing exit.");
+      exit(1);
+    }, timeoutMs);
+  });
+}


### PR DESCRIPTION
### Problem

Closes #1070.

`agent/server.ts`, `server.ts`, `services/pharmacy-payment/server.ts`, and
`services/drug-interaction-api/server.ts` each independently implemented an identical SIGTERM
handler with a hardcoded `setTimeout(() => { ...; process.exit(1); }, 30000)` force-exit
fallback. There was no shared helper and no env override, so tuning the shutdown grace period
required editing four separate files in lockstep, and the four copies could silently drift out of
sync over time.

Before designing anything, all four handlers were read in full and confirmed byte-for-byte
identical. Two things shaped the design: every handler sets a module-level `isDraining` flag
before calling `server.close()`, read by that file's own `/ready` endpoint to return 503 during
drain — a per-service side effect, not universal boilerplate, so the shared helper needed a hook
for it rather than owning the flag itself. And all four files already import the same `logger`
singleton from `shared/logger.ts`, so the helper defaults to that import rather than requiring
every call site to pass it explicitly.

`scripts/dev.ts` also has a `SIGTERM` handler, but it kills child dev-server processes — a
structurally different pattern, not named in the issue's Relevant Files, and left untouched.

### What changed and how the flow works now

`shared/graceful-shutdown.ts` (#1070) is new and exports `gracefulShutdown(options)`: on SIGTERM,
it drains the given `server` via `close()`, exiting cleanly (code 0) once that completes, or
force-exiting (code 1) after a timeout if `close()` hasn't finished. The timeout resolves in the
same precedence order already used elsewhere in this codebase
(`shared/x402-middleware.ts`'s `X402_FACILITATOR_HEALTH_INTERVAL_MS`): an explicit function option,
then the new `SHUTDOWN_TIMEOUT_MS` env var, then the existing 30000ms default. Malformed or
non-positive env values (`"abc"`, `"-100"`, `"0"`, empty) fall back to the default safely, using
the same defensive-parsing shape already established in `shared/rate-limit.ts`'s `parseLimitEnv`
(that file's own comment traces it to issue #799 — a malformed value must never silently produce
dangerous behavior, here an effectively-immediate force exit via `setTimeout(fn, NaN)`).

All four entrypoints (#1070) now call:
```ts
gracefulShutdown({ server, onDrainStart: () => { isDraining = true; } });
```
in place of their own ~11-line handler. Each file's own `isDraining` variable and `/ready`
endpoint are completely untouched — only the SIGTERM-handling code that used to be copy-pasted
four times is gone, replaced by one call to the shared implementation.

`gracefulShutdown` registers with `process.on`, not `.once` — matching every original handler's
behavior exactly: a second SIGTERM re-runs the handler rather than being silently dropped. (An
earlier draft used `.once` for test-cleanup convenience; Node's own `events` documentation
explicitly cautions against `.once` for signal handlers, since the listener auto-removing after
the first signal means a second SIGTERM would fall through to the OS's default disposition —
immediate termination — instead of running the handler again. Caught during review and reverted
before this PR, with a test added specifically covering the corrected behavior.)

`shared/__tests__/graceful-shutdown.test.ts` (#1070) is new, 11 tests, including the
acceptance-criterion-required case: force-exit after the configured timeout when `close()` hangs.

### Why this matters

Four independently-maintained copies of the same shutdown logic meant tuning the grace period —
or fixing a bug in it — required editing four files in lockstep, with no guarantee they'd stay in
sync. One shared, tested implementation means the drain-then-force-exit behavior is defined once,
verified once, and now configurable per-deployment via a single env var instead of four hardcoded
constants.

## Changed

- `shared/graceful-shutdown.ts` (#1070) — new. `gracefulShutdown(options)` implements the
  drain-then-force-exit pattern once; `DEFAULT_SHUTDOWN_TIMEOUT_MS` (30000) exported for tests
  and defaulting.
- `agent/server.ts`, `server.ts`, `services/pharmacy-payment/server.ts`,
  `services/drug-interaction-api/server.ts` (#1070) — each: added the `gracefulShutdown` import,
  replaced their ~11-line duplicated `process.on("SIGTERM", ...)` block with one call to the
  shared helper. `isDraining` flags and `/ready` endpoints untouched in all four.
- `shared/__tests__/graceful-shutdown.test.ts` (#1070) — new, 11 tests: force-exit on hang at the
  configured timeout, not-yet-timed-out behavior, the 30000ms default, `SHUTDOWN_TIMEOUT_MS` env
  override, malformed-env fallback (parametrized over 4 invalid values), clean exit without
  waiting for the timer, `onDrainStart` firing before `close()`, and repeated-SIGTERM behavior
  matching the original `process.on` semantics.

## Testing

```bash
npx vitest run shared/__tests__/graceful-shutdown.test.ts
npx tsc --noEmit
npx vitest run agent/__tests__ services/pharmacy-payment/__tests__ \
  services/drug-interaction-api/__tests__ tests/horizon-boot-timeout.test.ts
grep -rln "SIGTERM" --include="*.test.ts" .
```

- `shared/__tests__/graceful-shutdown.test.ts`: **11/11 passing**.
- `npx tsc --noEmit` (root): output byte-identical before/after this change (compared via
  `git stash`) — same 39 pre-existing, unrelated lines, zero new errors.
- Full test run across all four affected services plus root `server.ts`'s own dedicated suite
  (`tests/horizon-boot-timeout.test.ts`, 3/3 passing): failing-test names compared before vs.
  after via `git stash` — **identical set of 7 pre-existing, unrelated failures both before and
  after** (LLM token heuristics, LLM error-fallback mocking, an LLM eval, and a Horizon-timeout
  chaos test with a tight internal race — none reference `SIGTERM`, `gracefulShutdown`, or
  `isDraining`).
- `grep -rln "SIGTERM" --include="*.test.ts" .` found exactly two files: this fix's own new test,
  and `scripts/__tests__/dev.test.ts` (pre-existing, tests the unrelated `scripts/dev.ts`
  child-process-killing handler — confirmed unrelated, not touched).
- Verified `server.close(callback)` semantics against the official Node.js `http` documentation
  and `process.on` vs `.once` semantics against the official Node.js `events` documentation —
  the latter is what caught and fixed the `.once` regression described above before this PR.

## Scope Notes

- Backend-only: touches four server entrypoints and adds one `shared/` module plus its test. No
  frontend, no `compilerOptions`, no CI/package.json changes.
- No behavioral change to any of the four entrypoints beyond the refactor itself — same
  `process.on("SIGTERM", ...)` semantics, same drain-then-force-exit shape, same 30000ms default
  when `SHUTDOWN_TIMEOUT_MS` is unset.
- Found, but intentionally **not** touched (outside #1070's named scope of exactly four
  entrypoints): `services/pharmacy-api/server.ts` and `services/bill-audit-api/server.ts` have the
  identical duplicated SIGTERM handler (pharmacy-api via `startedApp.setDraining(true)` instead of
  a raw `isDraining` variable, otherwise structurally identical) but are not named in the issue's
  Relevant Files or acceptance criteria, which explicitly count "four" entrypoints. The new helper
  already fully supports wiring these up identically — flagging as a natural, low-risk follow-up
  rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)