### PR TITLE
docs: add caregiver guide for the Activity tab

### DIFF
--- a/docs/guides/activity-tab.md
+++ b/docs/guides/activity-tab.md
@@ -1,0 +1,102 @@
+# Activity Tab — A Guide for Caregivers
+
+This guide explains what you see on the **Activity tab** of the CareGuard dashboard: the live agent log, the transaction and audit timeline, and how to verify any entry on the Stellar blockchain.
+
+---
+
+## What the Activity tab shows
+
+The Activity tab has two parts, stacked top to bottom.
+
+### 1. Agent Log
+
+A dark, terminal-style panel showing a running log of what the agent is doing right now — for example, "Comparing prices for Lisinopril" or "Submitting order to CVS Pharmacy". This is a live feed, not a permanent record: clicking **Clear Log** empties it, and it resets when the page reloads. If an entry failed, it appears with an arrow (▸) you can click to expand the error detail, plus a **Copy error** button for sharing the exact message with support.
+
+### 2. Activity Table
+
+Below the log is a table combining two kinds of history into a single timeline, newest first:
+
+- **Transactions** — money the agent spent or moved
+- **Audit events** — actions the agent took that didn't necessarily involve money (e.g. a policy check or a paused action)
+
+Each row shows a time, a type, a description, an amount, a status, and a Stellar transaction link where one applies.
+
+---
+
+## Entry types explained
+
+| Type badge | What it means |
+|---|---|
+| **medication** | The agent paid a pharmacy to fill or refill a tracked medication. |
+| **bill** | The agent paid a medical bill on your behalf. |
+| **service_fee** | A small payment the agent made to use a paid data service — for example, a pharmacy price comparison, a bill audit, or a drug interaction check. These are usually a few cents or less. |
+| **audit** (dark badge) | A non-payment event, such as a spending-policy update, a blocked action, or the agent pausing itself. The **Description** column names the event and, if relevant, which tool was involved. |
+
+### Reading the "price check, order, audit, payment" entries
+
+- A **price check** shows up as a `service_fee` transaction — the agent paid a small fee to compare pharmacy prices.
+- An **order** shows up as a `medication` transaction — the actual cost of filling the prescription.
+- A **payment** for a bill shows up as a `bill` transaction.
+- An **audit** entry (dark badge) records something the agent *did* rather than something it *paid for* — for instance, "Spending Policy Updated" or a blocked transaction.
+
+### Status column
+
+Each transaction also carries a status:
+
+| Status | Meaning |
+|---|---|
+| **completed** | The payment settled successfully on Stellar. |
+| **blocked** | Your spending policy stopped this payment before it happened — no money moved. |
+| Anything else (e.g. pending/held) | The payment is still in progress, often waiting out a hold period before it settles. See [Spending Policy for Caregivers](spending-policy-for-caregivers.md) for how holds work. |
+
+Audit rows show the **actor** (who or what triggered the event) in the status column instead of a payment status, since no money is involved.
+
+---
+
+## Verifying a transaction on stellar.expert
+
+Every settled transaction shows a short transaction hash under **Stellar Tx** — this is your receipt, independent of anything CareGuard tells you. Because it's on a public blockchain, you can verify it yourself:
+
+1. Find the row for the transaction you want to check in the Activity table.
+2. Look at the **Stellar Tx** column. If you see a shortened hash (like `a1b2c3...e5f6`), the payment was verified and settled on-chain.
+3. Click the hash — it opens directly on the Stellar blockchain explorer in a new tab, already pointed at that transaction.
+4. On the explorer page, confirm:
+   - The **amount** matches what's shown in the Activity table.
+   - The **destination address** matches the pharmacy, biller, or service you expect.
+   - The transaction status is **Successful**.
+
+If you'd rather look it up manually, copy the full hash (hover over the link to see it, or use "Copy error" style inspection in your browser) and paste it into the search bar at [stellar.expert](https://stellar.expert). Search transaction hashes on the correct network — Testnet or Public (Mainnet) — matching whichever network your CareGuard instance is configured for. See [Testnet Explained](testnet-explained.md) if you're not sure which one you're on.
+
+### If the Stellar Tx column shows "unverifiable"
+
+Occasionally you'll see a yellow **⚠ unverifiable** label instead of a link. This means the agent made a payment through the x402 protocol but the system could not automatically extract the underlying Stellar transaction hash from the payment receipt. The payment still happened — it just can't be one-click verified from the dashboard. If you need to confirm it, check the wallet's full transaction history on stellar.expert directly (see [Wallet Tab](wallet-tab.md) for the wallet address) around the timestamp shown.
+
+A plain dash (`-`) means no Stellar transaction applies to that row at all — this is normal for audit entries, since they don't represent a payment.
+
+---
+
+## Filtering and searching activity
+
+The Activity tab does not currently offer a text search or category filter — every transaction and audit event for the care recipient appears in one combined, chronological table. You can narrow what you're looking at in these ways instead:
+
+- **Pagination controls** at the top of the table let you choose how many rows to view per page (10, 25, 50, or 100) and step through Previous/Next pages once there's more history than fits on one page.
+- **Download Report** exports the full transaction history (all pages, not just the one in view) as a PDF you can search, save, or share — useful if you need to look for a specific medication, amount, or date.
+- **Sorting** is fixed to newest-first; there's no way to reverse it from the dashboard.
+
+If you need to find a specific transaction quickly, downloading the report and using your PDF viewer's search (Ctrl+F / Cmd+F) is the most reliable option today.
+
+---
+
+## Clearing history
+
+- **Clear Log** only clears the live agent log panel (the terminal-style feed). It does not delete any transactions or audit events.
+- **Reset** (in red) is destructive: it permanently deletes all transactions, the agent log, and all audit results for this care recipient. CareGuard asks you to confirm before this happens, and the confirmation dialog tells you exactly how many transactions will be lost. This cannot be undone — use it only if you intend to start fresh.
+
+---
+
+## Related reading
+
+- [Wallet Tab](wallet-tab.md) — the agent's wallet address and balances, needed to look up full transaction history on stellar.expert
+- [Spending Policy for Caregivers](spending-policy-for-caregivers.md) — how holds, budgets, and blocked payments work
+- [Medications Tab](medications-tab.md) — where price checks and orders are initiated
+- [Testnet Explained](testnet-explained.md) — whether your transactions are on testnet or real Stellar mainnet


### PR DESCRIPTION
## Summary

Adds docs/guides/activity-tab.md, a caregiver-facing explanation of the Activity tab that mirrors the existing style of docs/guides/wallet-tab.md.

- Explains the two parts of the tab: the live agent log panel and the combined transaction/audit timeline table
- Documents what each entry type means: medication, bill, service_fee (price checks and paid data queries), and audit events, matching the request's "price check, order, audit, payment" framing
- Documents the status column (completed, blocked, pending) and the audit-row actor field
- Gives step-by-step instructions for verifying a settled transaction on stellar.expert using the tx hash shown in the Stellar Tx column, and explains the "unverifiable" state
- Explains that there is no in-dashboard text/category filter today, and gives the actual ways to narrow down activity (pagination controls, per-page size, and the full-history PDF export)
- Clarifies the difference between Clear Log (clears only the live log panel) and Reset (destructive, deletes all history)
- Cross-links Wallet Tab, Spending Policy for Caregivers, Medications Tab, and Testnet Explained

Written for non-technical caregivers, consistent with the tone of the existing guides in docs/guides/.

closes #1410

## Test plan

- [x] Verified against dashboard/src/components/tabs/activity-tab.tsx and dashboard/src/components/primitives/tx-link.tsx for accuracy of entry types, statuses, and the unverifiable/dash states
- [x] Verified against dashboard/src/lib/types.ts (TransactionSchema, AuditLogSchema) for the exact type/status vocabulary
- [x] Cross-checked links to other docs/guides/*.md files resolve to existing files
- [x] Proofread for a non-technical audience