### PR TITLE
refactor: fix #1467 interface collision, #1468 bill audit errors, and…

### DIFF
--- a/services/bill-audit-api/__tests__/multipliers.test.ts
+++ b/services/bill-audit-api/__tests__/multipliers.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // Pre-define environment variables before importing server.ts
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readFileSync: (path: any, options: any) => {
+      if (typeof path === 'string' && path.includes('audit_thresholds.json')) {
+        throw new Error('Mock read failure');
+      }
+      return actual.readFileSync(path, options);
+    },
+  };
+});
+
 vi.hoisted(() => {
   process.env.BILL_PROVIDER_PUBLIC_KEY = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
   process.env.BILL_AUDIT_OVERCHARGE_MULTIPLIER = '2.0';

--- a/services/bill-audit-api/__tests__/server.integration.test.ts
+++ b/services/bill-audit-api/__tests__/server.integration.test.ts
@@ -60,8 +60,8 @@ describe("POST /bill/audit (Issue #788)", () => {
     const res = await request(app).post("/bill/audit").send({ lineItems: [] });
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
-    expect(res.body.ok).toBe(false);
-    expect(typeof res.body.reason).toBe("string");
+    expect(res.body.error).toBeDefined();
+    expect(typeof res.body.code).toBe("string");
   });
 
   it("rejects a negative chargedAmount with a structured 4xx", async () => {
@@ -70,7 +70,8 @@ describe("POST /bill/audit (Issue #788)", () => {
       .send({ lineItems: [{ description: "Visit", cptCode: "99213", quantity: 1, chargedAmount: -50 }] });
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
-    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.code).toBeDefined();
   });
 
   it("rejects a NaN chargedAmount with a structured 4xx", async () => {
@@ -79,6 +80,8 @@ describe("POST /bill/audit (Issue #788)", () => {
       .send({ lineItems: [{ description: "Visit", cptCode: "99213", quantity: 1, chargedAmount: NaN }] });
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.code).toBeDefined();
   });
 
   it("rejects a malformed CPT code with a structured 4xx", async () => {
@@ -87,7 +90,8 @@ describe("POST /bill/audit (Issue #788)", () => {
       .send({ lineItems: [{ description: "Visit", cptCode: "not-a-cpt", quantity: 1, chargedAmount: 50 }] });
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
-    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.code).toBeDefined();
   });
 
   it("rejects an oversized lineItems array before processing it", async () => {
@@ -100,6 +104,24 @@ describe("POST /bill/audit (Issue #788)", () => {
     const res = await request(app).post("/bill/audit").send({ lineItems });
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/exceeds max/);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("rejects a payload that exceeds the body size limit with a 413 and standardized shape", async () => {
+    const hugeBody = {
+      lineItems: Array.from({ length: 3000 }, () => ({
+        description: "A".repeat(100),
+        cptCode: "99213",
+        quantity: 1,
+        chargedAmount: 50,
+      }))
+    };
+    const res = await request(app).post("/bill/audit").send(hugeBody);
+    expect(res.status).toBe(413);
+    expect(res.body.error).toBe("Request body too large");
+    expect(res.body.code).toBe("BODY_TOO_LARGE");
+    expect(res.body.details).toBeDefined();
+    expect(res.body.details.limit).toBeDefined();
   });
 });
 

--- a/services/bill-audit-api/server.ts
+++ b/services/bill-audit-api/server.ts
@@ -210,7 +210,10 @@ app.post("/bill/audit", (req, res, next) => {
   const items = req.body?.lineItems;
   if (Array.isArray(items) && items.length > BILL_AUDIT_MAX_ITEMS) {
     billAuditOversizedRejectionsTotal.inc();
-    res.status(400).json({ error: `lineItems exceeds max (${BILL_AUDIT_MAX_ITEMS})` });
+    res.status(400).json({
+      error: `lineItems exceeds max (${BILL_AUDIT_MAX_ITEMS})`,
+      code: "VALIDATION_ERROR",
+    });
     return;
   }
   next();
@@ -236,20 +239,26 @@ app.post("/bill/audit", (req, res) => {
     if (error instanceof BillAuditValidationError) {
       const validationError = error as BillAuditValidationError;
       res.status(400).json({
-        ok: false,
-        reason: validationError.code,
-        message: validationError.message,
-        issues: validationError.issues,
+        error: validationError.message,
+        code: validationError.code,
+        details: { issues: validationError.issues },
       });
     } else {
-      res.status(400).json({ ok: false, reason: "INVALID_REQUEST_BODY" });
+      res.status(400).json({
+        error: "Invalid request body",
+        code: "INVALID_REQUEST_BODY",
+      });
     }
   }
 });
 
 app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
   if (err.type === "entity.too.large") {
-    return res.status(413).json({ error: "Request body too large", limit: err.limit });
+    return res.status(413).json({
+      error: "Request body too large",
+      code: "BODY_TOO_LARGE",
+      details: { limit: err.limit },
+    });
   }
   next(err);
 });

--- a/services/care-recipients/db.ts
+++ b/services/care-recipients/db.ts
@@ -7,7 +7,7 @@ import { logger } from '../../shared/logger.ts';
 const require = createRequire(import.meta.url);
 const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
 
-export interface CareRecipient {
+export interface CareRecipientEntity {
   id: string;
   name: string;
   age: number | null;
@@ -37,7 +37,7 @@ function defaultDbPath(): string {
   return new URL('../../data/careguard.sqlite', import.meta.url).pathname;
 }
 
-function rowToRecipient(row: CareRecipientRow): CareRecipient {
+function rowToRecipient(row: CareRecipientRow): CareRecipientEntity {
   let medications: string[] = [];
   try {
     medications = JSON.parse(row.medications);
@@ -103,21 +103,21 @@ export class CareRecipientsStore {
     logger.info('[care-recipients] seeded default recipient Rosa Garcia');
   }
 
-  list(): CareRecipient[] {
+  list(): CareRecipientEntity[] {
     const rows = this.db
       .prepare('SELECT * FROM care_recipients ORDER BY name ASC')
       .all() as CareRecipientRow[];
     return rows.map(rowToRecipient);
   }
 
-  getById(id: string): CareRecipient | undefined {
+  getById(id: string): CareRecipientEntity | undefined {
     const row = this.db
       .prepare('SELECT * FROM care_recipients WHERE id = ?')
       .get(id) as CareRecipientRow | undefined;
     return row ? rowToRecipient(row) : undefined;
   }
 
-  create(input: Omit<CareRecipient, 'id'>): CareRecipient {
+  create(input: Omit<CareRecipientEntity, 'id'>): CareRecipientEntity {
     // Date.now() alone collides under concurrent creates of the same name within
     // the same millisecond (duplicate PRIMARY KEY -> insert throws); a short
     // random suffix keeps ids readable while guaranteeing uniqueness.

--- a/services/care-recipients/routes.ts
+++ b/services/care-recipients/routes.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response, type NextFunction } from "express";
-import type { CareRecipientsStore, CareRecipient } from "./db.ts";
+import type { CareRecipientsStore, CareRecipientEntity } from "./db.ts";
 import { registerKnownNames } from "../../shared/redact.ts";
 
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {
@@ -59,7 +59,7 @@ export function createCareRecipientsRouter(store: CareRecipientsStore, caregiver
   });
 
   router.post("/recipients", auth, (req, res) => {
-    const body = req.body as Partial<CareRecipient>;
+    const body = req.body as Partial<CareRecipientEntity>;
     if (!body?.name || typeof body.name !== "string" || !body.name.trim()) {
       res.status(400).json({ error: "name is required" });
       return;

--- a/services/pharmacy-api/__tests__/routes.integration.test.ts
+++ b/services/pharmacy-api/__tests__/routes.integration.test.ts
@@ -460,7 +460,10 @@ describe("GET /pharmacy/compare", () => {
     const { app } = makeApp();
     const res = await request(app).get("/pharmacy/compare").query({ drug: "unknowndrug", zip: "90210" });
     expect(res.status).toBe(404);
-    expect(res.body).toEqual({ ok: false, reason: "NO_PRICES_FOUND" });
+    expect(res.body).toEqual({
+      error: "No pricing records found for drug: unknowndrug",
+      code: "NOT_FOUND_DRUG"
+    });
   });
 
   it("returns 200 with ranked prices and correct cheapest entry", async () => {

--- a/services/pharmacy-api/__tests__/server.test.ts
+++ b/services/pharmacy-api/__tests__/server.test.ts
@@ -131,6 +131,9 @@ describe("pharmacy API persistence", () => {
       .query({ drug: "UnknownDrug", zip: "90210" });
 
     expect(response.status).toBe(404);
-    expect(response.body).toEqual({ ok: false, reason: "NO_PRICES_FOUND" });
+    expect(response.body).toEqual({
+      error: "No pricing records found for drug: unknowndrug",
+      code: "NOT_FOUND_DRUG"
+    });
   });
 });

--- a/services/pharmacy-api/server.ts
+++ b/services/pharmacy-api/server.ts
@@ -54,8 +54,8 @@ export interface PharmacyAppOptions {
   enablePayments?: boolean;
 }
 
-function sendCrudNotFound(res: express.Response, message: string) {
-  res.status(404).json({ error: message });
+function sendCrudNotFound(res: express.Response, message: string, code: string = "NOT_FOUND") {
+  res.status(404).json({ error: message, code });
 }
 
 export function createPharmacyApp(options: PharmacyAppOptions) {
@@ -120,6 +120,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
     if (!parsedBody.success) {
       res.status(400).json({
         error: parsedBody.error.issues[0]?.message ?? "Invalid drug payload",
+        code: "VALIDATION_INVALID_INPUT",
       });
       return;
     }
@@ -139,6 +140,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
     if (!parsedBody.success) {
       res.status(400).json({
         error: parsedBody.error.issues[0]?.message ?? "Invalid drug payload",
+        code: "VALIDATION_INVALID_INPUT",
       });
       return;
     }
@@ -152,7 +154,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       ? req.params.drugName[0]
       : req.params.drugName;
     if (!pricingStore.deleteDrug(drugName)) {
-      sendCrudNotFound(res, `Drug not found: ${drugName}`);
+      sendCrudNotFound(res, `Drug not found: ${drugName}`, "NOT_FOUND_DRUG");
       return;
     }
 
@@ -165,6 +167,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       res.status(400).json({
         error:
           parsedBody.error.issues[0]?.message ?? "Invalid pharmacy payload",
+        code: "VALIDATION_INVALID_INPUT",
       });
       return;
     }
@@ -187,6 +190,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       res.status(400).json({
         error:
           parsedBody.error.issues[0]?.message ?? "Invalid pharmacy payload",
+        code: "VALIDATION_INVALID_INPUT",
       });
       return;
     }
@@ -202,7 +206,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       ? req.params.pharmacyId[0]
       : req.params.pharmacyId;
     if (!pricingStore.deletePharmacy(pharmacyId)) {
-      sendCrudNotFound(res, `Pharmacy not found: ${pharmacyId}`);
+      sendCrudNotFound(res, `Pharmacy not found: ${pharmacyId}`, "NOT_FOUND_PHARMACY");
       return;
     }
 
@@ -215,6 +219,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       res.status(400).json({
         error:
           parsedBody.error.issues[0]?.message ?? "Invalid pharmacy price payload",
+        code: "VALIDATION_INVALID_INPUT",
       });
       return;
     }
@@ -241,6 +246,7 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       res.status(400).json({
         error:
           parsedQuery.error.issues[0]?.message ?? "Invalid pharmacy query parameters",
+        code: "VALIDATION_INVALID_INPUT",
       });
       return;
     }
@@ -265,13 +271,20 @@ export function createPharmacyApp(options: PharmacyAppOptions) {
       );
     } catch (error) {
       pharmacyUnknownDrugTotal.inc({ drug });
-      res.status(404).json({ ok: false, reason: "NO_PRICES_FOUND" });
+      res.status(404).json({
+        error: `No pricing records found for drug: ${drug}`,
+        code: "NOT_FOUND_DRUG",
+      });
     }
   });
 
   app.use((err: any, _req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (err.type === "entity.too.large") {
-      return res.status(413).json({ error: "Request body too large", limit: err.limit });
+      return res.status(413).json({
+        error: "Request body too large",
+        code: "BODY_TOO_LARGE",
+        details: { limit: err.limit },
+      });
     }
     next(err);
   });


### PR DESCRIPTION
Closes #1467 
Closes #1468 
Closes #1469 

This Pull Request cleanes up database interface collisions, standardizes JSON error-response envelopes across the bill-audit-api and pharmacy-api services, and updates tests to verify the unified error contracts.


## Changed
- **`services/care-recipients/db.ts`** — Renamed the `CareRecipient` database interface to `CareRecipientEntity`.
- **`services/care-recipients/routes.ts`** — Updated type imports and endpoint cast to use `CareRecipientEntity`.
- **`services/bill-audit-api/server.ts`** — Standardized REST API error response shapes to the `{ error, code, details }` format.
- **`services/bill-audit-api/__tests__/server.integration.test.ts`** — Updated integration tests to assert the standardized error shape and added a 413 payload-too-large test case.
- **`services/bill-audit-api/__tests__/multipliers.test.ts`** — Mocked `fs.readFileSync` for `audit_thresholds.json` to allow testing environment variable overrides on Mac.
- **`services/pharmacy-api/server.ts`** — Standardized JSON error response shapes to `{ error, code, details }`.
- **`services/pharmacy-api/__tests__/routes.integration.test.ts`** — Updated the price-lookup 404 test to assert the new envelope.
- **`services/pharmacy-api/__tests__/server.test.ts`** — Updated the price-lookup 404 test to assert the new envelope.
