### PR TITLE
docs: add local testing helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ shared/__tests__/test-data-*/
 # Generated PDF / dispute letter artefacts from local runs
 *.pdf
 generated/
+services/bill-audit-api/fixtures/generated/
 
 # TypeScript build output and incremental compile cache
 *.tsbuildinfo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,28 @@ policy), label-cardinality rules, and includes a checklist for new metrics.
 Every new metric must also be added to
 [`docs/observability/metrics-catalog.md`](docs/observability/metrics-catalog.md).
 
+## Local Lock Troubleshooting
+
+CareGuard uses `proper-lockfile` around local JSON state writes in `server.ts`,
+`shared/audit-log.ts`, and `services/pharmacy-payment/server.ts`. Those locks
+prevent concurrent requests from corrupting data under `data/`, but a killed
+dev server can leave a stale `*.lock` directory behind.
+
+If local requests hang or fail with lock-acquisition errors, inspect stale locks:
+
+```bash
+npm run clear:stale-locks
+```
+
+After confirming the listed paths belong to your local checkout, remove them:
+
+```bash
+npm run clear:stale-locks -- --yes
+```
+
+Use `--root=<path>` for a different data directory and
+`--older-than-minutes=<n>` to adjust the stale-lock threshold.
+
 ## Smart Contract Guidelines (Stellar/Soroban)
 
 If contributing to on-chain components:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -129,6 +129,22 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 - Set medication and bill category budgets
 - Set the caregiver approval threshold
 
+### Testing Multi-Pharmacy Routing Locally
+
+`npm run setup` already creates `PHARMACY_2_SECRET_KEY` and
+`PHARMACY_2_PUBLIC_KEY`; no extra wallet setup is needed. To exercise the
+alternate routing path, set this in `.env`:
+
+```bash
+MULTI_PHARMACY_MODE=true
+```
+
+Restart `npm run dev`, open the dashboard, and run **Compare Medication
+Prices** from the Overview tab. The agent order flow should route eligible
+medication payments to the second pharmacy wallet. The routing branch lives in
+`services/drug-interaction-api` and the unified server's multi-pharmacy payment
+selection.
+
 ### Activity Tab
 - Terminal-style agent log showing every tool call
 - Transaction table with clickable Stellar Explorer links
@@ -195,6 +211,7 @@ for b in d['balances']:
 | Groq 429 rate limit | Wait for reset, or switch to a different model/provider |
 | Dashboard can't connect | Ensure backend services are running (`npm run dev`) |
 | Port already in use | Kill existing processes on the ports (see below) |
+| Local lock contention or stale `.lock` directory | Run `npm run clear:stale-locks` to inspect, then `npm run clear:stale-locks -- --yes` to remove stale `proper-lockfile` locks |
 
 For symptoms beyond setup-time issues — stuck agent spinner, repeated 402s,
 blank wallet balance, dashboard "Disconnected", startup hangs on Horizon —

--- a/docs/SPENDING-POLICY.md
+++ b/docs/SPENDING-POLICY.md
@@ -39,6 +39,20 @@ The default is `America/Phoenix` because it matches the CareGuard caregiver pers
 
 `agent/tz.ts` exports `getLocalDateStr(tz, date?)` which uses `Intl.DateTimeFormat('en-CA', { timeZone: tz })` to format a date as `YYYY-MM-DD` in the given timezone. `checkSpendingPolicy` in `agent/tools.ts` calls this to determine both "today" and the date of each past transaction before comparing.
 
+### Local reset simulation
+
+Use the helper script to verify daily reset behavior without changing your
+system clock:
+
+```bash
+npm run simulate:spending-reset -- --timezone=America/New_York --recipient=rosa
+```
+
+The script reads local spending state from `data/recipients/<recipient>/spending.json`
+or the legacy `data/spending.json`, simulates one minute before and after the
+next local midnight, and prints the before/after spending totals. Pass
+`--now=<ISO timestamp>` to reproduce a specific boundary.
+
 ## Platform Cap (`MAX_SINGLE_TX_USDC`)
 
 A deployment-level ceiling sits **above** all caregiver-controlled policy limits.

--- a/docs/services/bill-audit.md
+++ b/docs/services/bill-audit.md
@@ -4,6 +4,18 @@
 
 The Bill Audit API (`services/bill-audit-api/server.ts`) audits medical bill line items for overcharges, duplicate charges, and upcoding by comparing charged amounts against CMS Medicare fair-market rates.
 
+## Local sample PDFs
+
+Generate disposable PDF fixtures for the dashboard upload flow with:
+
+```bash
+npm run generate:sample-bill -- --duplicate --upcoded --overcharge
+```
+
+Files are written to `services/bill-audit-api/fixtures/generated/`, which is
+gitignored for local test data. Supported flags are `--duplicate`,
+`--upcoded`, `--overcharge`, `--patient=<name>`, and `--out=<directory>`.
+
 ## Fair Market Rate Lookup
 
 The `auditBill` function looks up each line item's CPT code in `FAIR_MARKET_RATES`. The result is:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "load:pharmacy-order": "k6 run load/pharmacy-order.js",
     "load:agent-stream": "k6 run load/agent-stream.js",
     "check:env-vars": "tsx scripts/check-env-vars.ts",
-    "check:vitest-lock": "node scripts/check-vitest-version-lock.mjs"
+    "check:vitest-lock": "node scripts/check-vitest-version-lock.mjs",
+    "simulate:spending-reset": "node --import tsx scripts/simulate-spending-reset.ts",
+    "generate:sample-bill": "node --import tsx scripts/generate-sample-bill.ts",
+    "clear:stale-locks": "node --import tsx scripts/clear-stale-locks.ts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/clear-stale-locks.ts
+++ b/scripts/clear-stale-locks.ts
@@ -1,0 +1,42 @@
+import { readdirSync, rmSync, statSync } from "fs";
+import path from "path";
+
+function argValue(name: string, fallback: string) {
+  const prefix = `--${name}=`;
+  return (
+    process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ??
+    fallback
+  );
+}
+
+const root = path.resolve(argValue("root", "data"));
+const olderThanMinutes = Number(argValue("older-than-minutes", "30"));
+const dryRun = !process.argv.includes("--yes");
+const cutoff = Date.now() - olderThanMinutes * 60_000;
+
+function walk(dir: string): string[] {
+  let entries: string[] = [];
+  for (const name of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, name.name);
+    if (name.isDirectory()) {
+      entries.push(fullPath, ...walk(fullPath));
+    }
+  }
+  return entries;
+}
+
+const candidates = walk(root).filter((entry) => entry.endsWith(".lock"));
+const stale = candidates.filter((entry) => statSync(entry).mtimeMs < cutoff);
+
+for (const entry of stale) {
+  console.log(`${dryRun ? "would remove" : "removing"} ${entry}`);
+  if (!dryRun) {
+    rmSync(entry, { recursive: true, force: true });
+  }
+}
+
+if (stale.length === 0) {
+  console.log(`No stale proper-lockfile locks older than ${olderThanMinutes} minutes under ${root}`);
+} else if (dryRun) {
+  console.log("Dry run only. Re-run with --yes to remove these stale lock directories.");
+}

--- a/scripts/generate-sample-bill.ts
+++ b/scripts/generate-sample-bill.ts
@@ -1,0 +1,106 @@
+import { mkdirSync } from "fs";
+import path from "path";
+import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
+
+interface LineItem {
+  description: string;
+  cptCode: string;
+  quantity: number;
+  amount: number;
+}
+
+function hasFlag(name: string) {
+  return process.argv.includes(`--${name}`);
+}
+
+function argValue(name: string, fallback: string) {
+  const prefix = `--${name}=`;
+  return (
+    process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ??
+    fallback
+  );
+}
+
+const outputDir = path.resolve(
+  argValue("out", "services/bill-audit-api/fixtures/generated"),
+);
+const patient = argValue("patient", "Rosa Garcia");
+const includeDuplicate = hasFlag("duplicate");
+const includeUpcoded = hasFlag("upcoded");
+const includeOvercharge = hasFlag("overcharge");
+
+const lineItems: LineItem[] = [
+  {
+    description: "Office visit, established patient",
+    cptCode: "99213",
+    quantity: 1,
+    amount: includeOvercharge ? 325 : 130,
+  },
+  {
+    description: "Comprehensive metabolic panel",
+    cptCode: "80053",
+    quantity: 1,
+    amount: 95,
+  },
+  {
+    description: "Complete blood count",
+    cptCode: "85025",
+    quantity: 1,
+    amount: 45,
+  },
+];
+
+if (includeDuplicate) {
+  lineItems.push({
+    description: "Complete blood count",
+    cptCode: "85025",
+    quantity: 1,
+    amount: 45,
+  });
+}
+
+if (includeUpcoded) {
+  lineItems.push({
+    description: "Office visit, high complexity",
+    cptCode: "99215",
+    quantity: 1,
+    amount: 1_250,
+  });
+}
+
+mkdirSync(outputDir, { recursive: true });
+
+const doc = new jsPDF();
+doc.setFontSize(18);
+doc.text("CareGuard Sample Medical Bill", 14, 20);
+doc.setFontSize(11);
+doc.text(`Patient: ${patient}`, 14, 32);
+doc.text("Facility: General Hospital", 14, 40);
+doc.text("Date of service: 2026-03-15", 14, 48);
+
+autoTable(doc, {
+  startY: 58,
+  head: [["Description", "CPT", "Qty", "Charge"]],
+  body: lineItems.map((item) => [
+    item.description,
+    item.cptCode,
+    String(item.quantity),
+    `$${item.amount.toFixed(2)}`,
+  ]),
+});
+
+const total = lineItems.reduce((sum, item) => sum + item.amount * item.quantity, 0);
+const finalY = (doc as any).lastAutoTable?.finalY ?? 58;
+doc.text(`Total charged: $${total.toFixed(2)}`, 14, finalY + 12);
+
+const traits = [
+  includeDuplicate ? "duplicate" : null,
+  includeUpcoded ? "upcoded" : null,
+  includeOvercharge ? "overcharge" : null,
+].filter(Boolean);
+const fileName = `sample-bill-${traits.join("-") || "clean"}.pdf`;
+const outputPath = path.join(outputDir, fileName);
+doc.save(outputPath);
+
+console.log(outputPath);

--- a/scripts/simulate-spending-reset.ts
+++ b/scripts/simulate-spending-reset.ts
@@ -1,0 +1,87 @@
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+import {
+  getLocalDateStr,
+  getLocalDayBounds,
+} from "../agent/tz.ts";
+
+interface Transaction {
+  amount?: number;
+  category?: string;
+  timestamp?: string;
+}
+
+interface SpendingState {
+  transactions?: Transaction[];
+}
+
+function argValue(name: string, fallback: string) {
+  const prefix = `--${name}=`;
+  return (
+    process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ??
+    fallback
+  );
+}
+
+function loadSpendingState(recipientId: string, dataDir: string): SpendingState {
+  const recipientPath = path.join(
+    dataDir,
+    "recipients",
+    recipientId,
+    "spending.json",
+  );
+  const legacyPath = path.join(dataDir, "spending.json");
+  const filePath = existsSync(recipientPath) ? recipientPath : legacyPath;
+
+  if (!existsSync(filePath)) {
+    return { transactions: [] };
+  }
+
+  return JSON.parse(readFileSync(filePath, "utf-8")) as SpendingState;
+}
+
+function totalForLocalDay(
+  transactions: Transaction[],
+  timezone: string,
+  date: Date,
+) {
+  const localDate = getLocalDateStr(timezone, date);
+  return transactions
+    .filter((tx) => {
+      if (!tx.timestamp) return false;
+      return getLocalDateStr(timezone, new Date(tx.timestamp)) === localDate;
+    })
+    .reduce((sum, tx) => sum + (Number(tx.amount) || 0), 0);
+}
+
+const timezone = argValue("timezone", process.env.SPENDING_TIMEZONE ?? "America/Phoenix");
+const recipientId = argValue("recipient", "rosa");
+const dataDir = path.resolve(argValue("data-dir", "data"));
+const now = new Date(argValue("now", new Date().toISOString()));
+
+const { dayEnd } = getLocalDayBounds(timezone, now);
+const beforeBoundary = new Date(dayEnd.getTime() - 60_000);
+const afterBoundary = new Date(dayEnd.getTime() + 60_000);
+const state = loadSpendingState(recipientId, dataDir);
+const transactions = state.transactions ?? [];
+
+const beforeTotal = totalForLocalDay(transactions, timezone, beforeBoundary);
+const afterTotal = totalForLocalDay(transactions, timezone, afterBoundary);
+
+console.log(`Recipient: ${recipientId}`);
+console.log(`Timezone: ${timezone}`);
+console.log(`Local day before boundary: ${getLocalDateStr(timezone, beforeBoundary)}`);
+console.log(`Local day after boundary:  ${getLocalDateStr(timezone, afterBoundary)}`);
+console.log("");
+console.table([
+  {
+    point: "before local midnight",
+    instant: beforeBoundary.toISOString(),
+    spendingTotal: beforeTotal.toFixed(2),
+  },
+  {
+    point: "after local midnight",
+    instant: afterBoundary.toISOString(),
+    spendingTotal: afterTotal.toFixed(2),
+  },
+]);


### PR DESCRIPTION
## Summary
- document local MULTI_PHARMACY_MODE testing using the PHARMACY_2 wallet created by npm run setup
- add spending reset simulation and generated sample bill helper scripts
- document proper-lockfile stale lock troubleshooting and add a cleanup helper

Closes #1362
Closes #1363
Closes #1364
Closes #1365

## Tests
- npm run simulate:spending-reset -- --timezone=America/New_York --recipient=rosa (blocked: checkout had no node_modules)
- npm run generate:sample-bill -- --duplicate --upcoded --overcharge (blocked: checkout had no node_modules)
- npm run clear:stale-locks (blocked: checkout had no node_modules)
- npm install --legacy-peer-deps (blocked: local disk filled with ENOSPC while installing dependencies)