### PR TITLE
docs: document the bill-audit dispute-letter feature for caregivers

### DIFF
--- a/docs/guides/bill-disputes.md
+++ b/docs/guides/bill-disputes.md
@@ -1,0 +1,48 @@
+# Disputing a Medical Bill
+
+When CareGuard audits a medical bill and finds errors, you can generate a ready-to-send dispute letter directly from the Bills tab. This guide explains what the dispute letter is, when it appears, and how to use it.
+
+## What triggers a dispute letter
+
+A dispute letter option only appears after a bill has been audited and the audit finds at least one error. The Bill Audit API flags each line item as one of:
+
+- **Overcharged** — billed more than 1.5x the CMS fair-market rate
+- **Upcoded** — billed more than 3x the fair-market rate (suggests the wrong billing code was used)
+- **Duplicate** — the same procedure code billed more than once
+
+If the audit result has `errorCount > 0`, the Bills tab shows **Dispute** and **Email Text** buttons next to that bill's results. If the audit finds no errors, no dispute option is shown — there is nothing to dispute.
+
+See [Bill Audit API example](../api-examples/bill-audit.md) for what a full audit result with findings looks like, and [Bill Audit Service internals](../services/bill-audit.md) for how overcharge, upcoding, and duplicate detection work.
+
+## What's in the letter
+
+The generated letter is addressed to the billing department of the facility on file for your care recipient, and lists every flagged line item with:
+
+- The description and CPT code
+- The amount charged
+- The CMS fair-market rate CareGuard suggests instead
+- A short explanation of the specific issue (e.g. "Duplicate charge for CPT 85025. Appears 2 times.")
+
+It closes with the total overcharge amount and a request that the facility review and correct the bill.
+
+## Reviewing, sending, or discarding the letter
+
+From the Bills tab, on any audited bill with errors:
+
+1. **Dispute** — generates the letter as a PDF and downloads it to your device (`careguard-dispute-letter-<bill-id>.pdf`). Open the PDF to review the wording and figures before doing anything with it.
+2. **Email Text** — generates the same letter as an HTML email body and opens it in a new browser tab, so you can copy it into your own email client.
+
+Neither button sends anything on your behalf. CareGuard prepares the letter; you decide whether to send it, edit it first, or discard it entirely. If you close the tab or delete the PDF without acting on it, nothing is sent and no record is created elsewhere — generating a letter has no effect on your spending policy, wallet, or the underlying bill.
+
+## Current limitations
+
+- **Sending is manual.** CareGuard does not email, fax, or otherwise transmit the dispute letter to the facility. You are responsible for delivering it through whatever channel the facility accepts.
+- **No dispute tracking.** CareGuard does not track whether a letter was sent, whether the facility responded, or the outcome of a dispute. Once downloaded, follow-up is outside the app.
+- **The letter is a draft, not legal advice.** Review the figures and wording before sending — you may want to add your own account or claim numbers, or adjust the tone for your situation.
+- **The billing facility name comes from your care recipient's profile.** If it's missing or wrong, the letter falls back to a generic "General Hospital" placeholder — update the recipient's facility in their profile before generating a letter to avoid this.
+
+## Related reading
+
+- [Bill Audit API example](../api-examples/bill-audit.md)
+- [Bill Audit Service internals](../services/bill-audit.md)
+- [Submitting a bill for audit](submitting-a-bill.md)

--- a/docs/guides/submitting-a-bill.md
+++ b/docs/guides/submitting-a-bill.md
@@ -70,6 +70,8 @@ If CareGuard finds billing errors on your submission, you can immediately take a
 2. **Generate Dispute Letter**: Click **Dispute** to automatically create a formal, formatted dispute letter addressed to the healthcare facility's billing department.
 3. **Email Text Template**: Click **Email Text** to open a ready-to-send dispute message in your email client or web browser.
 
+See [Disputing a Medical Bill](bill-disputes.md) for what triggers the dispute letter, what it contains, and its current limitations (for example, CareGuard does not send it for you).
+
 ---
 
 ## Need Help?


### PR DESCRIPTION
## Summary

closes #1404

The Bills tab generates dispute letters from audit results (dashboard/src/components/tabs/bills-tab.tsx and the generateDisputeLetter tool in agent/tools.ts), but there was no user-facing doc explaining what a dispute letter is, when it appears, or what a caregiver is expected to do with it.

- New doc docs/guides/bill-disputes.md explaining the dispute-letter workflow for caregivers, written in the same plain-language caregiver-guide style as docs/guides/submitting-a-bill.md
- Describes what triggers dispute-letter generation: an audit result with errorCount > 0 (overcharge, upcoding, or duplicate findings), which is when the Dispute and Email Text buttons appear
- Explains the caregiver's steps: Dispute downloads a PDF, Email Text opens an HTML draft in a new tab, and the caregiver reviews and decides whether to send it themselves, edit it, or discard it
- Documents current limitations verified against the actual code: sending is manual (no email/fax integration), there is no dispute tracking after the letter is generated, the letter is a draft rather than legal advice, and the facility name falls back to "General Hospital" if the recipient profile has none set (confirmed in bills-tab.tsx)
- Linked from docs/guides/submitting-a-bill.md, which already briefly mentions the Dispute/Email Text buttons

## Test plan

- [ ] Confirmed the trigger condition (errorCount > 0) and button behavior against dashboard/src/components/tabs/bills-tab.tsx and dashboard/src/app/pdf.ts (downloadDisputeLetterPDF, downloadDisputeLetterEmail)
- [ ] Confirmed the "General Hospital" fallback and manual-send behavior described in Limitations match the current implementation, not just the intended design
- [ ] Verified the link from docs/guides/submitting-a-bill.md resolves to docs/guides/bill-disputes.md