### PR TITLE
chore: remove orphaned agent/.eslintrc.json

### DIFF
--- a/agent/.eslintrc.json
+++ b/agent/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "no-console": "error"
-  }
-}


### PR DESCRIPTION
## Summary

`agent/.eslintrc.json` sets `no-console: error`, but nothing invokes it:

- The root `package.json` `lint` script runs `tsc --noEmit`, not ESLint.
- The root `package.json` has no `eslint` dependency at all — only `dashboard/package.json` has ESLint 9 with flat config.
- The legacy `.eslintrc.json` format is incompatible with ESLint 9's flat config anyway, so even if ESLint were run at the root, this file's format wouldn't be picked up.

This is dead configuration. Since the root project has no ESLint setup to migrate this into, and no CI workflow or documentation references the file, the correct fix is to remove it rather than add a whole new ESLint setup at the root just to keep one rule alive.

## Changes

- Deleted `agent/.eslintrc.json`.

## Verification

- `grep -r "\.eslintrc"` across the repo returns no other references.
- No `.github/workflows` file references `agent/.eslintrc.json` or ESLint at the root.
- README already correctly scopes ESLint to the dashboard only (`Dashboard additionally runs ESLint (cd dashboard && npm run lint)`), so no doc changes were needed.

## Test plan

- [x] Confirmed no CI workflow, README, or CONTRIBUTING doc references `agent/.eslintrc.json`
- [x] Confirmed root `package.json` has no `eslint` devDependency

closes #1470