### PR TITLE
docs: add caregiver guide for verifying a payment on stellar.expert

### DIFF
--- a/docs/guides/activity-tab.md
+++ b/docs/guides/activity-tab.md
@@ -1,0 +1,66 @@
+# Activity Tab — A Guide for Caregivers
+
+This guide explains what you see on the **Activity tab** of the CareGuard
+dashboard: the agent log, the transaction and order history, and how to dig
+deeper into any individual entry.
+
+---
+
+## What the Activity tab shows
+
+The Activity tab is organized into two parts:
+
+### 1. Agent log
+
+A live, terminal-style feed at the top of the tab showing what the agent is
+doing in real time — checking prices, evaluating spending policy, submitting
+payments, and so on. Entries with an error attached can be expanded to see
+the full error detail, and copied for troubleshooting.
+
+### 2. Transaction and order history
+
+A table below the log listing every completed action, newest first:
+
+| Column | What it shows |
+|---|---|
+| **Time** | When the entry happened (hidden on narrow screens). |
+| **Type** | `medication`, `bill`, `service_fee`, or `audit` for policy/system events. |
+| **Description** | A short summary — the drug and pharmacy for a medication order, the bill description for a payment, or the audit event name. |
+| **Amount** | The dollar amount, in USDC. |
+| **Status** | `completed`, `blocked`, or `pending`, depending on the entry type. |
+| **Stellar Tx** | A link to the transaction on the Stellar block explorer, when one exists. |
+
+Use **Download Report** to export the full history (including pages not
+currently in view) as a PDF, or **Reset** to clear all agent data — this is
+destructive and cannot be undone.
+
+---
+
+## Medication orders specifically
+
+When the agent places a medication order, the confirmation appears in this
+same table as a `medication` entry. See
+[Order Confirmation](order-confirmation.md) for exactly what details show up
+and where to find a specific past order.
+
+---
+
+## Verifying a payment on-chain
+
+Every row with a Stellar transaction hash links out to the block explorer so
+you can independently confirm the payment happened. See
+[Verifying a Payment](verifying-a-payment.md) for a full walkthrough, from
+clicking the link in this tab to reading the result on stellar.expert.
+
+---
+
+## Related reading
+
+- [Order Confirmation](order-confirmation.md) — what appears after a
+  medication order is placed
+- [Verifying a Payment](verifying-a-payment.md) — step-by-step guide to
+  reading a transaction on stellar.expert
+- [Wallet Tab](wallet-tab.md) — balances and funding, the other half of the
+  payment picture
+- [Testnet Explained](testnet-explained.md) — why the transactions you see
+  here are testnet, not real money, by default

--- a/docs/guides/verifying-a-payment.md
+++ b/docs/guides/verifying-a-payment.md
@@ -1,0 +1,102 @@
+# Verifying a Payment on stellar.expert — A Guide for Caregivers
+
+CareGuard says every payment is "verifiable on stellar.expert." This guide
+walks through exactly how to do that, starting from an entry in the
+dashboard's Activity tab and ending on the transaction's page in the
+explorer.
+
+You don't need any technical or crypto background to follow these steps.
+
+---
+
+## Step 1: Open the Activity tab
+
+In the CareGuard dashboard, click the **Activity** tab. You'll see a table
+of past transactions and orders, newest first.
+
+## Step 2: Find the entry you want to verify
+
+Each row shows a type (`medication`, `bill`, or `service_fee`), a
+description, an amount, and a status. Find the row for the payment you want
+to check.
+
+## Step 3: Click the Stellar Tx link
+
+On the right side of the row, in the **Stellar Tx** column, you'll see one
+of three things:
+
+| What you see | What it means |
+|---|---|
+| A short code like `a1b2c3...9f8e` | A working link — click it to open the transaction on stellar.expert. |
+| `⚠ unverifiable` | The transaction hash could not be captured for this entry. The payment may still have succeeded, but it cannot be checked on-chain from CareGuard. |
+| `-` | No transaction hash exists for this entry (for example, an audit or policy event that didn't move money). |
+
+Click the short code to open stellar.expert in a new tab.
+
+## Step 4: Read the transaction on stellar.expert
+
+The explorer page shows several sections. The ones that matter for
+confirming a payment:
+
+| What to look for | Where it is | What it should match |
+|---|---|---|
+| **Amount** | Under "Operations," look for a "Payment" or "Invoke Contract" operation | The dollar amount shown in the Activity tab row |
+| **Asset** | Next to the amount | `USDC` for medication orders and bill payments |
+| **Timestamp** | Near the top of the page, or under "Created at" | The time shown in the Activity tab row (allow a few seconds' difference — the dashboard timestamp is when the entry was recorded, not the exact ledger close time) |
+| **Successful** | A green "Successful" badge near the top | Confirms the transaction was accepted by the network, not just submitted |
+| **Source account** | Near the top | The agent's wallet address, shown on the [Wallet tab](wallet-tab.md) |
+
+If the amount, asset, and rough timestamp all line up with what you saw in
+the Activity tab, the payment is confirmed on-chain.
+
+---
+
+## Testnet vs. mainnet: how to tell them apart
+
+This is the detail people miss most often, because the two explorer pages
+look almost identical.
+
+- **Look at the URL.** A testnet transaction is at
+  `stellar.expert/explorer/testnet/tx/<hash>`. A mainnet (real-money)
+  transaction is at `stellar.expert/explorer/public/tx/<hash>`. The word
+  `testnet` or `public` right after `/explorer/` is the tell.
+- **Look for a banner.** stellar.expert shows a distinct banner or color
+  treatment on testnet pages warning that you're viewing test network data.
+- **Check which network CareGuard is configured for.** By default, CareGuard
+  runs on Stellar **testnet** — meaning the USDC and XLM involved are test
+  tokens with no real-world value, even though the workflow behaves exactly
+  like it would in production. The link that CareGuard generates for you
+  already points at the correct network for your instance, so if you always
+  click through from the Activity tab (rather than pasting a hash into
+  stellar.expert's search bar by hand), you'll land on the right page
+  automatically. See [Testnet Explained](testnet-explained.md) for the full
+  picture.
+- **If you're checking manually**, always confirm the network in the URL
+  before treating any balance or transaction as real money.
+
+---
+
+## If the link doesn't work or the transaction isn't found
+
+- **`⚠ unverifiable` in the Activity tab** — the payment likely still went
+  through (CareGuard would show a `blocked` status otherwise), but the
+  on-chain hash wasn't captured for that entry. There's nothing to click
+  through to verify in this case; treat the dashboard status as the source
+  of truth for that entry.
+- **"Not Found" on stellar.expert** — double-check you're on the right
+  network (testnet vs. mainnet, above). A testnet hash will never resolve on
+  the mainnet explorer page and vice versa.
+- **Amount or timestamp doesn't match** — this would be unexpected; if you
+  see a genuine mismatch between what the Activity tab reports and what the
+  explorer shows, treat it as worth flagging rather than dismissing it.
+
+---
+
+## Related reading
+
+- [Activity Tab](activity-tab.md) — everything else shown in this tab
+- [Order Confirmation](order-confirmation.md) — what appears right after a
+  medication order is placed
+- [Wallet Tab](wallet-tab.md) — the agent's wallet address and balances
+- [Testnet Explained](testnet-explained.md) — why CareGuard uses testnet
+  money by default and what that means for you


### PR DESCRIPTION
## Summary

README.md claims every payment is verifiable on stellar.expert, but no doc walked a non-technical caregiver through actually doing that starting from a dashboard Activity tab entry.

- Add docs/guides/verifying-a-payment.md with numbered steps from opening the Activity tab, finding the right row, clicking the Stellar Tx link (including what the unverifiable and - states mean), and reading the resulting stellar.expert page.
- Document what a caregiver should expect to see on the explorer page: amount, asset, timestamp, the Successful badge, and the source account, each matched back to what's shown in the Activity tab row.
- Explain how to tell testnet and mainnet transactions apart on the explorer, grounded in the actual URL pattern used by dashboard/src/lib/stellar-network.ts (/explorer/testnet/ vs /explorer/public/), plus the banner stellar.expert itself shows on testnet pages.
- Also add docs/guides/activity-tab.md, which is referenced as a link target by this issue's acceptance criteria but did not exist in the repo yet, so the new guide (and docs/guides/order-confirmation.md from #1431) has a home tab overview to link from.

## Test plan

- [x] Verified the testnet/mainnet URL pattern against dashboard/src/lib/stellar-network.ts rather than assuming it
- [x] Verified the unverifiable / - link states against dashboard/src/components/primitives/tx-link.tsx
- [x] Manual read-through of the doc for a non-technical audience

closes #1434