### PR TITLE
fix: upgrade dependencies zod typescript jest-dom jsdom

### DIFF
--- a/agent/tools.ts
+++ b/agent/tools.ts
@@ -747,7 +747,7 @@ export const SpendingPolicySchema = z
       .object({
         email: z.boolean(),
         sms: z.boolean(),
-        emailAddress: z.string().email().optional(),
+        emailAddress: z.email().optional(),
         phoneNumber: z.string().optional(),
       })
       .optional(),

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -29,7 +29,7 @@
     "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
     "@types/node": "^20",
@@ -40,10 +40,10 @@
     "@vitest/coverage-v8": "^3.2.7",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
-    "jsdom": "^25.0.0",
+    "jsdom": "^26.0.0",
     "pdf-parse": "^1.1.1",
     "tailwindcss": "^4",
-    "typescript": "5.8.3",
+    "typescript": "^5.8.3",
     "vitest": "^3.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,11 +69,11 @@
     "sonner": "^2.0.7",
     "tailwindcss": "^4.3.1",
     "tsx": "^4.21.0",
-    "zod": "^3.25.76"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
     "@types/cors": "^2.8.19",
@@ -85,12 +85,12 @@
     "@vitest/coverage-v8": "^3.2.7",
     "concurrently": "^9.2.1",
     "ioredis-mock": "^8.13.1",
-    "jsdom": "^25.0.0",
+    "jsdom": "^26.0.0",
     "pino-pretty": "^13.1.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "supertest": "^7.2.2",
-    "typescript": "5.8.3",
+    "typescript": "^5.8.3",
     "vitest": "^3.2.7"
   },
   "overrides": {


### PR DESCRIPTION
Closes #1379
Closes #1380
Closes #1382
Closes #1381

Upgrade zod from ^3.25.76 to ^4.0.0 (both package.json files)
 Update zod v3 email validation pattern in agent/tools.ts from z.string().email() to z.email()
Upgrade TypeScript from exact 5.8.3 to ^5.8.3 (both root and dashboard package.json)
 Switch from exact pinning to caret to receive future 5.x bugfixes
Upgrade @testing-library/jest-dom from ^6.4.0 to ^6.6.3 (both package.json files)
Upgrade jsdom from ^25.0.0 to ^26.0.0 (both package.json files)
