### PR TITLE
RFC proposals for issues #1441 #1443 #1444 #1446

### DIFF
--- a/docs/rfc/1441-shared-package-boundaries.md
+++ b/docs/rfc/1441-shared-package-boundaries.md
@@ -1,0 +1,142 @@
+# RFC 1441: Give `shared/` real package boundaries instead of relative-path imports
+
+**Status:** Proposed
+**Date:** 2026-08-27
+**Issue:** [#1441](https://github.com/harystyleseze/careguard/issues/1441)
+
+---
+
+## Context
+
+Today every `services/*/server.ts` (and `agent/server.ts`, `server.ts`) reaches into
+`shared/` through raw relative paths such as
+`import { logger } from "../../shared/logger.ts";` (see
+`services/bill-audit-api/server.ts:28`, `services/drug-interaction-api/server.ts:20`,
+`services/pharmacy-api/server.ts:19`). `pnpm-workspace.yaml` only configures
+`allowBuilds` for `core-js`/`esbuild`/`sharp` and declares **no** `packages:` list, so
+there is:
+
+- no dependency graph — pnpm cannot tell which services depend on which shared modules;
+- no per-package versioning or publish surface;
+- no enforced *export surface* — any file inside `shared/` is importable from anywhere,
+  so an accidental coupling (a service reaching into an internal helper that was meant to
+  be private) is invisible until runtime.
+
+This RFC proposes turning `shared/` into a first-class pnpm workspace package
+(`@careguard/shared`) with an explicit `exports` map, so the importable surface is
+declared in one place and accidental coupling becomes a build/type error.
+
+## Trade-off
+
+More upfront ceremony (`package.json`, `exports` map, per-service `package.json`
+dependency, a codemod) versus today's zero-friction relative imports. The payoff is that
+the *intended* public API of `shared/` is explicit and deviations are caught by the
+type-checker and by workspace-aware tooling.
+
+## Acceptance criteria
+
+### 1. Document today's relative-import pattern and its lack of an enforced export surface
+
+- **Pattern:** `services/<svc>/server.ts` and `server.ts`/`agent/server.ts` import
+  `shared/*.ts` via `../../shared/<module>.ts` relative specifiers.
+- **No export surface:** Every `.ts` file in `shared/` is reachable. There is no
+  `index.ts` gate and no `exports` map, so a service can import an internal helper
+  (e.g. `shared/__tests__/…` or a `_`-prefixed helper) just as easily as a public one.
+- **No graph:** `pnpm-workspace.yaml` has no `packages:` entry for `shared`, so pnpm
+  treats each service as an island and cannot resolve a shared dependency or detect
+  cycles.
+
+### 2. Propose a `shared/package.json` with an exports map
+
+```json
+// shared/package.json
+{
+  "name": "@careguard/shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./agent-state": "./dist/agent-state.js",
+    "./redis": "./dist/redis.js",
+    "./redact": "./dist/redact.js",
+    "./sanitize": "./dist/sanitize.js",
+    "./pricing-sources": "./dist/pricing-sources.js",
+    "./logger": "./dist/logger.js"
+    // … one entry per intentionally public module
+  }
+}
+```
+
+Only modules listed in `exports` are importable from outside the package. Internal-only
+helpers (anything under `__tests__/`, `_`-prefixed files) are simply omitted, making the
+public contract self-documenting.
+
+### 3. How `services/*/package.json` would declare the dependency
+
+Each service gains a workspace dependency instead of a relative path:
+
+```json
+// services/bill-audit-api/package.json
+{
+  "dependencies": {
+    "@careguard/shared": "workspace:*"
+  }
+}
+```
+
+and imports become package-specifier based:
+
+```ts
+// before
+import { sanitizeUserString } from "../../shared/sanitize.ts";
+// after
+import { sanitizeUserString } from "@careguard/shared/sanitize";
+```
+
+The `.ts` extension is dropped at the boundary because the `exports` map points at the
+built `.js`/`.d.ts` artifacts.
+
+### 4. Migration plan (codemod for import paths, one service first)
+
+1. **Add `shared` to the workspace.** Append to `pnpm-workspace.yaml`:
+   ```yaml
+   packages:
+     - "shared"
+     - "services/*"
+   ```
+2. **Author `shared/package.json`** (above) plus a `shared/tsconfig.build.json` that emits
+   `dist/` with declaration files.
+3. **Write a codemod** (`scripts/codemod-shared-imports.ts`, run with `tsx`) that rewrites
+   every `from "(\.\./)+shared/(.*?)\.ts"` in `services/**` and the root `*.ts` to
+   `from "@careguard/shared/$2"` and adds the `workspace:*` dependency to the owning
+   `package.json`.
+4. **One-service-first pilot:** apply the codemod to `services/bill-audit-api` only, build
+   `shared`, run `pnpm --filter @careguard/bill-audit-api typecheck` and its tests. This
+   proves the `exports` surface is complete (any missing export fails the type-check).
+5. **Roll out** to the remaining services, `agent/`, and root `server.ts` once the pilot is
+   green, then delete the now-redundant relative reachability (e.g. ensure no
+   `../../shared` specifiers remain via a lint rule).
+
+### 5. CI implications (build order, workspace-aware type-checking)
+
+- **Build order:** `shared` must be built (emit `dist/`) before any dependent service's
+  type-check/test. Introduce a pnpm pipeline: `pnpm -r --filter "./shared..." build`
+  followed by `pnpm -r build`, or rely on `pnpm` topological run.
+- **Workspace-aware type-check:** switch CI from per-folder `tsc` to
+  `pnpm -r typecheck` so cross-package boundary type errors surface.
+- **Lint guard:** add a `no-restricted-imports` ESLint rule forbidding `**/shared/**`
+  relative specifiers outside `shared/`, locking in the package boundary.
+- **Caching:** `shared/dist` becomes a build artifact; ensure CI caches it between the
+  build and test stages, or merge build+test into a single job per package.
+
+## Open questions
+
+- Do we keep `.ts` source in the `exports` map (for `tsx`/dev) or only ship built `.js`?
+  Recommendation: ship built artifacts and have `shared` expose a `dev` script using
+  `tsx` watch for local iteration.

--- a/docs/rfc/1443-split-pricing-sources.md
+++ b/docs/rfc/1443-split-pricing-sources.md
@@ -1,0 +1,102 @@
+# RFC 1443: Split `shared/pricing-sources.ts` (979 lines) by pricing-source concern
+
+**Status:** Proposed
+**Date:** 2026-08-27
+**Issue:** [#1443](https://github.com/harystyleseze/careguard/issues/1443)
+
+---
+
+## Context
+
+`shared/pricing-sources.ts` is ~979 lines and mixes several concerns in a single module:
+
+- **source-adapter definitions** (`StaticProvider`, `GoodRxProvider`, `CostcoRxProvider`),
+- **normalization logic** (drug-name lowercasing, price adjustment),
+- **caching** (in-memory `Map` with 24h TTL in `BasePricingProvider`),
+- **comparison/scoring** (the comparison endpoint's ranking of returned prices).
+
+Because everything lives in one file, a change to one source's drug database can silently
+affect reasoning about unrelated sections, and the file is hard to review. This RFC
+proposes splitting it into per-source adapter files plus a thin orchestration module, so
+each pricing source becomes independently testable and reviewable.
+
+## Trade-off
+
+More files to navigate, but each source's database and logic is isolated. Existing public
+API surface (`PricingProvider`, `BasePricingProvider`, `createPricingProvider`,
+`StaticProvider`, `GoodRxProvider`, `CostcoRxProvider`) is preserved via a re-exporting
+`index.ts`, so no call site changes are required.
+
+## Acceptance criteria
+
+### 1. Map the current file's sections (with line ranges)
+
+| Section | Lines | Concern |
+|---|---|---|
+| `PricingProvider` interface + `PharmacyPrice` types | 1–16 | Public types |
+| `CacheEntry` interface | 20–24 | Caching types |
+| `BasePricingProvider` (cache get/set, `getCacheKey`) | 28–63 | Caching + normalization base |
+| `StaticProvider` | 65–84 | Source adapter |
+| `GoodRxProvider` (expanded drug DB, scraping-style pricing) | 85–778 | Source adapter (largest) |
+| `CostcoRxProvider` | 784–961 | Source adapter |
+| `createPricingProvider` factory | 965–979 | Orchestration/factory |
+
+`GoodRxProvider` alone spans ~693 lines (85–778), almost entirely its hardcoded
+`drugDatabase` map. That is the prime candidate for extraction.
+
+### 2. Target module layout
+
+```
+shared/pricing-sources/
+  index.ts            # re-exports public surface (PricingProvider, providers, factory)
+  types.ts            # PricingProvider, PharmacyPrice, CacheEntry
+  base-provider.ts    # BasePricingProvider (cache + normalization)
+  static-provider.ts  # StaticProvider
+  goodrx-provider.ts  # GoodRxProvider (+ its drugDatabase)
+  costco-provider.ts  # CostcoRxProvider
+```
+
+`index.ts` preserves the current import contract so `shared/__tests__/pricing-sources.test.ts`
+and `scripts/test-pricing-providers.ts` keep working unchanged:
+
+```ts
+// shared/pricing-sources/index.ts
+export * from "./types.ts";
+export * from "./base-provider.ts";
+export * from "./static-provider.ts";
+export * from "./goodrx-provider.ts";
+export * from "./costco-provider.ts";
+```
+
+### 3. Shared interface each source adapter must implement
+
+Unchanged from today — every adapter extends `BasePricingProvider`, which implements the
+`PricingProvider` interface (`getPrices(drugName, zipCode?): Promise<PharmacyPrice[]>`).
+The split only relocates the concrete classes; the interface contract is untouched.
+
+### 4. Migration plan preserving the existing public API surface and tests
+
+1. Create `shared/pricing-sources/` directory.
+2. Move `PricingProvider`/`PharmacyPrice`/`CacheEntry` → `types.ts`.
+3. Move `BasePricingProvider` → `base-provider.ts` (imports types from `./types.ts`).
+4. Move `StaticProvider`, `GoodRxProvider`, `CostcoRxProvider` into their files; each
+   imports `BasePricingProvider` from `./base-provider.ts` and types from `./types.ts`.
+5. Replace `shared/pricing-sources.ts` with a thin `index.ts` that re-exports everything
+   (so `import { GoodRxProvider } from "../shared/pricing-sources.ts"` still resolves).
+   Alternatively, delete the old file and update its two importers (step below).
+6. Run `pnpm --filter … typecheck` and `shared/__tests__/pricing-sources.test.ts`.
+
+### 5. Existing tests that need path updates
+
+- `shared/__tests__/pricing-sources.test.ts` — only if we drop the re-export shim; with the
+  `index.ts` shim **no change is required**.
+- `scripts/test-pricing-providers.ts` — imports from `../shared/pricing-sources.ts`;
+  unchanged with the shim.
+
+If we choose to fully delete the old file (preferred long-term), update the two importers
+to `../shared/pricing-sources/index.ts` (or the new package path from RFC 1441).
+
+## Open questions
+
+- Should `GoodRxProvider`'s large `drugDatabase` move to its own `goodrx-database.ts`?
+  Recommendation: yes, to keep `goodrx-provider.ts` focused on behavior.

--- a/docs/rfc/1444-redis-agent-state.md
+++ b/docs/rfc/1444-redis-agent-state.md
@@ -1,0 +1,109 @@
+# RFC 1444: Replace `shared/agent-state.ts` module-level pause flags with a Redis-backed store
+
+**Status:** Proposed
+**Date:** 2026-08-27
+**Issue:** [#1444](https://github.com/harystyleseze/careguard/issues/1444)
+
+---
+
+## Context
+
+`shared/agent-state.ts` stores pause state as plain module-level variables:
+
+```ts
+let paused = false;
+let pausedReason: PauseReason | null = null;
+let pausedAt: string | null = null;
+```
+
+The module's own doc comment (lines 5–8) admits this only works for a single-process
+deploy: *"State is in-memory (single-process). For multi-process deploys this needs to
+move to Redis…"*. Under a second server replica (horizontal scaling, e.g. multiple
+Render instances behind a load balancer), each replica holds an **independent,
+inconsistent** pause state — one replica pauses, the other keeps spending.
+
+`shared/redis.ts` already exists and provides a `CacheClient` (`get`/`set`/`del`,
+in-process fallback when `REDIS_URL` is unset) used elsewhere for shared mutable state.
+This RFC proposes migrating pause state into Redis behind the **same**
+`getAgentState`/`pauseAgent`/`resumeAgent`/`isPaused` interface.
+
+## Trade-off
+
+Adds a network round-trip (and a Redis-availability dependency) to every pause/resume
+check, but makes horizontal scaling of the agent server correct: all replicas observe a
+single source of truth.
+
+## Acceptance criteria
+
+### 1. Document the current module-level state and the multi-replica failure
+
+See the code snippet above. `paused`/`pausedReason`/`pausedAt` are process-local. With N
+replicas, a `pauseAgent()` call hitting replica A is invisible to replica B, so B
+continues to service tool calls and spend. The current deploy (`render.yaml`, single
+unified server) hides the bug, but any scale-out reintroduces it.
+
+### 2. Redis key/value schema mirroring `AgentState`
+
+Store the state as a single JSON blob under one key, mirroring the existing shape:
+
+```
+Key:    agent:state
+Type:   string (JSON)
+Value:  { "paused": boolean, "pausedReason": string|null, "pausedAt": string|null }
+TTL:    none (pause is durable until explicitly resumed; matches today's semantics)
+```
+
+Optionally also expose `agent:state:paused` as a fast boolean for `isPaused()` hot paths,
+but a single JSON key keeps the schema simple and consistent with `getAgentState()`.
+
+### 3. Keep the existing function signatures stable
+
+The public surface is unchanged:
+
+```ts
+export interface AgentState { paused: boolean; pausedReason: PauseReason | null; pausedAt: string | null; }
+export function getAgentState(): Promise<AgentState>;
+export function pauseAgent(reason: PauseReason): Promise<AgentState>;
+export function resumeAgent(): Promise<AgentState>;
+export function isPaused(): Promise<boolean>;
+```
+
+This is a **breaking async change** for the three callers (`shared/wallet-balance.ts:17`,
+`server.ts:62`, `agent/server.ts`). Migration is mechanical: `await` the calls. The
+in-process file persistence in `agent/server.ts:189` (`data/agent-state.json`) is a
+separate concern and can be retained as a cold-start seed (see migration plan).
+
+### 4. Fallback behavior when Redis is unavailable (fail open vs fail closed)
+
+`shared/redis.ts` already falls back to an in-process `Map` when `REDIS_URL` is unset, but
+**that fallback is also process-local** and reintroduces the multi-replica bug. Two modes:
+
+- **`REDIS_URL` unset (dev / single process):** use the in-process fallback. Acceptable,
+  matches today.
+- **`REDIS_URL` set but Redis unreachable:** **fail closed** — `isPaused()` should return
+  `true` (treat the agent as paused) so a Redis outage does not permit uncontrolled
+  spending. `pauseAgent`/`resumeAgent` throw/log, and the caller (e.g.
+  `wallet-balance.ts`) already treats a paused agent conservatively.
+
+Concretely, wrap `redis.get` in a try/catch: on error, `getAgentState()` returns
+`{ paused: true, … }` (fail closed) and logs, rather than silently returning `paused:
+false`.
+
+### 5. Migration plan with a feature flag to switch stores
+
+1. Define `USE_REDIS_AGENT_STATE` env flag (default: follow `REDIS_URL`).
+2. Implement `createRedisAgentStateStore(client)` and keep
+   `createInMemoryAgentStateStore()` (current vars) as the fallback.
+3. Add a factory `getAgentStateStore()` that selects the store based on the flag.
+4. Convert the four exported functions into thin wrappers over the selected store.
+5. Update the three call sites to `await` the now-async functions.
+6. Optionally seed Redis from `data/agent-state.json` on cold start, then drop the file
+   once Redis is the source of truth in all environments.
+7. Ship behind the flag; enable per-environment; remove the in-memory store path once
+   stable.
+
+## Open questions
+
+- Should `isPaused()` be cached locally with a short TTL to avoid a round-trip on every
+  tool call? Recommendation: yes, a ~1s in-memory cache of the boolean, since pause
+  transitions are rare.

--- a/docs/rfc/1446-consolidate-pii.md
+++ b/docs/rfc/1446-consolidate-pii.md
@@ -1,0 +1,130 @@
+# RFC 1446: Consolidate `sanitize.ts`, `redact.ts`, `prompt-scrub.ts` into one PII module
+
+**Status:** Proposed
+**Date:** 2026-08-27
+**Issue:** [#1446](https://github.com/harystyleseze/careguard/issues/1446)
+
+---
+
+## Context
+
+Three similarly-named modules each implement their own slice of removing sensitive data
+from strings/objects, with **no shared vocabulary** for what counts as PII or how it is
+masked:
+
+- `shared/sanitize.ts` (26 lines) — `sanitizeUserString`
+- `shared/redact.ts` (125 lines) — `redact`, `redactString`, `redactPII`, `hashTask`,
+  `registerKnownNames`
+- `shared/prompt-scrub.ts` (50 lines) — `buildScrubSession`, `scrubText`
+
+A new call site can easily pick the wrong one, or miss a field pattern that another module
+already catches. This RFC proposes merging them into a single `shared/pii.ts` with
+purpose-specific exports (`redactForLogs`, `scrubForPrompt`, `sanitizeForResponse`) built
+on one shared pattern registry.
+
+## Trade-off
+
+A larger single file versus three small ones — but one source of truth for which patterns
+are treated as sensitive, and one place to add a new PII pattern.
+
+## Acceptance criteria
+
+### 1. Diff the three modules' regex/field-matching patterns
+
+| Concern | `sanitize.ts` | `redact.ts` | `prompt-scrub.ts` |
+|---|---|---|---|
+| Control chars | `[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x80-\x9F]` | — | — |
+| Disallowed chars | `[^a-zA-Z0-9 \-()]` (allow-list) | — | — |
+| Length cap | 80 chars | — | — |
+| Stellar secret | — | `\bS[A-Z2-7]{55}\b` | — |
+| Bearer/JWT | — | `\bBearer\s+[A-Za-z0-9._\-+/=]{20,}\b` | — |
+| Secret field names | — | `SECRET_FIELD_NAMES` set (24 names) | — |
+| Patient names | — | `registerKnownNames` → `[PATIENT NAME]` | `buildScrubSession` → `Patient A` |
+| Drug specifics | — | `[A-Z][a-z]+ \d+mg` → `[MEDICATION]` | — |
+| Caregiver names | — | (covered by known-names) | `Caregiver A` pseudonym |
+
+**Key divergence:** `redact.ts` *masks* names to the literal `[PATIENT NAME]`, while
+`prompt-scrub.ts` *pseudonymizes* to `Patient A`/`Caregiver B` (reversible server-side via
+the session map). These serve different goals (log hygiene vs. LLM PHI minimization) and
+must **not** be merged into one behavior.
+
+**Important nuance:** `sanitize.ts` is *not* a PII tool — it is input hardening (strips
+control chars / RTL marks / enforces a char allow-list and length cap) to prevent UI
+parsing breakage in receipts/PDFs. It must stay as `sanitizeForResponse` and keep its
+exact behavior; it shares only the "make strings safe" theme.
+
+### 2. Consolidated module's export surface + internal pattern registry
+
+`shared/pii.ts`:
+
+```ts
+// ── shared pattern registry (single source of truth) ──
+const STELLAR_SECRET_RE = /\bS[A-Z2-7]{55}\b/g;
+const BEARER_RE = /\bBearer\s+[A-Za-z0-9._\-+/=]{20,}\b/gi;
+const DRUG_SPECIFIC_RE = /\b[A-Z][a-z]+ \d+\s*mg\b/gi;
+const SECRET_FIELD_NAMES = new Set([ /* …24 names… */ ]);
+
+// log redaction (conservative: when in doubt, redact)
+export function redactForLogs<T>(value: T, depth = 0): T;          // was redact
+export function redactForLogsString(value: string): string;        // was redactString
+export function redactPIIString(value: string): string;            // was redactPII
+export function registerKnownNames(names: string[]): void;         // unchanged
+export function hashTask(task: string): string;                    // unchanged
+
+// prompt PHI scrubbing (pseudonymize, not mask)
+export function buildScrubSession(patients: string[], caregivers: string[]): ScrubSession;
+export function scrubForPrompt(text: string, session: ScrubSession): string; // was scrubText
+
+// input hardening (NOT PII — keeps exact current behavior)
+export function sanitizeForResponse(input: unknown): string;       // was sanitizeUserString
+```
+
+### 3. Migration plan updating all call sites
+
+Add a backward-compat shim (`shared/redact.ts`, `shared/sanitize.ts`,
+`shared/prompt-scrub.ts`) that re-exports from `pii.ts`, OR update call sites directly.
+Direct updates:
+
+| File | Current | New |
+|---|---|---|
+| `agent/runner.ts:12,14` | `buildScrubSession, scrubText`, `redactPII` | `scrubForPrompt`+`buildScrubSession`, `redactPIIString` |
+| `agent/server.ts:30` | `redactPII, hashTask, registerKnownNames` | `redactPIIString, hashTask, registerKnownNames` |
+| `shared/sentry.ts:19` | `redact` | `redactForLogs` |
+| `services/care-recipients/routes.ts:3` | `registerKnownNames` | unchanged name |
+| `services/bill-audit-api/server.ts:31` | `sanitizeUserString` | `sanitizeForResponse` |
+| `services/pharmacy-payment/server.ts:25` | `sanitizeUserString` | `sanitizeForResponse` |
+| `server.ts:38-39` | `sanitizeUserString`, `registerKnownNames` | `sanitizeForResponse`, unchanged |
+
+Because `registerKnownNames` and `hashTask` keep their names, only `redact`→`redactForLogs`,
+`redactString`→`redactForLogsString`, `redactPII`→`redactPIIString`, `scrubText`→
+`scrubForPrompt`, `sanitizeUserString`→`sanitizeForResponse` change at call sites.
+
+### 4. Test suite asserting each purpose-specific function still meets needs
+
+Re-point the existing suites (no behavior change, so they pass as-is once re-exported):
+- `shared/__tests__/redact.test.ts` → assert `redactForLogs`/`redactPIIString` mask names,
+  secrets, bearer tokens, and field names.
+- `shared/__tests__/sanitize.test.ts` → assert `sanitizeForResponse` strips control chars,
+  enforces allow-list and 80-char cap.
+- `shared/__tests__/prompt-scrub.test.ts` → assert `scrubForPrompt` pseudonymizes via the
+  session map and that `aliasToReal` round-trips.
+- Add one integration test in `shared/pii.test.ts` proving a string containing a Stellar
+  secret + a known patient name + a drug is handled correctly by each of the three
+  purpose functions without leaking across them.
+
+### 5. Behavior differences intentionally fixed vs preserved
+
+- **Preserved:** every regex/field-set/cap value is copied verbatim; no masking behavior
+  changes. `sanitizeForResponse` keeps its exact char allow-list and 80-char cap.
+- **Preserved:** `prompt-scrub` pseudonymization remains reversible server-side via the
+  session map; it is *not* collapsed into `[PATIENT NAME]`.
+- **Intentionally fixed (if found):** any pattern duplicated across the three modules
+  becomes a single registry entry, eliminating drift. Today `redact.ts` and
+  `prompt-scrub.ts` each maintain their own name lists — after consolidation there is one
+  known-names registry shared by `redactForLogs` and `scrubForPrompt`.
+
+## Open questions
+
+- Keep the three old files as re-export shims for one release (easier external imports),
+  then delete? Recommendation: yes, delete after the next minor to avoid breaking
+  out-of-tree callers.


### PR DESCRIPTION
## Summary

This PR adds RFC design documents for the four open RFC issues. Each document addresses every acceptance criterion using concrete analysis of the current code.

- **docs/rfc/1441-shared-package-boundaries.md** — turn `shared/` into a real `@careguard/shared` pnpm package with an explicit `exports` map; documents today's relative-import pattern, proposes the `package.json`/`exports` surface, the per-service `workspace:*` dependency, a codemod migration (one-service-first pilot), and CI/build-order implications.
- **docs/rfc/1443-split-pricing-sources.md** — split `shared/pricing-sources.ts` (979 lines) into `shared/pricing-sources/{types,base-provider,static-provider,goodrx-provider,costco-provider,index}.ts`, preserving the public API and existing tests via a re-export shim.
- **docs/rfc/1444-redis-agent-state.md** — migrate `shared/agent-state.ts` module-level pause flags to Redis behind the same `getAgentState/pauseAgent/resumeAgent/isPaused` interface, with fail-closed fallback and a feature flag.
- **docs/rfc/1446-consolidate-pii.md** — consolidate `sanitize.ts`, `redact.ts`, `prompt-scrub.ts` into `shared/pii.ts` with `redactForLogs`, `scrubForPrompt`, `sanitizeForResponse` over one shared pattern registry; notes that `sanitize` is input hardening (not PII) and must keep its exact behavior.

## Notes

These are RFC (design proposal) issues, so the deliverable is the proposal documents rather than the code refactors themselves. Each RFC includes a concrete migration plan ready to be executed in follow-up PRs.

Closes #1441
Closes #1443
Closes #1444
Closes #1446