### PR TITLE
docs: fix #1476 components readme for ui subfolder

### DIFF
--- a/dashboard/src/components/README.md
+++ b/dashboard/src/components/README.md
@@ -7,6 +7,8 @@ Shared UI lives here, split between leaf primitives and per-tab compositions.
 - `primitives/` — small, reusable building blocks. No knowledge of the dashboard
   page layout or app state. Examples: `Card`, `Bar`, `Btn`, `TxLink`,
   `LiveRegion`, `Toast`, `ConfirmDialog`, `BillLineItemsVirtualized`.
+- `ui/` — generic, reusable UI kit/component library elements (e.g. vendored
+  or utility-based presentation blocks). Examples: `Skeleton`, `Toaster`.
 - `tabs/` — one file per tab on the main page (`overview-tab.tsx`,
   `medications-tab.tsx`, `bills-tab.tsx`, `policy-tab.tsx`, `wallet-tab.tsx`,
   `activity-tab.tsx`, `settings-tab.tsx`). Each is a presentational component
@@ -36,6 +38,9 @@ local UI state (a confirm-dialog open flag, a "show errors only" toggle, etc).
 - Tabs accept the data they render plus callbacks for any mutations. They never
   call `fetch` directly — that belongs in the hook so it can stay testable.
 - Primitives must not import from `tabs/` or `app/`. Tabs may import primitives.
+- `ui/` vs `primitives/`:
+  - Components in `ui/` are generic, off-the-shelf, or vendored layout elements (e.g. generic UI kit items like skeletons or notifications wrappers) that are completely application-agnostic.
+  - Components in `primitives/` are hand-rolled, custom-tailored building blocks specific to CareGuard's domain UI needs (e.g. `TxLink`, `ConfirmDialog`, `BillLineItemsVirtualized`). They are presentational and have no knowledge of the global application state, but represent our custom UI design language rather than generic UI framework elements. `primitives/` components may import from `ui/`.
 - Keep `app/page.tsx` under ~250 lines. If a tab grows large, split it further
   inside `tabs/<name>/`.
 


### PR DESCRIPTION
Closes #1476 

This Pull Request updates the caregiver dashboard component architecture documentation.

1.  The `ui/` subfolder to the **Layout** section of the README has been added to document generic, reusable, and vendored UI elements.
2.  Architectural boundaries under the **Conventions** section has been added to clearly distinguish between `ui/` and `primitives/` components:
    *   `ui/` components are completely application-agnostic, third-party or off-the-shelf component primitives (e.g., standard layout templates, generic skeleton loaders, or notification alert wrappers).
    *   `primitives/` components are custom presentational building blocks hand-rolled specifically for CareGuard's product UI domain (e.g. `TxLink`, `ConfirmDialog`, `BillLineItemsVirtualized`), which may compose generic `ui/` components.

This maintains a clean code architecture by establishing a clear separation of concerns between vendor kit presentation wrappers and application-specific domain components.

## What changed
*   **[`dashboard/src/components/README.md`](file:///Users/favoureze/careguard/dashboard/src/components/README.md)** — Documented the `ui/` subfolder under Layout and added convention boundaries clarifying `ui/` vs `primitives/`.
