### PR TITLE
docs: clarify redactString vs redactPII scope in shared/redact.ts

### DIFF
--- a/shared/redact.ts
+++ b/shared/redact.ts
@@ -91,10 +91,30 @@ export function registerKnownNames(names: string[]): void {
 // Drug specifics: capitalized drug name followed by optional dosage (e.g. "Lisinopril 10mg", "Metformin 500mg")
 const DRUG_SPECIFIC_RE = /\b[A-Z][a-z]+ \d+\s*mg\b/gi;
 
+/**
+ * Strips secrets from a string: Stellar secret seeds (`S...`) and bearer/JWT
+ * tokens. Does not touch patient names or drug specifics — use {@link redactPII}
+ * for that.
+ *
+ * Use this (or `redact()`, which calls it recursively) on any value that may
+ * contain credentials but is not known to carry free-text task/PHI content,
+ * e.g. HTTP headers, request bodies, generic error payloads.
+ */
 export function redactString(value: string): string {
   return value.replace(STELLAR_SECRET_RE, REDACTED).replace(BEARER_RE, `Bearer ${REDACTED}`);
 }
 
+/**
+ * Strips PII from a string: known patient/caregiver names (registered via
+ * {@link registerKnownNames}) and drug-plus-dosage mentions (e.g.
+ * "Lisinopril 10mg"). Does not touch secrets — use {@link redactString} (or
+ * `redact()`) for that.
+ *
+ * Call this explicitly at sites that log free-text content known to
+ * originate from a patient/caregiver task description, e.g. the raw `task`
+ * string logged by the agent runner. It is deliberately *not* part of the
+ * generic `redact()` recursion — see the comment there for why.
+ */
 export function redactPII(value: string): string {
   return value
     .replace(getPatientNameRegex(), "[PATIENT NAME]")
@@ -105,6 +125,22 @@ export function hashTask(task: string): string {
   return createHash("sha256").update(task, "utf-8").digest("hex");
 }
 
+/**
+ * Recursively walks an object/array/string and strips secrets (via
+ * {@link redactString}) and known secret-named fields (via
+ * `SECRET_FIELD_NAMES`). Intended as the generic, safe-by-default pass for
+ * arbitrary payloads (e.g. Sentry events) whose shape and contents are not
+ * known ahead of time.
+ *
+ * Intentionally does NOT call {@link redactPII} on string values. PII
+ * redaction depends on `registerKnownNames()` having been populated with the
+ * current patient/caregiver names, which is not guaranteed for every payload
+ * flowing through this generic path, and running it unconditionally here
+ * would give a false sense of safety for names it doesn't yet know about.
+ * Call sites that log a specific free-text field known to contain patient
+ * task text (e.g. `task`) must call {@link redactPII} on that field
+ * explicitly instead of relying on this function to catch it.
+ */
 export function redact<T>(value: T, depth = 0): T {
   if (depth > 8) return value;
   if (value == null) return value;


### PR DESCRIPTION
## Summary

`shared/redact.ts` exports `redactString` and `redactPII` as separate, similarly-named functions with no JSDoc explaining the split. The generic `redact()` wrapper only calls `redactString` on string values and silently skips `redactPII`, which is easy to misuse without reading the source.

This PR documents the intended usage without changing any regex patterns or redaction behavior:

- Added JSDoc to `redactString` explaining it strips Stellar secret seeds and bearer/JWT tokens, and when to use it.
- Added JSDoc to `redactPII` explaining it strips known patient/caregiver names and drug-plus-dosage mentions, and when to use it.
- Added a code comment inside `redact()` explaining why it intentionally does not call `redactPII` on the default recursive path: PII redaction depends on `registerKnownNames()` having been populated with the current patient/caregiver names, which is not guaranteed for arbitrary payloads flowing through the generic path (e.g. Sentry events). Call sites that log a specific free-text field known to contain patient task text (`agent/runner.ts`, `agent/server.ts`) call `redactPII` explicitly on that field instead.

## Why document rather than fix

Looking at the actual call sites, the split is intentional: `redact()` is used as a blanket pass over arbitrary Sentry payloads (headers, contexts, breadcrumbs) whose shape isn't known ahead of time, while `redactPII` is called explicitly only where the field is known to hold a patient/caregiver task string. Silently folding `redactPII` into the generic recursive path would apply an expensive regex built from `registerKnownNames()` everywhere, without actually broadening PII coverage beyond registered names. Per the acceptance criteria, documenting the current behavior as intentional (with no change to redaction behavior) was the appropriate fix here.

## Test plan

- [x] `npx vitest run shared/__tests__/redact.test.ts` — all 20 existing tests pass unmodified
- [x] No regex patterns changed; diff is JSDoc/comments only

closes #1477