### PR TITLE
docs: add caregiver guides and pharmacy API example

### DIFF
--- a/docs/api-examples/pharmacy-compare.md
+++ b/docs/api-examples/pharmacy-compare.md
@@ -1,0 +1,169 @@
+# Pharmacy Price Comparison — API Example (`GET /pharmacy/compare`)
+
+This guide shows a complete curl request/response cycle for the pharmacy price-comparison endpoint, including the x402 payment header flow.
+
+---
+
+## Overview
+
+The `GET /pharmacy/compare` endpoint compares medication prices across partnered pharmacies. It costs **$0.002 USDC** per request via the x402 protocol on Stellar.
+
+> For general x402 setup, see [docs/setup/x402.md](../setup/x402.md). For a conceptual overview of x402 payments, see [paying-with-x402.md](paying-with-x402.md).
+
+---
+
+## Parameters
+
+| Parameter | Required | Type | Description |
+|---|---|---|---|
+| `drug` | Yes | `string` (1–80 chars) | Medication name to compare |
+| `dosage` | No | `string` (1–80 chars) | Dosage string (e.g. `10mg`) |
+| `zip` | No | `string` (5 digits) | 5-digit ZIP code for distance adjustments |
+
+---
+
+## Step 1: Initial Request (no payment)
+
+```bash
+curl -i "http://localhost:3000/pharmacy/compare?drug=Lisinopril&dosage=10mg"
+```
+
+The server responds with **402 Payment Required** and a challenge body:
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+
+{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "stellar:testnet",
+      "payTo": "GA...RECIPIENT_STELLAR_ADDRESS",
+      "price": "$0.002",
+      "asset": "USDC"
+    }
+  ],
+  "error": "Payment required to access /pharmacy/compare"
+}
+```
+
+The challenge tells you:
+- Which Stellar network to use
+- The payee address
+- The exact amount and asset to pay
+
+---
+
+## Step 2: Retry with `X-Payment` Header
+
+After constructing a signed Stellar authorization entry (see [paying-with-x402.md](paying-with-x402.md) for details), attach it in the `X-Payment` header:
+
+```bash
+curl -i "http://localhost:3000/pharmacy/compare?drug=Lisinopril&dosage=10mg" \
+  -H "X-Payment: <BASE64_OR_JSON_PAYMENT_PAYLOAD>"
+```
+
+---
+
+## Step 3: Successful Response
+
+On success, the server returns **200 OK** with pharmacy price data:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "drug": "lisinopril",
+  "dosage": "10mg",
+  "prices": [
+    {
+      "pharmacyId": "cvs-phoenix-01",
+      "pharmacyName": "CVS Pharmacy",
+      "price": 12.49,
+      "inStock": true
+    },
+    {
+      "pharmacyId": "walgreens-downtown-02",
+      "pharmacyName": "Walgreens",
+      "price": 14.25,
+      "inStock": true
+    },
+    {
+      "pharmacyId": "costco-riverside-03",
+      "pharmacyName": "Costco Pharmacy",
+      "price": 9.99,
+      "inStock": true
+    }
+  ]
+}
+```
+
+Results are sorted from lowest to highest price.
+
+---
+
+## Error Responses
+
+### `400 Bad Request` — Missing drug parameter
+
+```bash
+curl -i "http://localhost:3000/pharmacy/compare?dosage=10mg"
+```
+
+```json
+{
+  "error": "drug is required",
+  "code": "VALIDATION_MISSING_FIELD"
+}
+```
+
+### `404 Not Found` — Drug not found
+
+```json
+{
+  "error": "Drug not found: nonexistentdrug",
+  "code": "NOT_FOUND_DRUG"
+}
+```
+
+### `429 Too Many Requests`
+
+```json
+{
+  "error": "Rate limit exceeded",
+  "code": "RATE_LIMIT_EXCEEDED"
+}
+```
+
+Check the `Retry-After` header and back off before retrying.
+
+---
+
+## SDK Alternative
+
+Instead of manually handling the 402 challenge and retry, use the `@x402/fetch` wrapper:
+
+```typescript
+import { wrapFetchWithX402 } from "@x402/fetch";
+import { Keypair } from "@stellar/stellar-sdk";
+
+const keypair = Keypair.fromSecret(process.env.CLIENT_STELLAR_SECRET!);
+const x402Fetch = wrapFetchWithX402(fetch, { signer: keypair });
+
+const response = await x402Fetch(
+  "http://localhost:3000/pharmacy/compare?drug=Lisinopril&dosage=10mg"
+);
+const data = await response.json();
+console.log(data.prices);
+```
+
+---
+
+## Related reading
+
+- [Paying with x402](paying-with-x402.md) — full x402 payment flow explanation
+- [x402 Setup](../setup/x402.md) — server-side facilitator configuration
+- [OpenAPI Spec](../openapi.yml) — full API schema

--- a/docs/guides/agent-pause-and-resume.md
+++ b/docs/guides/agent-pause-and-resume.md
@@ -1,0 +1,119 @@
+# Agent Pause and Resume — A Guide for Caregivers
+
+This guide explains what happens when the CareGuard agent pauses due to low wallet balance, what you should do, and how to get it running again.
+
+---
+
+## What the agent does
+
+The CareGuard agent automatically compares medication prices, audits bills, checks drug interactions, and makes payments on your behalf. To do this, it needs funds in its Stellar wallet.
+
+When the wallet balance drops too low, the agent **pauses** to avoid failed transactions. It will not attempt any payments or API queries until you top up the wallet and resume it.
+
+---
+
+## The low-balance banner
+
+When the agent pauses, a **red banner** appears at the top of the dashboard:
+
+> **Agent paused — low USDC balance.**
+> USDC: 0.00 · XLM: 0.00. Fund the agent wallet with testnet USDC, then resume the agent.
+
+Or:
+
+> **Agent paused — low XLM balance.**
+> USDC: 5.00 · XLM: 0.00. Fund the agent wallet with XLM (for transaction fees), then resume the agent.
+
+The banner tells you:
+
+1. **Which balance is low** — USDC (for payments) or XLM (for transaction fees)
+2. **Current balances** — so you can see how much is there
+3. **What to do** — fund the wallet, then click **Resume agent**
+
+---
+
+## What causes the pause
+
+The agent pauses when either of these drops below a threshold:
+
+| Balance | What it covers | Pause trigger |
+|---|---|---|
+| **USDC** | Medication orders, bill payments, API query fees | Balance too low to cover the next expected transaction |
+| **XLM** | Stellar network transaction fees | Balance too low to pay Stellar transaction fees |
+
+---
+
+## What the agent stops doing during a pause
+
+When paused, the agent will **not**:
+
+- Compare medication prices
+- Audit medical bills
+- Check drug interactions
+- Place medication orders
+- Make bill payments
+- Process any x402 API queries
+
+The agent remains connected to the dashboard and will resume automatically once you click **Resume agent** after topping up.
+
+---
+
+## How to top up the wallet
+
+### Adding USDC
+
+1. Copy the agent's wallet address from the **Wallet tab** in the dashboard
+2. Go to the [Circle USDC Faucet](https://faucet.circle.com)
+3. Paste the wallet address and request testnet USDC
+4. Wait a moment for the funds to appear
+
+### Adding XLM
+
+XLM is needed for Stellar transaction fees. You can get testnet XLM from the [Stellar Laboratory Friendbot](https://laboratory.stellar.org/#account/create?network=testnet).
+
+1. Open the Friendbot
+2. Paste the agent's wallet address
+3. Click **Get Test Network Lumens**
+
+---
+
+## How to resume the agent
+
+After topping up the wallet:
+
+1. Confirm the new balance on the **Wallet tab**
+2. Click the **Resume agent** button on the red banner
+3. The banner disappears and the agent resumes normal operation
+
+You do not need to restart the dashboard or the server.
+
+---
+
+## Checking wallet balances
+
+The **Wallet tab** shows:
+
+- **USDC Balance** — funds for payments and API queries
+- **XLM Balance** — funds for Stellar transaction fees
+- **Wallet Address** — the agent's Stellar account address
+- **Network** — which Stellar network you are on (testnet or mainnet)
+
+If the wallet tab shows an error loading balances, click the **Retry** button.
+
+---
+
+## Tips
+
+- **Check the Wallet tab regularly** — especially after the agent has been running for a while
+- **Top up proactively** — don't wait for the pause banner; fund the wallet before it runs out
+- **Use testnet faucets** — in the default setup, you are not using real money. See [Testnet Explained](testnet-explained.md) for details
+- **Monitor the Activity tab** — it shows all payments the agent has made, so you can predict when you'll need to top up
+
+---
+
+## Related reading
+
+- [Wallet Tab Guide](wallet-tab.md) — understanding the wallet display
+- [Testnet Explained](testnet-explained.md) — why CareGuard uses testnet money
+- [Getting Started](getting-started-caregiver.md) — full setup walkthrough
+- [Spending Policy](spending-policy-for-caregivers.md) — configuring spending limits

--- a/docs/guides/care-recipient-profile.md
+++ b/docs/guides/care-recipient-profile.md
@@ -1,0 +1,118 @@
+# Care Recipient Profile — A Guide for Caregivers
+
+This guide explains the profile fields for a care recipient, which fields are required, and how to manage the profile after initial setup.
+
+---
+
+## What is a care recipient profile
+
+A care recipient is the person you are managing healthcare for using CareGuard. The profile stores key information about them that the agent uses for medication comparisons, bill audits, and other tasks.
+
+---
+
+## Profile fields
+
+| Field | Required | Description |
+|---|---|---|
+| **name** | Yes | The care recipient's full name. Used to identify them in the dashboard and in agent logs. |
+| **age** | No | The care recipient's age. Can be used by the agent for age-related health considerations. |
+| **medications** | No | A list of medications the care recipient currently takes. The agent uses this for drug interaction checks and medication price comparisons. |
+| **primary doctor** | No | The name and location of the care recipient's primary care physician (e.g. "Dr. Chen, General Hospital"). |
+| **insurance** | No | The care recipient's insurance provider and plan (e.g. "Medicare Part D"). |
+
+---
+
+## Creating a care recipient profile
+
+Profiles are created when you first set up CareGuard. The system comes with a default profile for demonstration purposes.
+
+To create a new care recipient profile, use the CareGuard API:
+
+```bash
+curl -X POST http://localhost:3000/recipients \
+  -H "Authorization: Bearer YOUR_CAREGIVER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Maria Lopez",
+    "age": 72,
+    "medications": ["Metformin", "Lisinopril"],
+    "primary_doctor": "Dr. Smith, City Clinic",
+    "insurance": "Medicare Advantage"
+  }'
+```
+
+Only **name** is required. All other fields are optional.
+
+### Creating a profile with only a name
+
+```bash
+curl -X POST http://localhost:3000/recipients \
+  -H "Authorization: Bearer YOUR_CAREGIVER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "James Wilson"
+  }'
+```
+
+---
+
+## Viewing care recipient profiles
+
+To list all care recipient profiles:
+
+```bash
+curl http://localhost:3000/recipients \
+  -H "Authorization: Bearer YOUR_CAREGIVER_TOKEN"
+```
+
+This returns an array of all profiles in the system.
+
+---
+
+## Editing a care recipient profile
+
+> **Important:** There is currently **no update endpoint** for care recipient profiles. Once a profile is created, the following fields **cannot be changed** through the API:
+
+- **name** — the care recipient's name is permanent after creation
+- **age** — cannot be updated after creation
+- **medications** — the medication list is fixed at creation time
+- **primary doctor** — cannot be updated after creation
+- **insurance** — cannot be updated after creation
+
+If you need to change any of these fields, you would need to:
+
+1. Create a new care recipient profile with the correct information
+2. Use the new profile going forward
+
+> **Note:** This is a known limitation. A `PUT` or `PATCH` endpoint for updating profiles may be added in a future release.
+
+---
+
+## How the profile is used
+
+The agent uses care recipient profile information in several ways:
+
+| Field | How it is used |
+|---|---|
+| **name** | Displayed in the dashboard and transaction logs |
+| **medications** | Used for drug interaction checks and medication price comparisons |
+| **primary_doctor** | May be referenced in bill audit reports |
+| **insurance** | May be used for insurance-related claims processing |
+
+---
+
+## Tips
+
+- **Add all current medications** when creating the profile — this ensures drug interaction checks are accurate
+- **Keep the medication list up to date** — if you need to change medications, create a new profile
+- **Include the insurance provider** — this helps the agent understand coverage context
+- **Name format** — use the care recipient's common name so it is easy to identify in the dashboard
+
+---
+
+## Related reading
+
+- [Getting Started](getting-started-caregiver.md) — full setup walkthrough
+- [Spending Policy](spending-policy-for-caregivers.md) — configuring spending limits
+- [Wallet Tab](wallet-tab.md) — understanding the agent's wallet
+- [FAQ](faq.md) — common questions and answers

--- a/docs/guides/wallet-tab.md
+++ b/docs/guides/wallet-tab.md
@@ -1,0 +1,117 @@
+# Wallet Tab — A Guide for Caregivers
+
+This guide explains what you see on the **Wallet tab** of the CareGuard dashboard: the balance display, the wallet address, and how to fund the agent's wallet.
+
+---
+
+## What the Wallet tab shows
+
+The Wallet tab displays the agent's Stellar wallet information. It is organized into three sections:
+
+### 1. Balances
+
+Two cards at the top show:
+
+| Card | What it shows |
+|---|---|
+| **USDC Balance** | The amount of USDC (a digital dollar) in the agent's wallet. This is the money the agent uses to pay for medications, bills, and API queries. |
+| **XLM Balance** | The amount of XLM (Stellar's native token) in the agent's wallet. XLM is used to pay Stellar network transaction fees. |
+
+### 2. Wallet Details
+
+Below the balances:
+
+| Field | What it means |
+|---|---|
+| **Wallet Address** | The agent's Stellar account address. You can copy this and use it to send funds to the wallet. |
+| **Network** | Which Stellar network the agent is on — either "Stellar Testnet" or "Stellar Mainnet". |
+| **LLM Provider** | The AI language model the agent uses for its decisions. |
+
+### 3. Action Buttons
+
+| Button | What it does |
+|---|---|
+| **View on Explorer** | Opens the agent's account on the Stellar blockchain explorer so you can see all transactions |
+| **Fund Wallet** | Opens the Circle USDC faucet (testnet) so you can add funds |
+
+---
+
+## What the balance means
+
+### USDC Balance
+
+This is the agent's spending money. The agent uses USDC to:
+
+- Pay for medication orders
+- Pay for medical bills
+- Pay for API queries (pharmacy comparisons, bill audits, drug interaction checks)
+
+When the USDC balance drops too low, the agent pauses and you see a red **low-balance banner**. See [Agent Pause and Resume](agent-pause-and-resume.md) for what to do.
+
+### XLM Balance
+
+XLM is used for Stellar network transaction fees — the small cost of sending any transaction on Stellar. Even if you have plenty of USDC, the agent needs XLM to actually submit transactions.
+
+If the XLM balance drops too low, the agent pauses even though it may still have USDC.
+
+---
+
+## Testnet vs. Mainnet
+
+In the default setup, CareGuard runs on **Stellar Testnet**. This means:
+
+- The USDC and XLM in the wallet are **testnet tokens** — they have no real-world value
+- You can get free testnet funds from faucets
+- All transactions are on a test network, not the live Stellar blockchain
+
+If your CareGuard instance is configured for **Stellar Mainnet** (via `NEXT_PUBLIC_STELLAR_NETWORK=public`), the balances represent real funds. See [Testnet Explained](testnet-explained.md) for more details.
+
+---
+
+## How to fund the wallet
+
+### Adding USDC (testnet)
+
+1. Copy the agent's wallet address from the Wallet tab
+2. Go to [faucet.circle.com](https://faucet.circle.com)
+3. Paste the address and request testnet USDC
+4. The funds appear in the wallet within a few seconds
+
+### Adding XLM (testnet)
+
+1. Copy the agent's wallet address from the Wallet tab
+2. Go to the [Stellar Laboratory Friendbot](https://laboratory.stellar.org/#account/create?network=testnet)
+3. Paste the address and request testnet lumens
+4. The funds appear within a few seconds
+
+---
+
+## How payments work
+
+The Wallet tab includes a section explaining the three payment methods the agent uses:
+
+| Method | What it pays for | How it works |
+|---|---|---|
+| **x402** | API queries (pharmacy prices, bill audits, drug interactions) | Per-request micropayment on Stellar using the x402 protocol |
+| **MPP** | Medication orders | The agent signs a Stellar smart contract transfer; the pharmacy broadcasts the transaction |
+| **USDC** | Bill payments | Direct Stellar USDC transfer from the agent's wallet |
+
+You do not need to manage these payment methods separately — the agent handles all of this automatically.
+
+---
+
+## If the wallet tab shows an error
+
+If the balance cards show a loading error:
+
+1. Click the **Retry** button to fetch the balance again
+2. If the error persists, check that the server is running and the wallet address is configured correctly
+
+---
+
+## Related reading
+
+- [Agent Pause and Resume](agent-pause-and-resume.md) — what to do when the agent pauses
+- [Testnet Explained](testnet-explained.md) — why CareGuard uses testnet money
+- [Paying with x402](../api-examples/paying-with-x402.md) — how the x402 payment protocol works
+- [Getting Started](getting-started-caregiver.md) — full setup walkthrough

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -199,6 +199,7 @@ paths:
   /pharmacy/compare:
     get:
       summary: 'Compare pharmacy prices for a drug'
+      description: 'Returns pharmacy price comparison results for a given medication. See docs/api-examples/pharmacy-compare.md for a full curl example including the x402 payment flow.'
       tags:
         - 'Pharmacy'
       security:

--- a/docs/setup/x402.md
+++ b/docs/setup/x402.md
@@ -16,3 +16,8 @@ CareGuard uses x402 to charge for certain API routes (for example, pharmacy comp
 
 - If `STELLAR_NETWORK=public` and `OZ_FACILITATOR_API_KEY` is missing, the server exits with a clear error message.
 
+## API Examples
+
+- [Pharmacy Compare](../api-examples/pharmacy-compare.md) — full curl example for `GET /pharmacy/compare`
+- [Paying with x402](../api-examples/paying-with-x402.md) — conceptual overview of x402 payments
+


### PR DESCRIPTION
Adds caregiver-facing documentation for four issues:

**New guides:**
- `docs/guides/care-recipient-profile.md` — profile fields, creation, and edit limitations
- `docs/guides/wallet-tab.md` — balance display, wallet address, and funding instructions
- `docs/guides/agent-pause-and-resume.md` — low-balance pause behavior and resume steps

**New API example:**
- `docs/api-examples/pharmacy-compare.md` — full curl example with x402 payment flow

**Updated docs:**
- `docs/openapi.yml` — linked pharmacy-compare.md from /pharmacy/compare description
- `docs/setup/x402.md` — added API examples section with links to new docs

Closes #1401
Closes #1402
Closes #1413
Closes #1414