### PR TITLE
docs: document what caregivers see after a medication order is confirmed

### DIFF
--- a/docs/guides/activity-tab.md
+++ b/docs/guides/activity-tab.md
@@ -1,0 +1,66 @@
+# Activity Tab — A Guide for Caregivers
+
+This guide explains what you see on the **Activity tab** of the CareGuard
+dashboard: the agent log, the transaction and order history, and how to dig
+deeper into any individual entry.
+
+---
+
+## What the Activity tab shows
+
+The Activity tab is organized into two parts:
+
+### 1. Agent log
+
+A live, terminal-style feed at the top of the tab showing what the agent is
+doing in real time — checking prices, evaluating spending policy, submitting
+payments, and so on. Entries with an error attached can be expanded to see
+the full error detail, and copied for troubleshooting.
+
+### 2. Transaction and order history
+
+A table below the log listing every completed action, newest first:
+
+| Column | What it shows |
+|---|---|
+| **Time** | When the entry happened (hidden on narrow screens). |
+| **Type** | `medication`, `bill`, `service_fee`, or `audit` for policy/system events. |
+| **Description** | A short summary — the drug and pharmacy for a medication order, the bill description for a payment, or the audit event name. |
+| **Amount** | The dollar amount, in USDC. |
+| **Status** | `completed`, `blocked`, or `pending`, depending on the entry type. |
+| **Stellar Tx** | A link to the transaction on the Stellar block explorer, when one exists. |
+
+Use **Download Report** to export the full history (including pages not
+currently in view) as a PDF, or **Reset** to clear all agent data — this is
+destructive and cannot be undone.
+
+---
+
+## Medication orders specifically
+
+When the agent places a medication order, the confirmation appears in this
+same table as a `medication` entry. See
+[Order Confirmation](order-confirmation.md) for exactly what details show up
+and where to find a specific past order.
+
+---
+
+## Verifying a payment on-chain
+
+Every row with a Stellar transaction hash links out to the block explorer so
+you can independently confirm the payment happened. See
+[Verifying a Payment](verifying-a-payment.md) for a full walkthrough, from
+clicking the link in this tab to reading the result on stellar.expert.
+
+---
+
+## Related reading
+
+- [Order Confirmation](order-confirmation.md) — what appears after a
+  medication order is placed
+- [Verifying a Payment](verifying-a-payment.md) — step-by-step guide to
+  reading a transaction on stellar.expert
+- [Wallet Tab](wallet-tab.md) — balances and funding, the other half of the
+  payment picture
+- [Testnet Explained](testnet-explained.md) — why the transactions you see
+  here are testnet, not real money, by default

--- a/docs/guides/order-confirmation.md
+++ b/docs/guides/order-confirmation.md
@@ -1,0 +1,90 @@
+# Order Confirmation — A Guide for Caregivers
+
+When the CareGuard agent places a medication order, this guide explains what
+confirmation you'll see in the dashboard, where to find it later, and what to
+do if something about the order needs to change.
+
+---
+
+## What happens when an order is placed
+
+The agent submits the order and pays the pharmacy on Stellar. Once the
+payment settles, the order is confirmed — there is no separate "pending
+order" state to wait through once you see it in the dashboard.
+
+## What the confirmation shows
+
+The confirmed order appears as a new row in the **Activity tab**, with:
+
+| Detail | Where it comes from |
+|---|---|
+| **Drug** | The medication name, as included in the order description. |
+| **Pharmacy** | Which pharmacy fulfilled the order. |
+| **Amount** | The dollar amount paid, in USDC. |
+| **Status** | `completed` once the payment has settled on Stellar. |
+| **Stellar transaction** | A link to the on-chain payment, so you can independently confirm it — see [Verifying a Payment](verifying-a-payment.md). |
+| **Time** | When the order was confirmed. |
+
+CareGuard does not currently show a separate order number, pharmacy contact
+details, or a pickup/delivery estimate in the dashboard — the confirmation is
+the transaction record itself (drug, pharmacy, amount, and the on-chain
+receipt). If your pharmacy sends its own confirmation (text, email, or
+in-store receipt) with a pickup time or order number, treat that as the
+authoritative source for pickup logistics; CareGuard's role is to confirm the
+order was placed and paid for, not to relay the pharmacy's fulfillment
+details.
+
+---
+
+## Where to find past orders
+
+All confirmed orders live in the **Activity tab**, listed newest first
+alongside bill payments and other agent activity. To find a specific past
+order:
+
+1. Open the **Activity** tab.
+2. Look for a row with type `medication` — the description names the drug
+   and pharmacy.
+3. If the order is older than the current page of results, use the
+   pagination controls at the top of the table, or increase the page size.
+4. Use **Download Report** to export the full history (including orders not
+   on the currently visible page) as a PDF for your records.
+
+See [Activity Tab](activity-tab.md) for the full breakdown of everything
+shown in that view.
+
+---
+
+## If an order needs to be cancelled or corrected
+
+CareGuard does not have an in-dashboard cancel or edit action for a
+medication order once it's confirmed — the payment has already settled
+on-chain by the time you see the confirmation, so there's nothing left in
+CareGuard's own state to change.
+
+If an order was placed in error, was for the wrong medication, or needs to
+be cancelled:
+
+1. **Contact the pharmacy directly.** Since the payment already settled,
+   cancelling or correcting the order is a pharmacy-side fulfillment
+   decision, the same as it would be for any other pharmacy order.
+2. **Keep the transaction record.** The Stellar transaction link on the
+   Activity tab row is your proof of payment — see
+   [Verifying a Payment](verifying-a-payment.md) if the pharmacy needs you to
+   confirm the payment independently.
+3. **Check your spending policy if the concern is a budget issue**, not the
+   order itself. See
+   [Spending Policy for Caregivers](spending-policy-for-caregivers.md) to
+   adjust limits going forward so a similar order doesn't recur unexpectedly.
+
+---
+
+## Related reading
+
+- [Activity Tab](activity-tab.md) — everything shown in this tab, including
+  bill payments and audit events alongside medication orders
+- [Verifying a Payment](verifying-a-payment.md) — how to independently
+  confirm the on-chain payment for an order
+- [Wallet Tab](wallet-tab.md) — the balance the order was paid from
+- [Spending Policy for Caregivers](spending-policy-for-caregivers.md) — how
+  to adjust limits so future orders behave differently


### PR DESCRIPTION
## Summary

POST /pharmacy/order returns an order-confirmed response, but there was no caregiver-facing doc explaining what actually appears in the dashboard after the agent places an order.

- Add docs/guides/order-confirmation.md describing exactly which confirmation fields the Activity tab shows for a medication order (drug, pharmacy, amount, status, Stellar transaction link, time), based on the order object shape in services/pharmacy-payment/server.ts and what activity-tab.tsx actually renders.
- Explicitly note that CareGuard does not surface a separate order number, pharmacy contact details, or a pickup/delivery estimate in the dashboard today — the confirmation is the transaction record itself — and point caregivers to their pharmacy's own confirmation for pickup logistics.
- Explain where to find past orders in the Activity tab, including pagination and the PDF export.
- Cover what to do if an order needs to be cancelled or corrected: since payment has already settled on-chain by the time the confirmation appears, there is no in-dashboard cancel/edit action, so this walks through contacting the pharmacy directly and keeping the transaction record as proof of payment.
- Also add docs/guides/activity-tab.md, which is referenced as a link target by this issue's acceptance criteria but did not exist in the repo yet, so this guide has a home tab overview to link from.

## Test plan

- [x] Verified the confirmed-order field shape against services/pharmacy-payment/server.ts (the newOrder object) and dashboard/src/components/tabs/activity-tab.tsx (what's actually rendered)
- [x] Verified no order number/pickup info is surfaced anywhere in the dashboard by checking dashboard/src/lib/tx-receipt.ts (orderId is parsed internally only, never displayed)
- [x] Manual read-through of the doc for a non-technical audience

closes #1431